### PR TITLE
Detect daemon version skew

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Diagnostics check:
 Diagnostics do not make model calls. If auth cannot be proven locally without a model call, the backend reports `auth_unknown` with a next-step hint.
 
 Supervisor agents can use the MCP tool `get_backend_status` to retrieve the same diagnostics.
+When called through the daemon, that report also includes the frontend package version, daemon package version, daemon PID, and whether the two package versions match.
 
 ## MCP Client Config
 
@@ -140,6 +141,7 @@ The guarantee is deliberately scoped:
 
 - MCP-client or supervisor restarts preserve run state and in-flight runs because the daemon keeps running.
 - Daemon restarts do not preserve in-flight worker ownership. On daemon startup, any run still marked `running` becomes terminal `orphaned` with the previous daemon PID and worker PID in the error context.
+- Package upgrades can restart the stdio MCP frontend without restarting the daemon. If their package versions differ, tool calls return `DAEMON_VERSION_MISMATCH` with both versions and a restart hint instead of failing later with stale method or result-shape errors.
 
 ## Daemon Lifecycle
 
@@ -150,6 +152,8 @@ agent-orchestrator-mcp-daemon status
 agent-orchestrator-mcp-daemon start
 agent-orchestrator-mcp-daemon stop
 agent-orchestrator-mcp-daemon stop --force
+agent-orchestrator-mcp-daemon restart
+agent-orchestrator-mcp-daemon restart --force
 agent-orchestrator-mcp-daemon prune --older-than-days 30 --dry-run
 agent-orchestrator-mcp-daemon prune --older-than-days 30
 ```
@@ -159,10 +163,18 @@ With `npx`, target the daemon bin explicitly:
 ```bash
 npx -y --package @ralphkrauss/agent-orchestrator-mcp@latest agent-orchestrator-mcp-daemon status
 npx -y --package @ralphkrauss/agent-orchestrator-mcp@latest agent-orchestrator-mcp-daemon stop --force
+npx -y --package @ralphkrauss/agent-orchestrator-mcp@latest agent-orchestrator-mcp-daemon restart
+npx -y --package @ralphkrauss/agent-orchestrator-mcp@latest agent-orchestrator-mcp-daemon restart --force
 npx -y --package @ralphkrauss/agent-orchestrator-mcp@latest agent-orchestrator-mcp-daemon prune --older-than-days 30 --dry-run
 ```
 
-`stop` refuses while runs are active and prints the active run IDs. `stop --force` cancels active runs through the normal cancellation path, waits for terminal statuses, and exits. Direct `SIGTERM`/`SIGINT` to the daemon behaves like `stop --force`; `SIGKILL` cannot be caught and any in-flight runs become `orphaned` on next daemon startup.
+`stop` refuses while runs are active and prints the active run IDs. `stop --force` cancels active runs through the normal cancellation path, waits for terminal statuses, and exits. `restart` uses the same safe default and refuses active runs; `restart --force` cancels active runs before starting a fresh daemon. Direct `SIGTERM`/`SIGINT` to the daemon behaves like `stop --force`; `SIGKILL` cannot be caught and any in-flight runs become `orphaned` on next daemon startup.
+
+After changing the configured npm version or dist-tag, restart the daemon so it picks up the same package build as the MCP frontend:
+
+```bash
+npx -y --package @ralphkrauss/agent-orchestrator-mcp@latest agent-orchestrator-mcp-daemon restart
+```
 
 `prune` deletes only terminal runs with `finished_at` older than the requested age. Use `--dry-run` first to inspect the matching run IDs.
 

--- a/docs/development/mcp-tooling.md
+++ b/docs/development/mcp-tooling.md
@@ -150,6 +150,17 @@ just orchestrator-prune-dry-run 30
 just orchestrator-prune 30
 ```
 
+The daemon is long-lived across MCP reconnects and editor restarts. After
+changing package source, rebuilding `dist/`, or switching npm dist-tags during
+dogfooding, restart the daemon so the frontend and daemon package versions
+match:
+
+```bash
+node dist/daemonCli.js restart
+node dist/daemonCli.js restart --force
+just orchestrator-restart
+```
+
 Access level: read/write local process orchestration. The server can start
 Codex or Claude worker CLI processes in a requested working directory. Worker
 authentication remains whatever the host Codex or Claude CLI already has.

--- a/justfile
+++ b/justfile
@@ -62,10 +62,7 @@ orchestrator-stop *args: orchestrator-build
 
 # Restart the daemon so it picks up the current build.
 orchestrator-restart: orchestrator-build
-    -node dist/daemonCli.js stop --force
-    sleep 1
-    node dist/daemonCli.js start
-    node dist/daemonCli.js status
+    node dist/daemonCli.js restart --force
 
 # Preview terminal run pruning for runs older than the requested age.
 orchestrator-prune-dry-run days="30": orchestrator-build

--- a/plans/1-daemon-survives-package-upgrades-silently-frontenddaemon-version-skew-causes-confusing-failures/plan.md
+++ b/plans/1-daemon-survives-package-upgrades-silently-frontenddaemon-version-skew-causes-confusing-failures/plan.md
@@ -1,0 +1,10 @@
+# Plan Index
+
+Branch: `1-daemon-survives-package-upgrades-silently-frontenddaemon-version-skew-causes-confusing-failures`
+Updated: 2026-05-02
+
+## Sub-Plans
+
+| Plan | Scope | Status | File |
+|---|---|---|---|
+| Daemon Version Handshake | Detect and report frontend/daemon package version skew, add diagnostics, restart ergonomics, docs, and tests for issue #1. | completed | `plans/1-daemon-survives-package-upgrades-silently-frontenddaemon-version-skew-causes-confusing-failures/plans/1-daemon-version-handshake.md` |

--- a/plans/1-daemon-survives-package-upgrades-silently-frontenddaemon-version-skew-causes-confusing-failures/plans/1-daemon-version-handshake.md
+++ b/plans/1-daemon-survives-package-upgrades-silently-frontenddaemon-version-skew-causes-confusing-failures/plans/1-daemon-version-handshake.md
@@ -1,0 +1,155 @@
+# Daemon Version Handshake
+
+Branch: `1-daemon-survives-package-upgrades-silently-frontenddaemon-version-skew-causes-confusing-failures`
+Plan Slug: `daemon-version-handshake`
+Parent Issue: #1
+Created: 2026-05-02
+Status: completed
+
+## Context
+
+Issue #1 reports that the stdio MCP frontend can update while the long-lived daemon keeps running old code. The observed failures are confusing because the frontend advertises new tools while the stale daemon still validates an older `RpcMethodSchema`, causing errors such as `Invalid enum value ... received 'get_backend_status'`, missing `session_id`, and follow-up rejection because the parent run has no backend session id. The issue's preferred fix is a structured version handshake that reports both frontend and daemon versions with a recovery hint.
+
+Current code already has an IPC `PROTOCOL_VERSION` in `src/contract.ts` and checks it in `src/ipc/protocol.ts`, but that version only represents frame/schema compatibility. It does not encode the package build version, and stale daemons with the same numeric protocol can still accept or reject methods in confusing ways. `src/server.ts` auto-starts the daemon when `ping` fails, but it treats a responding old daemon as healthy. `src/orchestratorService.ts` currently returns `ping` with only `pong` and `daemon_pid`. `get_backend_status` in `src/diagnostics.ts` reports backend CLI health but not frontend/daemon package skew. The daemon CLI in `src/daemon/daemonCli.ts` has `start`, `stop`, `status`, and `prune`, while `justfile` already has a local `orchestrator-restart` workaround.
+
+Sources read:
+
+- GitHub issue #1 and its 2026-05-02 owner comment.
+- `AGENTS.md`
+- `.agents/rules/node-typescript.md`
+- `.agents/rules/mcp-tool-configs.md`
+- `.agents/rules/ai-workspace-projections.md`
+- `package.json`
+- `tsconfig.json`
+- `README.md`
+- `docs/development/mcp-tooling.md`
+- `justfile`
+- `src/contract.ts`
+- `src/ipc/protocol.ts`
+- `src/ipc/client.ts`
+- `src/ipc/server.ts`
+- `src/server.ts`
+- `src/cli.ts`
+- `src/daemon/daemonMain.ts`
+- `src/daemon/daemonCli.ts`
+- `src/orchestratorService.ts`
+- `src/diagnostics.ts`
+- `src/__tests__/ipc.test.ts`
+- `src/__tests__/contract.test.ts`
+- `src/__tests__/diagnostics.test.ts`
+- `src/__tests__/integration/orchestrator.test.ts`
+
+Relevant commands:
+
+- `pnpm build`
+- `pnpm test`
+- Narrow pass while developing: `pnpm build && node --test dist/__tests__/ipc.test.js dist/__tests__/contract.test.js dist/__tests__/diagnostics.test.js`
+
+## Decisions
+
+| # | Decision | Choice | Rationale | Rejected Alternatives |
+|---|---|---|---|---|
+| 1 | Version source | Add a small shared package metadata helper that reads the installed root `package.json` at runtime and exposes the package version to both frontend and daemon code. | Avoids hard-coded versions like the current MCP server `0.1.0`, keeps packed npm installs and local builds aligned, and does not require new dependencies or TypeScript config changes. | Build-time replacement; duplicating version constants in multiple files; importing JSON with `resolveJsonModule` changes. |
+| 2 | Handshake shape | Keep `PROTOCOL_VERSION` as the numeric wire format version, and add a package version handshake using a request `frontend_version` plus daemon-side `daemon_version` comparison. | Package upgrades are not always wire-format changes. Separating protocol and package versions avoids unnecessary protocol bumps while still detecting stale daemon code. | Bump `PROTOCOL_VERSION` for every package release; rely only on new method failures; compare process paths. |
+| 3 | Old daemon compatibility | Make the frontend preflight `ping` require a daemon version before forwarding tool calls. If a responding daemon omits `daemon_version`, return `DAEMON_VERSION_MISMATCH` with `daemon_version: null` and a restart hint. | New frontend cannot force old daemon code to validate a new field, but it can classify an old `ping` response before calling newer tools. | Let the old daemon fail with `INTERNAL`; auto-stop any daemon that omits version; only document manual restart. |
+| 4 | Error contract | Add `DAEMON_VERSION_MISMATCH` to `OrchestratorErrorCodeSchema` and include details for `frontend_version`, `daemon_version`, `daemon_pid` when known, and `recovery_hint`. | Preserves the existing `{ ok: false, error }` operational failure envelope and gives clients actionable data. | Use MCP `isError: true`; overload `PROTOCOL_VERSION_MISMATCH`; return plain strings from CLI/server code. |
+| 5 | Diagnostic shape | Extend `BackendStatusReportSchema` with top-level orchestrator version fields: `frontend_version`, `daemon_version`, `version_match`, and `daemon_pid`. | `get_backend_status` is the current health surface; these fields let current-version clients prove the daemon matches and inspect the running daemon PID. | Add a separate `get_daemon_status` tool; bury the fields under backend-specific diagnostics; expose only CLI status. |
+| 6 | Restart behavior | Add a first-class `agent-orchestrator-mcp-daemon restart [--force]` command, but do not auto-restart from the MCP frontend in this pass. | Restart is useful and discoverable, while automatic restart requires careful active-run policy and should not surprise users by orphaning or cancelling work. | Always auto-restart on mismatch; add only README workaround; make restart always forceful. |
+| 7 | Documentation | Document the long-lived daemon upgrade behavior, mismatch error, `restart`, and `npx --package ... agent-orchestrator-mcp-daemon restart` recovery path. | The issue is operational; users need a clear remediation path even before automatic recovery exists. | Only update tests/code; only mention local `just orchestrator-restart`. |
+
+## Scope
+
+### In Scope
+
+- Add package version metadata available to the MCP frontend, daemon, IPC layer, diagnostics, and CLI help/status output.
+- Include the frontend package version in IPC requests.
+- Have the daemon reject package version mismatches with structured `DAEMON_VERSION_MISMATCH`.
+- Have the new frontend classify old daemons that respond to `ping` without version data as `DAEMON_VERSION_MISMATCH`.
+- Add daemon version data to `ping` and `get_backend_status`.
+- Add a `restart [--force]` daemon CLI command with safe default behavior.
+- Update README and local development docs for upgrade/restart guidance.
+- Add focused tests for contract schema, IPC mismatch behavior, diagnostics version fields, and stale-daemon frontend classification.
+
+### Out Of Scope
+
+- Automatic frontend-driven daemon restart on mismatch.
+- Any npm publishing, package version bump, dist-tag change, or release workflow change.
+- Changes to worker backend result derivation except where tests confirm the original symptom is now preempted by version mismatch detection.
+- New external dependencies.
+- Windows named-pipe support or broader daemon transport changes.
+
+## Risks And Edge Cases
+
+| # | Scenario | Mitigation | Covered By |
+|---|---|---|---|
+| 1 | New frontend talks to an old daemon that does not know `frontend_version`. | Require `daemon_version` in the frontend `ping` preflight and synthesize `DAEMON_VERSION_MISMATCH` when missing. | IPC/server tests with an old-style ping response. |
+| 2 | Old frontend talks to a new daemon without `frontend_version`. | Daemon treats missing frontend version as a mismatch with `frontend_version: null` and returns a structured error. | IPC request validation tests. |
+| 3 | Frontend and daemon versions differ but the method is otherwise valid. | Daemon validates version before dispatching to `OrchestratorService`. | IPC mismatch tests for a known method such as `list_runs`. |
+| 4 | Numeric IPC protocol mismatch still occurs. | Keep existing `PROTOCOL_VERSION_MISMATCH` behavior separate from package version mismatch. | Existing IPC protocol test plus any adjusted response parsing tests. |
+| 5 | `get_backend_status` cannot execute against a truly old daemon. | Return the mismatch envelope from the frontend before dispatch; document that status fields are available after daemon restart or when the daemon is current enough to support the contract. | Server/tool response tests and README note. |
+| 6 | `restart` is run while active worker runs exist. | Default `restart` uses non-force stop semantics and refuses with active run IDs; `restart --force` follows existing forced shutdown behavior. | CLI lifecycle tests or documented manual verification if direct CLI tests are too brittle. |
+| 7 | Runtime package version lookup fails in an unusual install layout. | Helper falls back to a clear `unknown` value; mismatch messages still show `unknown` and recovery guidance. | Unit test for helper fallback if helper is injectable, otherwise contract/diagnostic tests cover normal path. |
+| 8 | Existing clients parse `BackendStatusReport` strictly. | Add fields in a backward-compatible way at the top level while preserving existing backend fields. | Contract schema test updates. |
+
+## Implementation Tasks
+
+| Task ID | Title | Depends On | Status | Acceptance Criteria |
+|---|---|---|---|---|
+| T1 | Add package metadata helper and contract fields | None | completed | A shared helper exposes the package version without new dependencies or `tsconfig` loosening; MCP server metadata uses the package version; `OrchestratorErrorCodeSchema` includes `DAEMON_VERSION_MISMATCH`; `BackendStatusReportSchema` accepts orchestrator version fields. |
+| T2 | Implement IPC package version handshake | T1 | completed | `createRpcRequest` includes `frontend_version`; request validation detects missing or different frontend versions before method dispatch; mismatch errors include frontend and daemon versions plus a recovery hint; existing protocol mismatch behavior remains distinct. |
+| T3 | Classify stale daemon from the MCP frontend | T1, T2 | completed | `ensureDaemon` verifies `ping` includes a matching `daemon_version`; a live old daemon that omits version data is reported as `{ ok: false, error: { code: "DAEMON_VERSION_MISMATCH", ... } }`; frontend does not call newer tools after mismatch detection. |
+| T4 | Expose daemon/frontend versions in status surfaces | T1, T2 | completed | `ping` returns daemon version and PID; `get_backend_status` returns `frontend_version`, `daemon_version`, `version_match`, and `daemon_pid`; `formatBackendStatus` prints version match details; direct `OrchestratorService.dispatch` tests can pass or omit frontend context deterministically. |
+| T5 | Add daemon restart CLI ergonomics | T1 | completed | `agent-orchestrator-mcp-daemon restart` stops then starts the daemon; default restart refuses active runs through existing stop semantics; `restart --force` force-stops first; help output in `src/cli.ts` and daemon CLI usage include restart; status output includes daemon version when available. |
+| T6 | Update documentation | T3, T5 | completed | `README.md` documents long-lived daemon upgrade behavior, the mismatch error, and restart commands for installed and `npx` usage; `docs/development/mcp-tooling.md` points local developers at `just orchestrator-restart` and first-class daemon restart. |
+| T7 | Add focused tests and run quality gates | T1, T2, T3, T4, T5, T6 | completed | Tests cover contract schema changes, IPC mismatch and old-daemon classification, diagnostics version fields, and CLI restart/status behavior where practical; `pnpm build` and the narrow node test command pass; `pnpm test` passes before handoff. |
+
+## Rule Candidates
+
+| # | Candidate | Scope | Create After |
+|---|---|---|---|
+| 1 | Daemon/client IPC contracts should include both wire protocol compatibility and package/build version diagnostics. | `.agents/rules/node-typescript.md` or a new daemon lifecycle rule covering `src/ipc/**`, `src/daemon/**`, and `src/server.ts`. | After this issue lands and the pattern is stable. |
+
+## Quality Gates
+
+- [x] `pnpm build` passes. Evidence: command exited 0 on 2026-05-02.
+- [x] `node --test dist/__tests__/ipc.test.js dist/__tests__/contract.test.js dist/__tests__/diagnostics.test.js dist/__tests__/daemonCli.test.js` passes after `pnpm build`. Evidence: 19 tests passed, command exited 0 on 2026-05-02.
+- [x] `pnpm test` passes. Evidence: 39 tests passed, command exited 0 on 2026-05-02.
+- [x] Relevant `.agents/rules/` checks are satisfied: used `pnpm`, added no dependencies, kept Node 22-compatible TypeScript, updated schemas/docs/tests for MCP contract changes, and verified CLI behavior with tests plus `node dist/cli.js doctor` and `node dist/cli.js doctor --json`.
+- [x] `git diff --check` passes. Evidence: command exited 0 on 2026-05-02.
+
+## Execution Log
+
+### T1: Add package metadata helper and contract fields
+- **Status:** completed
+- **Evidence:** Added `src/packageMetadata.ts`; exported package metadata helpers from `src/index.ts`; updated MCP server metadata in `src/server.ts`; added `DAEMON_VERSION_MISMATCH`, `daemonVersionMismatchError`, and backend status version fields in `src/contract.ts`; `pnpm build` exited 0.
+- **Notes:** Package version is read from the installed root `package.json` with an `unknown` fallback and no dependency or `tsconfig` changes.
+
+### T2: Implement IPC package version handshake
+- **Status:** completed
+- **Evidence:** Updated `src/ipc/protocol.ts`, `src/ipc/client.ts`, and `src/ipc/server.ts`; `src/__tests__/ipc.test.ts` covers mismatched frontend versions, lifecycle recovery bypass for `ping`/`shutdown`, and protocol mismatch separation; targeted node test command exited 0.
+- **Notes:** Numeric `PROTOCOL_VERSION_MISMATCH` remains separate from package `DAEMON_VERSION_MISMATCH`; `ping` and `shutdown` intentionally bypass package mismatch so stale daemons can be diagnosed and stopped.
+
+### T3: Classify stale daemon from the MCP frontend
+- **Status:** completed
+- **Evidence:** Added `src/daemonVersion.ts` and wired it into `src/server.ts`; startup allows list-tools to work on mismatch while tool calls return the structured mismatch envelope; `src/__tests__/ipc.test.ts` classifies old-style ping responses as `DAEMON_VERSION_MISMATCH`.
+- **Notes:** Auto-restart remains out of scope; stale daemons are reported instead of being stopped automatically.
+
+### T4: Expose daemon/frontend versions in status surfaces
+- **Status:** completed
+- **Evidence:** Updated `src/orchestratorService.ts` ping and `get_backend_status` dispatch; updated `src/diagnostics.ts` and `formatBackendStatus`; `src/__tests__/diagnostics.test.ts` verifies direct diagnostics and daemon-dispatch version fields; `node dist/cli.js doctor` and `node dist/cli.js doctor --json` both exited 0 and showed version fields.
+- **Notes:** Direct `doctor` diagnostics show daemon version as not connected; daemon-mediated diagnostics report matching frontend and daemon versions.
+
+### T5: Add daemon restart CLI ergonomics
+- **Status:** completed
+- **Evidence:** Added `restart [--force]` to `src/daemon/daemonCli.ts`, CLI help in `src/cli.ts`, and simplified `just orchestrator-restart`; `src/__tests__/daemonCli.test.ts` verifies help, restart from stopped state, status version match output, and restart of a stale daemon with mismatched package version.
+- **Notes:** Default restart uses existing safe stop semantics; `restart --force` uses existing forced cancellation behavior. Status reports live mismatched daemons with `runs=unavailable` when `list_runs` is blocked by the handshake.
+
+### T6: Update documentation
+- **Status:** completed
+- **Evidence:** Updated `README.md` diagnostics, architecture, daemon lifecycle, npx restart examples, and upgrade guidance; updated `docs/development/mcp-tooling.md` with local restart guidance.
+- **Notes:** Documentation explicitly calls out long-lived daemon/package-upgrade version skew.
+
+### T7: Add focused tests and run quality gates
+- **Status:** completed
+- **Evidence:** `pnpm build` exited 0; targeted command `node --test dist/__tests__/ipc.test.js dist/__tests__/contract.test.js dist/__tests__/diagnostics.test.js dist/__tests__/daemonCli.test.js` passed 19 tests; `node --test dist/__tests__/ipc.test.js dist/__tests__/daemonCli.test.js` passed 9 tests for the review finding fix; `pnpm test` passed 39 tests; `git diff --check` exited 0.
+- **Notes:** Hardening pass checked IPC/server call sites, daemon CLI behavior, docs, and status/report surfaces.

--- a/src/__tests__/contract.test.ts
+++ b/src/__tests__/contract.test.ts
@@ -34,6 +34,10 @@ describe('contract schemas and envelopes', () => {
     });
 
     BackendStatusReportSchema.parse({
+      frontend_version: '0.1.1-beta.0',
+      daemon_version: '0.1.1-beta.0',
+      version_match: true,
+      daemon_pid: 123,
       platform: 'linux',
       node_version: 'v22.0.0',
       posix_supported: true,
@@ -94,6 +98,10 @@ describe('contract schemas and envelopes', () => {
     assert.deepStrictEqual(
       wrapErr(orchestratorError('UNKNOWN_RUN', 'missing')),
       { ok: false, error: { code: 'UNKNOWN_RUN', message: 'missing' } },
+    );
+    assert.deepStrictEqual(
+      wrapErr(orchestratorError('DAEMON_VERSION_MISMATCH', 'mismatch', { frontend_version: 'new', daemon_version: 'old' })),
+      { ok: false, error: { code: 'DAEMON_VERSION_MISMATCH', message: 'mismatch', details: { frontend_version: 'new', daemon_version: 'old' } } },
     );
   });
 });

--- a/src/__tests__/daemonCli.test.ts
+++ b/src/__tests__/daemonCli.test.ts
@@ -1,0 +1,106 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { execFile } from 'node:child_process';
+import { mkdir, mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { promisify } from 'node:util';
+import { IpcServer } from '../ipc/server.js';
+import { getPackageVersion } from '../packageMetadata.js';
+
+const execFileAsync = promisify(execFile);
+const testDir = dirname(fileURLToPath(import.meta.url));
+const cliPath = join(testDir, '..', 'cli.js');
+const daemonCliPath = join(testDir, '..', 'daemonCli.js');
+
+describe('daemon CLI', () => {
+  it('documents restart in the top-level CLI help', async () => {
+    const result = await execFileAsync(process.execPath, [cliPath, '--help'], { timeout: 5_000 });
+
+    assert.match(result.stdout, /agent-orchestrator-mcp-daemon restart \[--force\]/);
+  });
+
+  it('restarts a stopped daemon and reports matching versions in status', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'agent-daemon-cli-'));
+    const home = join(root, 'home');
+    const env = { ...process.env, AGENT_ORCHESTRATOR_HOME: home };
+
+    try {
+      const restart = await execFileAsync(process.execPath, [daemonCliPath, 'restart'], { env, timeout: 10_000 });
+      assert.match(restart.stdout, /agent-orchestrator daemon is stopped/);
+      assert.match(restart.stdout, /agent-orchestrator daemon started pid=/);
+
+      const status = await execFileAsync(process.execPath, [daemonCliPath, 'status'], { env, timeout: 10_000 });
+      assert.match(status.stdout, /running pid=/);
+      assert.match(status.stdout, new RegExp(`daemon_version=${escapeRegExp(getPackageVersion())}`));
+      assert.match(status.stdout, new RegExp(`frontend_version=${escapeRegExp(getPackageVersion())}`));
+      assert.match(status.stdout, /version_match=true/);
+    } finally {
+      await execFileAsync(process.execPath, [daemonCliPath, 'stop', '--force'], { env, timeout: 10_000 }).catch(() => undefined);
+      await waitForStopped(env);
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it('restarts a stale daemon with a mismatched package version', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'agent-daemon-cli-'));
+    const home = join(root, 'home');
+    const socket = join(home, 'daemon.sock');
+    const env = { ...process.env, AGENT_ORCHESTRATOR_HOME: home };
+    let staleServer: IpcServer | null = null;
+
+    try {
+      await mkdir(home);
+      staleServer = new IpcServer(socket, async (method) => {
+        if (method === 'ping') {
+          return { ok: true, pong: true, daemon_pid: process.pid, daemon_version: '0.0.0-stale' };
+        }
+        if (method === 'shutdown') {
+          setImmediate(() => {
+            void staleServer?.close();
+            staleServer = null;
+          });
+          return { ok: true, accepted: true };
+        }
+        return { ok: true, runs: [] };
+      }, '0.0.0-stale');
+      await staleServer.listen();
+
+      const staleStatus = await execFileAsync(process.execPath, [daemonCliPath, 'status'], { env, timeout: 10_000 });
+      assert.match(staleStatus.stdout, /daemon_version=0\.0\.0-stale/);
+      assert.match(staleStatus.stdout, /version_match=false/);
+      assert.match(staleStatus.stdout, /runs=unavailable/);
+
+      const restart = await execFileAsync(process.execPath, [daemonCliPath, 'restart'], { env, timeout: 10_000 });
+      assert.match(restart.stdout, /agent-orchestrator daemon stopping/);
+      assert.match(restart.stdout, /agent-orchestrator daemon started pid=/);
+
+      const currentStatus = await execFileAsync(process.execPath, [daemonCliPath, 'status'], { env, timeout: 10_000 });
+      assert.match(currentStatus.stdout, new RegExp(`daemon_version=${escapeRegExp(getPackageVersion())}`));
+      assert.match(currentStatus.stdout, /version_match=true/);
+    } finally {
+      await staleServer?.close().catch(() => undefined);
+      await execFileAsync(process.execPath, [daemonCliPath, 'stop', '--force'], { env, timeout: 10_000 }).catch(() => undefined);
+      await waitForStopped(env);
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+});
+
+async function waitForStopped(env: NodeJS.ProcessEnv): Promise<void> {
+  const deadline = Date.now() + 5_000;
+  while (Date.now() < deadline) {
+    try {
+      await execFileAsync(process.execPath, [daemonCliPath, 'status'], { env, timeout: 2_000 });
+      await new Promise((resolve) => setTimeout(resolve, 100));
+    } catch {
+      return;
+    }
+  }
+  throw new Error('daemon did not stop before timeout');
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}

--- a/src/__tests__/diagnostics.test.ts
+++ b/src/__tests__/diagnostics.test.ts
@@ -6,6 +6,7 @@ import { tmpdir } from 'node:os';
 import { getBackendStatus } from '../diagnostics.js';
 import { createBackendRegistry } from '../backend/registry.js';
 import { OrchestratorService } from '../orchestratorService.js';
+import { getPackageVersion } from '../packageMetadata.js';
 import { RunStore } from '../runStore.js';
 
 let originalPath = process.env.PATH;
@@ -36,6 +37,10 @@ describe('backend diagnostics', () => {
 
     const report = await getBackendStatus();
 
+    assert.equal(report.frontend_version, getPackageVersion());
+    assert.equal(report.daemon_version, null);
+    assert.equal(report.version_match, false);
+    assert.equal(report.daemon_pid, null);
     assert.equal(report.posix_supported, true);
     assert.deepStrictEqual(report.backends.map((backend) => backend.status), ['missing', 'missing']);
     assert.ok(report.backends.every((backend) => backend.hints.length > 0));
@@ -99,9 +104,13 @@ describe('backend diagnostics', () => {
 
     const service = new OrchestratorService(new RunStore(join(root, 'home')), createBackendRegistry());
     await service.initialize();
-    const result = await service.dispatch('get_backend_status', {}) as { ok: boolean; status?: { backends: { status: string }[] } };
+    const result = await service.dispatch('get_backend_status', {}, { frontend_version: getPackageVersion() }) as { ok: boolean; status?: { frontend_version: string; daemon_version: string | null; version_match: boolean; daemon_pid: number | null; backends: { status: string }[] } };
 
     assert.equal(result.ok, true);
+    assert.equal(result.status?.frontend_version, getPackageVersion());
+    assert.equal(result.status?.daemon_version, getPackageVersion());
+    assert.equal(result.status?.version_match, true);
+    assert.equal(result.status?.daemon_pid, process.pid);
     assert.deepStrictEqual(result.status?.backends.map((backend) => backend.status), ['auth_unknown', 'auth_unknown']);
   });
 

--- a/src/__tests__/ipc.test.ts
+++ b/src/__tests__/ipc.test.ts
@@ -7,16 +7,19 @@ import { connect } from 'node:net';
 import { IpcClient, IpcRequestError } from '../ipc/client.js';
 import { IpcServer } from '../ipc/server.js';
 import { encodeFrame, FrameReader, writeFrame } from '../ipc/protocol.js';
+import { PROTOCOL_VERSION } from '../contract.js';
+import { checkDaemonVersion } from '../daemonVersion.js';
+import { getPackageVersion } from '../packageMetadata.js';
 
 describe('IPC protocol', () => {
   it('round-trips JSON-RPC requests', async () => {
     const root = await mkdtemp(join(tmpdir(), 'agent-ipc-'));
     const socket = join(root, 'daemon.sock');
-    const server = new IpcServer(socket, async (method, params) => ({ method, params }));
+    const server = new IpcServer(socket, async (method, params, context) => ({ method, params, frontend_version: context.frontend_version }));
     await server.listen();
     const client = new IpcClient(socket);
     const result = await client.request('ping', { hello: true });
-    assert.deepStrictEqual(result, { method: 'ping', params: { hello: true } });
+    assert.deepStrictEqual(result, { method: 'ping', params: { hello: true }, frontend_version: getPackageVersion() });
     await server.close();
     await rm(root, { recursive: true, force: true });
   });
@@ -39,6 +42,66 @@ describe('IPC protocol', () => {
     raw.destroy();
     await server.close();
     await rm(root, { recursive: true, force: true });
+  });
+
+  it('allows ping and shutdown during daemon version mismatch for recovery', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'agent-ipc-'));
+    const socket = join(root, 'daemon.sock');
+    const calls: string[] = [];
+    const server = new IpcServer(socket, async (method) => {
+      calls.push(method);
+      return { method };
+    }, '0.0.0-stale');
+    await server.listen();
+
+    const raw = connect(socket);
+    await new Promise<void>((resolve) => raw.once('connect', resolve));
+    raw.write(encodeFrame({ protocol_version: PROTOCOL_VERSION, frontend_version: getPackageVersion(), id: 'ping', method: 'ping' }));
+    raw.write(encodeFrame({ protocol_version: PROTOCOL_VERSION, frontend_version: getPackageVersion(), id: 'shutdown', method: 'shutdown' }));
+    const reader = new FrameReader();
+    const responses = await new Promise<Record<string, unknown>[]>((resolve) => {
+      const frames: Record<string, unknown>[] = [];
+      raw.on('data', (chunk) => {
+        frames.push(...reader.push(chunk) as Record<string, unknown>[]);
+        if (frames.length === 2) resolve(frames);
+      });
+    });
+    assert.deepStrictEqual(responses.map((response) => response.ok), [true, true]);
+    assert.deepStrictEqual(calls, ['ping', 'shutdown']);
+    raw.destroy();
+    await server.close();
+    await rm(root, { recursive: true, force: true });
+  });
+
+  it('returns daemon version mismatch when frontend version differs', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'agent-ipc-'));
+    const socket = join(root, 'daemon.sock');
+    const server = new IpcServer(socket, async () => ({ ok: true }));
+    await server.listen();
+
+    const raw = connect(socket);
+    await new Promise<void>((resolve) => raw.once('connect', resolve));
+    raw.write(encodeFrame({ protocol_version: PROTOCOL_VERSION, frontend_version: '0.0.0-stale', id: 'stale', method: 'list_runs' }));
+    const reader = new FrameReader();
+    const response = await new Promise<Record<string, unknown>>((resolve) => {
+      raw.once('data', (chunk) => resolve(reader.push(chunk)[0] as Record<string, unknown>));
+    });
+    assert.equal(response.ok, false);
+    const error = response.error as { code: string; details: { frontend_version: unknown; daemon_version: unknown } };
+    assert.equal(error.code, 'DAEMON_VERSION_MISMATCH');
+    assert.equal(error.details.frontend_version, '0.0.0-stale');
+    assert.equal(error.details.daemon_version, getPackageVersion());
+    raw.destroy();
+    await server.close();
+    await rm(root, { recursive: true, force: true });
+  });
+
+  it('classifies old-style daemon ping responses as a version mismatch', () => {
+    const check = checkDaemonVersion({ ok: true, pong: true, daemon_pid: 12345 });
+    assert.equal(check.ok, false);
+    assert.equal(check.ok ? null : check.error.code, 'DAEMON_VERSION_MISMATCH');
+    assert.equal(check.ok ? undefined : check.error.details?.daemon_version, null);
+    assert.equal(check.ok ? undefined : check.error.details?.daemon_pid, 12345);
   });
 
   it('wraps unavailable daemon as DAEMON_UNAVAILABLE', async () => {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -25,6 +25,7 @@ Daemon lifecycle:
   agent-orchestrator-mcp-daemon status
   agent-orchestrator-mcp-daemon start
   agent-orchestrator-mcp-daemon stop [--force]
+  agent-orchestrator-mcp-daemon restart [--force]
   agent-orchestrator-mcp-daemon prune --older-than-days <days> [--dry-run]
 `);
 } else {

--- a/src/contract.ts
+++ b/src/contract.ts
@@ -62,6 +62,10 @@ export const BackendDiagnosticSchema = z.object({
 export type BackendDiagnostic = z.infer<typeof BackendDiagnosticSchema>;
 
 export const BackendStatusReportSchema = z.object({
+  frontend_version: z.string(),
+  daemon_version: z.string().nullable(),
+  version_match: z.boolean(),
+  daemon_pid: z.number().int().nullable(),
   platform: z.string(),
   node_version: z.string(),
   posix_supported: z.boolean(),
@@ -94,6 +98,7 @@ export type GitSnapshot = z.infer<typeof GitSnapshotSchema>;
 
 export const OrchestratorErrorCodeSchema = z.enum([
   'DAEMON_UNAVAILABLE',
+  'DAEMON_VERSION_MISMATCH',
   'UNKNOWN_RUN',
   'INVALID_INPUT',
   'BACKEND_NOT_FOUND',
@@ -246,6 +251,7 @@ export type RpcMethod = z.infer<typeof RpcMethodSchema>;
 
 export const RpcRequestSchema = z.object({
   protocol_version: z.literal(PROTOCOL_VERSION),
+  frontend_version: z.string().min(1).optional(),
   id: z.string(),
   method: RpcMethodSchema,
   params: z.unknown().optional(),
@@ -278,4 +284,30 @@ export function orchestratorError(
   details?: Record<string, unknown>,
 ): OrchestratorError {
   return details ? { code, message, details } : { code, message };
+}
+
+export const DAEMON_VERSION_MISMATCH_RECOVERY_HINT =
+  'Restart the daemon so it picks up the current package build: agent-orchestrator-mcp-daemon restart';
+
+export function daemonVersionMismatchError(input: {
+  frontendVersion: string | null;
+  daemonVersion: string | null;
+  daemonPid?: number | null;
+}): OrchestratorError {
+  const frontendVersion = input.frontendVersion ?? 'unknown';
+  const daemonVersion = input.daemonVersion ?? 'unknown';
+  const details: Record<string, unknown> = {
+    frontend_version: input.frontendVersion,
+    daemon_version: input.daemonVersion,
+    recovery_hint: DAEMON_VERSION_MISMATCH_RECOVERY_HINT,
+  };
+  if (input.daemonPid !== undefined) {
+    details.daemon_pid = input.daemonPid;
+  }
+
+  return orchestratorError(
+    'DAEMON_VERSION_MISMATCH',
+    `Frontend package version ${frontendVersion} does not match daemon package version ${daemonVersion}. Restart the daemon so it picks up the current package build.`,
+    details,
+  );
 }

--- a/src/daemon/daemonCli.ts
+++ b/src/daemon/daemonCli.ts
@@ -6,6 +6,7 @@ import { readFile } from 'node:fs/promises';
 import { existsSync } from 'node:fs';
 import { IpcClient, IpcRequestError } from '../ipc/client.js';
 import { daemonPaths } from './paths.js';
+import { getPackageVersion } from '../packageMetadata.js';
 import { RunStore, type PruneRunsResult } from '../runStore.js';
 
 const paths = daemonPaths();
@@ -19,6 +20,9 @@ async function main(): Promise<void> {
     case 'stop':
       await stop(process.argv.includes('--force'));
       break;
+    case 'restart':
+      await restart(process.argv.includes('--force'));
+      break;
     case 'status':
       await status();
       break;
@@ -26,7 +30,7 @@ async function main(): Promise<void> {
       await prune();
       break;
     default:
-      process.stderr.write('Usage: daemonCli.js start | stop [--force] | status | prune --older-than-days <days> [--dry-run]\n');
+      process.stderr.write('Usage: daemonCli.js start | stop [--force] | restart [--force] | status | prune --older-than-days <days> [--dry-run]\n');
       process.exit(1);
   }
 }
@@ -65,14 +69,35 @@ async function stop(force: boolean): Promise<void> {
   }
 }
 
+async function restart(force: boolean): Promise<void> {
+  if (await ping()) {
+    await stop(force);
+    await waitForStopped(5_000);
+  } else {
+    process.stdout.write('agent-orchestrator daemon is stopped\n');
+  }
+  await start();
+}
+
 async function status(): Promise<void> {
   const client = new IpcClient(paths.socket);
   try {
-    const pingResult = await client.request('ping', {}) as { ok: true; pong: true; daemon_pid: number };
-    const listResult = await client.request('list_runs', {}) as { ok: true; runs: { status: string }[] };
-    const counts = new Map<string, number>();
-    for (const run of listResult.runs) counts.set(run.status, (counts.get(run.status) ?? 0) + 1);
-    process.stdout.write(`running pid=${pingResult.daemon_pid} runs=${JSON.stringify(Object.fromEntries(counts))}\n`);
+    const pingResult = await client.request('ping', {}) as { ok: true; pong: true; daemon_pid: number; daemon_version?: string };
+    let runs = 'unavailable';
+    try {
+      const listResult = await client.request('list_runs', {}) as { ok: true; runs: { status: string }[] };
+      const counts = new Map<string, number>();
+      for (const run of listResult.runs) counts.set(run.status, (counts.get(run.status) ?? 0) + 1);
+      runs = JSON.stringify(Object.fromEntries(counts));
+    } catch (error) {
+      if (!(error instanceof IpcRequestError && error.orchestratorError.code === 'DAEMON_VERSION_MISMATCH')) {
+        throw error;
+      }
+    }
+    const daemonVersion = typeof pingResult.daemon_version === 'string' ? pingResult.daemon_version : null;
+    const frontendVersion = getPackageVersion();
+    const versionMatch = daemonVersion === frontendVersion;
+    process.stdout.write(`running pid=${pingResult.daemon_pid} daemon_version=${daemonVersion ?? 'unknown'} frontend_version=${frontendVersion} version_match=${versionMatch} runs=${runs}\n`);
   } catch {
     process.stdout.write('stopped\n');
     process.exitCode = 1;
@@ -123,6 +148,15 @@ async function waitForDaemon(timeoutMs: number): Promise<void> {
     await new Promise((resolve) => setTimeout(resolve, 100));
   }
   throw new Error('daemon did not start before timeout');
+}
+
+async function waitForStopped(timeoutMs: number): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (!await ping()) return;
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  throw new Error('daemon did not stop before timeout');
 }
 
 async function readPid(): Promise<string | null> {

--- a/src/daemon/daemonMain.ts
+++ b/src/daemon/daemonMain.ts
@@ -32,7 +32,7 @@ async function main(): Promise<void> {
   const service = new OrchestratorService(store, createBackendRegistry(), log);
   await service.initialize();
 
-  ipcServer = new IpcServer(paths.socket, async (method, params) => service.dispatch(method, params));
+  ipcServer = new IpcServer(paths.socket, async (method, params, context) => service.dispatch(method, params, context));
   const oldUmask = process.umask(0o177);
   try {
     await ipcServer.listen();

--- a/src/daemonVersion.ts
+++ b/src/daemonVersion.ts
@@ -1,0 +1,23 @@
+import { daemonVersionMismatchError, type OrchestratorError } from './contract.js';
+import { getPackageVersion } from './packageMetadata.js';
+
+export type DaemonVersionCheck =
+  | { ok: true; daemon_version: string; daemon_pid: number | null }
+  | { ok: false; error: OrchestratorError };
+
+export function checkDaemonVersion(value: unknown, frontendVersion = getPackageVersion()): DaemonVersionCheck {
+  const rec = value && typeof value === 'object' ? value as Record<string, unknown> : {};
+  const daemonVersion = typeof rec.daemon_version === 'string' ? rec.daemon_version : null;
+  const daemonPid = typeof rec.daemon_pid === 'number' ? rec.daemon_pid : null;
+  if (daemonVersion !== frontendVersion) {
+    return {
+      ok: false,
+      error: daemonVersionMismatchError({
+        frontendVersion,
+        daemonVersion,
+        daemonPid,
+      }),
+    };
+  }
+  return { ok: true, daemon_version: daemonVersion, daemon_pid: daemonPid };
+}

--- a/src/diagnostics.ts
+++ b/src/diagnostics.ts
@@ -5,9 +5,16 @@ import { promisify } from 'node:util';
 import type { Backend, BackendDiagnostic, BackendStatusReport } from './contract.js';
 import { resolveBinary } from './backend/common.js';
 import { daemonPaths } from './daemon/paths.js';
+import { getPackageVersion } from './packageMetadata.js';
 
 const execFileAsync = promisify(execFile);
 const commandTimeoutMs = 2_000;
+
+export interface BackendStatusOptions {
+  frontendVersion?: string | null;
+  daemonVersion?: string | null;
+  daemonPid?: number | null;
+}
 
 interface BackendCheckDefinition {
   name: Backend;
@@ -58,13 +65,19 @@ const definitions: BackendCheckDefinition[] = [
   },
 ];
 
-export async function getBackendStatus(): Promise<BackendStatusReport> {
+export async function getBackendStatus(options: BackendStatusOptions = {}): Promise<BackendStatusReport> {
   const paths = daemonPaths();
   const runStore = await checkRunStore(paths.home);
   const posixSupported = process.platform !== 'win32';
   const backends = await Promise.all(definitions.map((definition) => diagnoseBackend(definition, posixSupported)));
+  const frontendVersion = options.frontendVersion ?? getPackageVersion();
+  const daemonVersion = options.daemonVersion ?? null;
 
   return {
+    frontend_version: frontendVersion,
+    daemon_version: daemonVersion,
+    version_match: daemonVersion !== null && frontendVersion === daemonVersion,
+    daemon_pid: options.daemonPid ?? null,
     platform: process.platform,
     node_version: process.version,
     posix_supported: posixSupported,
@@ -77,6 +90,10 @@ export function formatBackendStatus(report: BackendStatusReport): string {
   const lines: string[] = [
     'Agent Orchestrator MCP diagnostics',
     '',
+    `Frontend version: ${report.frontend_version}`,
+    `Daemon version: ${report.daemon_version ?? 'not connected'}`,
+    `Version match: ${report.daemon_version === null ? 'not checked' : report.version_match ? 'yes' : 'no'}`,
+    ...(report.daemon_pid === null ? [] : [`Daemon PID: ${report.daemon_pid}`]),
     `Platform: ${report.platform}`,
     `Node: ${report.node_version}`,
     `POSIX support: ${report.posix_supported ? 'yes' : 'no'}`,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,4 @@
 export * from './contract.js';
+export { checkDaemonVersion } from './daemonVersion.js';
 export { formatBackendStatus, getBackendStatus } from './diagnostics.js';
+export { getPackageMetadata, getPackageVersion } from './packageMetadata.js';

--- a/src/ipc/client.ts
+++ b/src/ipc/client.ts
@@ -2,15 +2,19 @@ import { connect } from 'node:net';
 import { once } from 'node:events';
 import { createRpcRequest, FrameReader, writeFrame } from './protocol.js';
 import { orchestratorError, type OrchestratorError, RpcResponseSchema, type RpcMethod } from '../contract.js';
+import { getPackageVersion } from '../packageMetadata.js';
 
 export class IpcClient {
-  constructor(private readonly socketPath: string) {}
+  constructor(
+    private readonly socketPath: string,
+    private readonly frontendVersion = getPackageVersion(),
+  ) {}
 
   async request<T = unknown>(method: RpcMethod, params?: unknown, timeoutMs = 30_000): Promise<T> {
     const socket = connect(this.socketPath);
     try {
       await once(socket, 'connect');
-      const request = createRpcRequest(method, params);
+      const request = createRpcRequest(method, params, this.frontendVersion);
       const reader = new FrameReader();
       return await new Promise<T>((resolve, reject) => {
         const timer = setTimeout(() => {

--- a/src/ipc/protocol.ts
+++ b/src/ipc/protocol.ts
@@ -1,17 +1,21 @@
 import type { Socket } from 'node:net';
 import { randomUUID } from 'node:crypto';
 import {
+  daemonVersionMismatchError,
   orchestratorError,
   PROTOCOL_VERSION,
   RpcRequestSchema,
+  type OrchestratorError,
   type RpcMethod,
   type RpcRequest,
   type RpcResponse,
 } from '../contract.js';
+import { getPackageVersion } from '../packageMetadata.js';
 
-export function createRpcRequest(method: RpcMethod, params?: unknown): RpcRequest {
+export function createRpcRequest(method: RpcMethod, params?: unknown, frontendVersion = getPackageVersion()): RpcRequest {
   return {
     protocol_version: PROTOCOL_VERSION,
+    frontend_version: frontendVersion,
     id: randomUUID(),
     method,
     params,
@@ -49,13 +53,32 @@ export function writeFrame(socket: Socket, value: unknown): void {
   socket.write(encodeFrame(value));
 }
 
-export function validateRpcRequest(value: unknown): RpcRequest | { protocolMismatch: true; id: string | null } {
+export function validateRpcRequest(
+  value: unknown,
+  daemonVersion = getPackageVersion(),
+): RpcRequest | { protocolMismatch: true; id: string | null } | { daemonVersionMismatch: true; id: string | null; error: OrchestratorError } {
   const rec = value && typeof value === 'object' ? value as Record<string, unknown> : {};
   const id = typeof rec.id === 'string' ? rec.id : null;
   if (rec.protocol_version !== PROTOCOL_VERSION) {
     return { protocolMismatch: true, id };
   }
-  return RpcRequestSchema.parse(value);
+  const request = RpcRequestSchema.parse(value);
+  if (request.frontend_version !== daemonVersion && !allowsLifecycleVersionMismatch(request.method)) {
+    return {
+      daemonVersionMismatch: true,
+      id,
+      error: daemonVersionMismatchError({
+        frontendVersion: request.frontend_version ?? null,
+        daemonVersion,
+        daemonPid: process.pid,
+      }),
+    };
+  }
+  return request;
+}
+
+function allowsLifecycleVersionMismatch(method: RpcMethod): boolean {
+  return method === 'ping' || method === 'shutdown';
 }
 
 export function rpcOk(id: string, result: unknown): RpcResponse {
@@ -73,5 +96,14 @@ export function rpcErr(id: string, code: Parameters<typeof orchestratorError>[0]
     id,
     ok: false,
     error: orchestratorError(code, message, details),
+  };
+}
+
+export function rpcErrFromError(id: string, error: OrchestratorError): RpcResponse {
+  return {
+    protocol_version: PROTOCOL_VERSION,
+    id,
+    ok: false,
+    error,
   };
 }

--- a/src/ipc/server.ts
+++ b/src/ipc/server.ts
@@ -1,8 +1,13 @@
 import { createServer, type Server as NetServer, type Socket } from 'node:net';
-import { FrameReader, rpcErr, rpcOk, validateRpcRequest, writeFrame } from './protocol.js';
+import { FrameReader, rpcErr, rpcErrFromError, rpcOk, validateRpcRequest, writeFrame } from './protocol.js';
 import type { RpcMethod } from '../contract.js';
+import { getPackageVersion } from '../packageMetadata.js';
 
-export type RpcHandler = (method: RpcMethod, params: unknown) => Promise<unknown>;
+export interface RpcContext {
+  frontend_version: string | null;
+}
+
+export type RpcHandler = (method: RpcMethod, params: unknown, context: RpcContext) => Promise<unknown>;
 
 export class IpcServer {
   private server: NetServer | null = null;
@@ -10,6 +15,7 @@ export class IpcServer {
   constructor(
     private readonly socketPath: string,
     private readonly handler: RpcHandler,
+    private readonly daemonVersion = getPackageVersion(),
   ) {}
 
   async listen(): Promise<void> {
@@ -46,12 +52,16 @@ export class IpcServer {
         const rec = frame && typeof frame === 'object' ? frame as Record<string, unknown> : {};
         const id = typeof rec.id === 'string' ? rec.id : 'unknown';
         try {
-          const request = validateRpcRequest(frame);
+          const request = validateRpcRequest(frame, this.daemonVersion);
           if ('protocolMismatch' in request) {
             writeFrame(socket, rpcErr(request.id ?? id, 'PROTOCOL_VERSION_MISMATCH', 'IPC protocol version mismatch'));
             continue;
           }
-          const result = await this.handler(request.method, request.params);
+          if ('daemonVersionMismatch' in request) {
+            writeFrame(socket, rpcErrFromError(request.id ?? id, request.error));
+            continue;
+          }
+          const result = await this.handler(request.method, request.params, { frontend_version: request.frontend_version ?? null });
           writeFrame(socket, rpcOk(request.id, result));
         } catch (error) {
           writeFrame(socket, rpcErr(id, 'INTERNAL', error instanceof Error ? error.message : String(error)));

--- a/src/orchestratorService.ts
+++ b/src/orchestratorService.ts
@@ -24,6 +24,7 @@ import type { WorkerBackend } from './backend/WorkerBackend.js';
 import { resolveBinary } from './backend/common.js';
 import { getBackendStatus } from './diagnostics.js';
 import { captureGitSnapshot } from './gitSnapshot.js';
+import { getPackageVersion } from './packageMetadata.js';
 import { ProcessManager, type ManagedRun } from './processManager.js';
 import { RunStore } from './runStore.js';
 
@@ -39,6 +40,10 @@ const defaultConfig: OrchestratorConfig = {
 
 type ToolResult = ToolResponse<object>;
 type OrchestratorLogger = (message: string) => void;
+
+export interface OrchestratorDispatchContext {
+  frontend_version?: string | null;
+}
 
 export class OrchestratorService {
   private readonly processManager: ProcessManager;
@@ -61,10 +66,10 @@ export class OrchestratorService {
     await this.orphanRunningRuns();
   }
 
-  async dispatch(method: string, params: unknown): Promise<unknown> {
+  async dispatch(method: string, params: unknown, context: OrchestratorDispatchContext = {}): Promise<unknown> {
     switch (method) {
       case 'ping':
-        return wrapOk({ pong: true, daemon_pid: process.pid });
+        return wrapOk({ pong: true, daemon_pid: process.pid, daemon_version: getPackageVersion() });
       case 'shutdown':
         return this.shutdown(params);
       case 'prune_runs':
@@ -86,7 +91,13 @@ export class OrchestratorService {
       case 'cancel_run':
         return this.cancelRun(params);
       case 'get_backend_status':
-        return wrapOk({ status: await getBackendStatus() });
+        return wrapOk({
+          status: await getBackendStatus({
+            frontendVersion: context.frontend_version ?? getPackageVersion(),
+            daemonVersion: getPackageVersion(),
+            daemonPid: process.pid,
+          }),
+        });
       default:
         return wrapErr(orchestratorError('INVALID_INPUT', `Unknown method: ${method}`));
     }

--- a/src/packageMetadata.ts
+++ b/src/packageMetadata.ts
@@ -1,0 +1,35 @@
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const fallbackName = '@ralphkrauss/agent-orchestrator-mcp';
+const fallbackVersion = 'unknown';
+
+export interface PackageMetadata {
+  name: string;
+  version: string;
+}
+
+let cached: PackageMetadata | null = null;
+
+export function getPackageMetadata(): PackageMetadata {
+  cached ??= readPackageMetadata();
+  return cached;
+}
+
+export function getPackageVersion(): string {
+  return getPackageMetadata().version;
+}
+
+function readPackageMetadata(): PackageMetadata {
+  const packageJsonPath = resolve(dirname(fileURLToPath(import.meta.url)), '../package.json');
+  try {
+    const parsed = JSON.parse(readFileSync(packageJsonPath, 'utf8')) as Record<string, unknown>;
+    return {
+      name: typeof parsed.name === 'string' && parsed.name ? parsed.name : fallbackName,
+      version: typeof parsed.version === 'string' && parsed.version ? parsed.version : fallbackVersion,
+    };
+  } catch {
+    return { name: fallbackName, version: fallbackVersion };
+  }
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -11,6 +11,8 @@ import {
 import { IpcClient, IpcRequestError } from './ipc/client.js';
 import { daemonPaths } from './daemon/paths.js';
 import { orchestratorError, wrapErr } from './contract.js';
+import { checkDaemonVersion } from './daemonVersion.js';
+import { getPackageVersion } from './packageMetadata.js';
 import { ipcTimeoutForTool } from './toolTimeout.js';
 
 const paths = daemonPaths();
@@ -112,7 +114,7 @@ const tools = [
 ] as const;
 
 const server = new Server(
-  { name: 'agent-orchestrator-mcp', version: '0.1.0' },
+  { name: 'agent-orchestrator-mcp', version: getPackageVersion() },
   { capabilities: { tools: {} } },
 );
 
@@ -150,11 +152,15 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
   }
 });
 
-async function ensureDaemon(): Promise<void> {
+async function ensureDaemon(options: { allowVersionMismatch?: boolean } = {}): Promise<void> {
   try {
-    await client.request('ping', {}, 500);
+    assertMatchingDaemon(await client.request('ping', {}, 500));
     return;
-  } catch {
+  } catch (error) {
+    if (isDaemonVersionMismatch(error)) {
+      if (options.allowVersionMismatch) return;
+      throw error;
+    }
     // Auto-start below.
   }
 
@@ -169,9 +175,10 @@ async function ensureDaemon(): Promise<void> {
   const deadline = Date.now() + 2_000;
   while (Date.now() < deadline) {
     try {
-      await client.request('ping', {}, 500);
+      assertMatchingDaemon(await client.request('ping', {}, 500));
       return;
-    } catch {
+    } catch (error) {
+      if (isDaemonVersionMismatch(error)) throw error;
       await new Promise((resolve) => setTimeout(resolve, 100));
     }
   }
@@ -179,9 +186,18 @@ async function ensureDaemon(): Promise<void> {
   throw new IpcRequestError(orchestratorError('DAEMON_UNAVAILABLE', `Daemon did not start; inspect ${paths.log}`));
 }
 
+function assertMatchingDaemon(value: unknown): void {
+  const check = checkDaemonVersion(value);
+  if (!check.ok) throw new IpcRequestError(check.error);
+}
+
+function isDaemonVersionMismatch(error: unknown): boolean {
+  return error instanceof IpcRequestError && error.orchestratorError.code === 'DAEMON_VERSION_MISMATCH';
+}
+
 process.on('SIGINT', () => process.exit(0));
 process.on('SIGTERM', () => process.exit(0));
 
 const transport = new StdioServerTransport();
-await ensureDaemon();
+await ensureDaemon({ allowVersionMismatch: true });
 await server.connect(transport);


### PR DESCRIPTION
## Summary

- Add a frontend/daemon package-version handshake over IPC and return structured `DAEMON_VERSION_MISMATCH` errors for stale daemons.
- Expose frontend/daemon version match details through `ping`, `get_backend_status`, `doctor`, and daemon status output.
- Add `agent-orchestrator-mcp-daemon restart [--force]`, document upgrade recovery, and cover stale-daemon restart behavior with tests.

## Issue

Closes #1

## Verification

- [x] `pnpm build`
- [x] `node --test dist/__tests__/ipc.test.js dist/__tests__/daemonCli.test.js`
- [x] `node --test dist/__tests__/ipc.test.js dist/__tests__/contract.test.js dist/__tests__/diagnostics.test.js dist/__tests__/daemonCli.test.js`
- [x] `pnpm test`
- [x] `node dist/cli.js doctor`
- [x] `node dist/cli.js doctor --json`
- [x] `git diff --check`

## Review

- Pre-PR review was run twice locally. The first pass found a stale-daemon restart issue; the fix is included. The second pass found no remaining findings.