### PR TITLE
Add native Windows daemon support

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,10 +23,13 @@ node dist/cli.js
 
 ## Prerequisites
 
-- POSIX environment. v1 uses Unix sockets and POSIX process groups. Windows named pipes are not implemented.
 - Node.js 22 or newer.
 - Codex CLI installed and authenticated if you want Codex workers.
 - Claude CLI installed and authenticated if you want Claude workers.
+
+Linux and macOS use Unix sockets and POSIX process groups. Windows uses a
+per-store named pipe for daemon IPC and `taskkill` for worker process-tree
+cancellation.
 
 The MCP package never installs or bundles worker CLIs. Missing workers are reported by diagnostics and by failed run results, but one missing backend does not prevent the MCP server from starting.
 
@@ -41,7 +44,7 @@ npx -y @ralphkrauss/agent-orchestrator-mcp@latest doctor --json
 
 Diagnostics check:
 
-- POSIX support
+- platform and POSIX process-group availability
 - Node version
 - run-store accessibility
 - `codex` and `claude` binary presence
@@ -133,7 +136,7 @@ There are two processes:
 
 | Process | Responsibility | Lifetime |
 |---|---|---|
-| `agent-orchestrator-mcp` | Stdio MCP server. Translates MCP tool calls into JSON-RPC requests over a Unix socket. Holds no run state. | Same lifetime as the MCP client. Restarts are expected. |
+| `agent-orchestrator-mcp` | Stdio MCP server. Translates MCP tool calls into JSON-RPC requests over a local daemon IPC endpoint. Holds no run state. | Same lifetime as the MCP client. Restarts are expected. |
 | `agent-orchestrator-mcp-daemon` | Owns worker subprocesses, active run handles, timeouts, cancellation, follow-up session reuse, and the durable run store. | Long-lived. Auto-started by the MCP server or controlled manually. |
 
 The guarantee is deliberately scoped:
@@ -172,10 +175,10 @@ Default location:
 
 ```text
 ~/.agent-orchestrator/
-  daemon.sock
   daemon.log
   daemon.pid
   config.json
+  daemon.sock        (POSIX only)
   runs/
     <run-id>/
       meta.json
@@ -193,12 +196,13 @@ AGENT_ORCHESTRATOR_HOME=/path/to/store
 
 Security behavior:
 
-- The root directory is created as `0700`.
-- If the root directory exists and is owned by another UID, startup aborts.
-- If the root directory is owned by the current UID but has broader permissions, startup coerces it to `0700`.
-- `daemon.sock` is bound under a restrictive umask so the socket file is `0600`.
-- `daemon.pid` is written as `0600`.
-- A stale socket is unlinked only when it is owned by the current UID.
+- The root directory is created with user-only permissions where the platform supports POSIX modes.
+- On POSIX, if the root directory exists and is owned by another UID, startup aborts.
+- On POSIX, if the root directory is owned by the current UID but has broader permissions, startup coerces it to `0700`.
+- On POSIX, `daemon.sock` is bound under a restrictive umask so the socket file is `0600`.
+- On Windows, the daemon listens on a named pipe derived from the run-store path; there is no socket file to remove.
+- `daemon.pid` is written with `0600` mode where supported.
+- A stale POSIX socket is unlinked only when it is owned by the current UID.
 
 Secrets and CLI credentials are not stored by the MCP package. Worker authentication comes from the host CLI's normal auth state or from environment variables already present when the MCP server/daemon starts. Do not pass API keys as MCP tool arguments; those requests can be logged by clients.
 
@@ -243,18 +247,25 @@ Most worker preparation failures are run failures rather than envelope failures.
 
 ## Operational Notes
 
-This package is for trusted local MCP clients. Worker processes run with the current user's OS privileges, inherit the daemon environment, and can use whatever credentials the host Codex or Claude CLI can access. Do not expose the daemon socket to untrusted users or pass secrets as MCP tool arguments.
+This package is for trusted local MCP clients. Worker processes run with the current user's OS privileges, inherit the daemon environment, and can use whatever credentials the host Codex or Claude CLI can access. Do not expose the daemon IPC endpoint to untrusted users or pass secrets as MCP tool arguments.
 
 Concurrent runs against the same `cwd` are the supervisor's responsibility. The orchestrator does not create worktrees, isolate file systems, or lock a working directory. If two workers edit the same files, they can conflict.
 
 If a daemon restart marks a run `orphaned`, the previous worker process may still be consuming CPU or API tokens. Inspect `~/.agent-orchestrator/daemon.log` and the run result for the previous daemon PID and worker PID, then clean up manually if needed.
 
-Prefer killing the process group when you know the PGID:
+On POSIX, prefer killing the process group when you know the PGID:
 
 ```bash
 kill -TERM -<worker-pgid>
 sleep 5
 kill -KILL -<worker-pgid>
+```
+
+On Windows, use the worker PID from the run result:
+
+```powershell
+taskkill /PID <worker-pid> /T
+taskkill /PID <worker-pid> /T /F
 ```
 
 ## Development

--- a/docs/development/mcp-tooling.md
+++ b/docs/development/mcp-tooling.md
@@ -137,7 +137,8 @@ This lets agents use the orchestrator while developing the orchestrator. Run
 daemon is already running, restart it too so it picks up the new `dist/` code.
 
 `dist/cli.js` starts the stdio MCP server and auto-starts the daemon if the
-daemon socket is not already responding. For manual lifecycle checks, use:
+local daemon IPC endpoint is not already responding. The endpoint is a Unix
+socket on POSIX and a named pipe on Windows. For manual lifecycle checks, use:
 
 ```bash
 just orchestrator-doctor

--- a/plans/2-add-windows-support/plan.md
+++ b/plans/2-add-windows-support/plan.md
@@ -1,0 +1,10 @@
+# Plan Index
+
+Branch: `2-add-windows-support`
+Updated: 2026-05-02
+
+## Sub-Plans
+
+| Plan | Scope | Status | File |
+|---|---|---|---|
+| Add Windows Support | Native Windows daemon IPC, lifecycle, diagnostics, tests, and docs for issue #2 | implemented-verification-blocked | `plans/2-add-windows-support/plans/2-add-windows-support.md` |

--- a/plans/2-add-windows-support/plans/2-add-windows-support.md
+++ b/plans/2-add-windows-support/plans/2-add-windows-support.md
@@ -1,0 +1,179 @@
+# Add Windows Support
+
+Branch: `2-add-windows-support`
+Plan Slug: `add-windows-support`
+Parent Issue: #2
+Created: 2026-05-02
+Status: implemented-verification-blocked
+
+## Context
+
+Issue #2 is open with the title "Add windows support" and no issue body or
+comments. The current branch name matches the issue scope.
+
+Context sources read:
+
+- `AGENTS.md`: use `pnpm` scripts, keep public behavior stable, add focused
+  tests for daemon lifecycle, run-store persistence, backend invocation, MCP
+  contracts, and release behavior when those areas change.
+- `.agents/rules/node-typescript.md`: keep Node.js 22 compatibility, use
+  existing scripts, prefer Node built-ins, update schemas/docs/tests for MCP
+  contract changes.
+- `.agents/rules/ai-workspace-projections.md`: relevant only if `.agents/`
+  files change; no projection edits are planned.
+- `.agents/rules/mcp-tool-configs.md`: relevant only if MCP config files or
+  secret-bearing scripts change; no config or secret behavior changes are
+  planned.
+- `package.json`: affected commands are `pnpm build`, `pnpm test`, and likely
+  `pnpm verify` before release-quality completion.
+- `README.md`: currently documents POSIX-only support, Unix sockets, POSIX
+  process groups, `daemon.sock`, and POSIX cleanup commands.
+- `docs/development/mcp-tooling.md`: documents local dogfood daemon usage and
+  MCP guardrails.
+- `src/daemon/paths.ts`: daemon paths currently include `daemon.sock`,
+  `daemon.pid`, and `daemon.log` under `AGENT_ORCHESTRATOR_HOME`.
+- `src/daemon/daemonMain.ts`: exits immediately on `win32`, cleans stale Unix
+  socket files with ownership checks, binds the socket under restrictive umask,
+  and cleans pid/socket files on exit.
+- `src/daemon/daemonCli.ts` and `src/server.ts`: auto-start and manual daemon
+  lifecycle both connect through `paths.socket`.
+- `src/ipc/client.ts`, `src/ipc/server.ts`, and `src/ipc/protocol.ts`: IPC is
+  framed JSON-RPC over `node:net`, but endpoint handling is a raw path string.
+- `src/processManager.ts`: worker spawning uses `detached: true`; cancellation
+  sends signals to negative POSIX process-group IDs.
+- `src/diagnostics.ts` and `src/contract.ts`: diagnostics expose
+  `posix_supported` and currently mark every backend unsupported on Windows.
+- `src/runStore.ts`: store root and pid/lock files use Node path APIs and
+  mostly need best-effort Windows permission behavior, not a redesign.
+- `src/backend/codex.ts`, `src/backend/claude.ts`, `src/backend/common.ts`:
+  backend invocation already avoids shells and uses `path.delimiter`; no major
+  Windows-specific invocation changes are expected.
+- Tests read: `src/__tests__/ipc.test.ts`, `src/__tests__/diagnostics.test.ts`,
+  `src/__tests__/processManager.test.ts`,
+  `src/__tests__/integration/orchestrator.test.ts`,
+  `src/__tests__/backendInvocation.test.ts`.
+
+No existing `plans/` directory was present before this plan.
+
+## Decisions
+
+| # | Decision | Choice | Rationale | Rejected Alternatives |
+|---|---|---|---|---|
+| 1 | Windows target | Add native Windows support for the daemon and stdio MCP server. | Issue #2 asks for Windows support, and the repo already has a Windows-aware `scripts/run-npx-mcp.mjs`, so treating WSL as the answer would leave the package behavior unchanged. | Document WSL-only support; keep daemon POSIX-only. |
+| 2 | IPC transport | Keep the framed JSON-RPC protocol and `node:net`, but introduce an endpoint abstraction that returns a Unix socket path on POSIX and a Windows named pipe path on `win32`. | This preserves the existing protocol and isolates platform differences to endpoint/path handling. Node supports named pipes through the same `net.Server.listen()` and `net.connect()` APIs. | Replace IPC with TCP localhost; add an HTTP server; special-case Windows throughout callers. |
+| 3 | Named pipe identity | Derive a stable per-store named pipe from `AGENT_ORCHESTRATOR_HOME`/store root, for example by hashing the resolved store root into a `\\\\.\\pipe\\agent-orchestrator-mcp-<hash>` name. | The current Unix socket is scoped to the store root. A hashed pipe keeps parallel stores isolated without exposing long or invalid Windows path text in the pipe name. | Use one global pipe for all stores; place the pipe under the home directory; require a user-configured pipe path. |
+| 4 | Stale endpoint cleanup | Keep Unix socket ownership cleanup on POSIX; make Windows endpoint cleanup a no-op and rely on named pipes disappearing when the server closes. | Windows named pipes are not filesystem entries, so `lstat`, `rm`, and ownership checks do not apply. A live pipe conflict should surface as daemon already running or bind failure. | Try to delete named pipe paths as files; remove stale socket ownership checks for POSIX. |
+| 5 | Process tree cancellation | Add a platform-specific process terminator: POSIX continues killing `-pid`; Windows uses `taskkill /PID <pid> /T` and escalates with `/F` when needed. | The current negative PGID strategy is invalid on Windows. `taskkill` is the built-in way to terminate a process tree without adding dependencies. | Kill only the direct child; use a shell; add a dependency for job objects. |
+| 6 | Diagnostics compatibility | Keep `posix_supported` for backward compatibility, but stop using it as the backend availability gate. Add only additive diagnostics if needed, such as transport or platform support details. | Removing or repurposing an existing MCP field would be a public contract break. Windows support should make backends diagnosable instead of immediately unsupported. | Rename `posix_supported`; remove it; leave Windows backends unsupported. |
+| 7 | Store permissions | Preserve current `0700`/`0600` calls as best effort and document that Windows ACL enforcement is platform-native rather than POSIX mode exact. | Node accepts mode parameters on Windows but POSIX permission semantics do not fully apply. The store should remain usable and avoid claiming Unix-mode guarantees on Windows. | Build custom Windows ACL management; remove permission hardening everywhere. |
+| 8 | Test strategy | Add deterministic platform-unit coverage by injecting or isolating platform decisions where practical, plus keep POSIX integration tests unchanged. | CI may not have Windows runners yet, so tests should validate path/diagnostic/process-command decisions on Linux while allowing future Windows CI to run the same suite. | Require a Windows machine for every test; rely only on manual testing. |
+
+## Scope
+
+### In Scope
+
+- Remove the hard Windows daemon startup block.
+- Add cross-platform daemon IPC endpoint generation and use it from daemon,
+  daemon CLI, MCP server, IPC client, and IPC tests.
+- Support Windows named pipes while preserving Unix socket behavior and stale
+  Unix socket cleanup.
+- Add platform-specific worker process-tree cancellation and timeout handling.
+- Update diagnostics so Windows is supported at the daemon/platform layer and
+  backend checks run normally when `codex` or `claude` are present.
+- Update README and development docs from POSIX-only language to
+  cross-platform behavior with Windows caveats.
+- Add focused tests for endpoint selection, diagnostics, IPC behavior, and
+  process cancellation command selection.
+
+### Out Of Scope
+
+- Installing Codex, Claude, Node, Git, or other host prerequisites.
+- Adding new runtime dependencies.
+- Changing MCP tool request or response envelopes beyond compatible additive
+  diagnostics.
+- Adding TCP or remote daemon access.
+- Implementing Windows service registration or background startup at login.
+- Changing MCP config secret handling.
+- Publishing, tagging, or changing package release automation.
+
+## Risks And Edge Cases
+
+| # | Scenario | Mitigation | Covered By |
+|---|---|---|---|
+| 1 | Named pipe path collides across store roots or users. | Hash the normalized store root into the pipe name and include a stable package prefix. | Endpoint unit tests. |
+| 2 | Existing Unix socket cleanup logic runs on Windows and fails. | Gate cleanup by endpoint transport; no filesystem cleanup for named pipes. | Daemon endpoint tests and IPC tests. |
+| 3 | Windows cancellation kills only the worker CLI and leaves grandchildren running. | Use `taskkill /T` for the tree and `/F` on escalation. | Process terminator tests; manual Windows lifecycle smoke. |
+| 4 | POSIX cancellation regresses while adding Windows support. | Keep the existing negative-PGID path and current integration test for grandchild cleanup. | Existing integration test plus process-manager tests. |
+| 5 | Diagnostics still report every backend as unsupported on Windows. | Decouple backend support checks from `posix_supported`; add tests for simulated `win32` decisions. | Diagnostics tests. |
+| 6 | Documentation overstates Windows permission guarantees. | Document store files as user-local and mode hardening as POSIX-specific where needed. | Docs review. |
+| 7 | Tests bake in `/tmp` paths or POSIX commands and fail on Windows CI. | Replace hard-coded `/tmp` and `mkdir -p`/`sleep` in touched tests with Node helpers or platform skips where process-group behavior is POSIX-only. | Test updates and future Windows CI. |
+| 8 | Backward compatibility breaks existing clients reading `posix_supported`. | Keep the field and avoid changing its type or removing it. | Contract tests. |
+
+## Implementation Tasks
+
+| Task ID | Title | Depends On | Status | Acceptance Criteria |
+|---|---|---|---|---|
+| T1 | Add daemon IPC endpoint abstraction | none | implemented | A module exposes endpoint transport/name/path data; POSIX endpoint remains `<store>/daemon.sock`; Windows endpoint is a stable named pipe derived from the store root; unit tests cover both platform branches without requiring Windows. |
+| T2 | Wire endpoint abstraction through daemon, CLI, server, and IPC tests | T1 | implemented | `daemonPaths()` or equivalent callers use the new endpoint; `IpcClient` and `IpcServer` still receive a `net` endpoint string; Unix stale socket cleanup only runs for socket-file endpoints; existing IPC tests pass on POSIX. |
+| T3 | Enable Windows daemon startup and lifecycle | T2 | implemented | `daemonMain` no longer exits on `win32`; pid/log/store setup still works; manual daemon CLI start/status/stop paths use the named pipe on Windows and the socket on POSIX; tests cover Windows cleanup no-op behavior where possible. |
+| T4 | Add platform-specific process-tree termination | none | implemented | `ProcessManager.cancel()` uses existing negative PGID behavior on POSIX and a Windows terminator using `taskkill /PID <pid> /T` plus forced escalation; timeout and cancellation final statuses remain unchanged; tests validate both command paths without killing real Windows processes on POSIX. |
+| T5 | Update diagnostics and contract tests | T1, T3 | implemented | `getBackendStatus()` no longer marks all Windows backends unsupported solely because `process.platform === 'win32'`; `posix_supported` remains present; any additive diagnostics fields are added to `contract.ts`, tests, README, and formatting output. |
+| T6 | Harden tests for cross-platform execution | T1, T2, T4, T5 | implemented | Touched tests avoid hard-coded `/tmp` daemon paths and POSIX shell commands where a Node alternative exists; POSIX-specific grandchild-kill assertions are retained or explicitly skipped only on Windows; `pnpm test` passes on the local platform. |
+| T7 | Update user and development docs | T1, T3, T4, T5 | implemented | README prerequisites, architecture, run-store layout, security behavior, diagnostics, daemon lifecycle, and cleanup guidance describe Unix sockets on POSIX and named pipes on Windows; development MCP docs remain accurate. |
+| T8 | Run focused and release-quality verification | T2, T3, T4, T5, T6, T7 | blocked | `pnpm build` passes; `pnpm test` passes; `pnpm verify` is run before claiming release readiness, or any failure is recorded with concrete output and follow-up. |
+
+## Rule Candidates
+
+| # | Candidate | Scope | Create After |
+|---|---|---|---|
+| 1 | Cross-platform daemon changes must isolate platform decisions behind small helpers and cover both branches with tests. | Future daemon/process lifecycle work. | After implementation, only if the pattern proves reusable across multiple files. |
+
+## Quality Gates
+
+- [ ] Affected build command passes: `pnpm build` blocked because `node_modules` is absent and `tsc` is not installed locally.
+- [ ] Affected tests pass: `pnpm test` returned exit 0 but discovered 0 tests because `dist/` is absent; not accepted as meaningful verification.
+- [ ] Release-quality check considered or run: `pnpm verify` blocked at `pnpm build` for missing `tsc`.
+- [x] Dependency-free diff check passes: `git diff --check`.
+- [x] Relevant `.agents/rules/` checks are satisfied for source/docs changes; no installs, commits, secrets, hooks, or external writes were performed.
+
+## Execution Log
+
+### T1: Add daemon IPC endpoint abstraction
+- **Status:** implemented
+- **Evidence:** Added `DaemonIpcEndpoint`/`daemonIpcEndpoint()` in `src/daemon/paths.ts`; added `src/__tests__/daemonPaths.test.ts` for POSIX socket and Windows named-pipe branches.
+- **Notes:** Verification blocked until dependencies are installed.
+
+### T2: Wire endpoint abstraction through daemon, CLI, server, and IPC tests
+- **Status:** implemented
+- **Evidence:** Replaced daemon, daemon CLI, MCP server, and IPC tests with `paths.ipc.path`; POSIX cleanup now uses `paths.ipc.cleanupPath` and no-ops for Windows named pipes.
+- **Notes:** Verification blocked until dependencies are installed.
+
+### T3: Enable Windows daemon startup and lifecycle
+- **Status:** implemented
+- **Evidence:** Removed the `win32` daemon startup exit in `src/daemon/daemonMain.ts`; made daemon listen with umask only for Unix sockets; `ensureSecureRoot()` now skips POSIX UID/mode checks on Windows.
+- **Notes:** Verification blocked until dependencies are installed.
+
+### T4: Add platform-specific process-tree termination
+- **Status:** implemented
+- **Evidence:** Added `terminateProcessTree()` and `prepareWorkerSpawn()` in `src/processManager.ts`; POSIX sends `SIGTERM`/`SIGKILL` to `-pid`, Windows uses `taskkill /PID <pid> /T` with `/F` on escalation; tests cover both branches.
+- **Notes:** Also added explicit `.cmd`/`.bat` wrapping through the Windows command processor for resolved worker CLI shims.
+
+### T5: Update diagnostics and contract tests
+- **Status:** implemented
+- **Evidence:** `getBackendStatus()` now accepts an optional platform for deterministic tests and no longer gates backend diagnostics on `posix_supported`; diagnostics command execution uses `prepareWorkerSpawn()` so `.cmd` shims can run on Windows.
+- **Notes:** No contract schema change was needed; `posix_supported` remains present.
+
+### T6: Harden tests for cross-platform execution
+- **Status:** implemented
+- **Evidence:** IPC tests use `daemonIpcEndpoint()`; diagnostics/integration/git tests use `path.delimiter`; integration mocks avoid `mkdir -p`, `/tmp` PATH sentinels, and `sleep`; Windows mock CLI shims are generated as `.cmd` wrappers.
+- **Notes:** Symlink fingerprint test is skipped on Windows because Windows symlink creation can require privileges.
+
+### T7: Update user and development docs
+- **Status:** implemented
+- **Evidence:** Updated `README.md` and `docs/development/mcp-tooling.md` to describe POSIX Unix sockets, Windows named pipes, Windows `taskkill`, and POSIX-specific permission/socket cleanup behavior.
+- **Notes:** No MCP config or secret docs changed.
+
+### T8: Run focused and release-quality verification
+- **Status:** blocked
+- **Evidence:** `git diff --check` passed. `pnpm build` failed with `sh: 1: tsc: not found` and the pnpm warning that `node_modules` is missing. `pnpm test` returned exit 0 but found 0 tests because `dist/` is absent. `pnpm verify` failed at `pnpm build` with the same missing `tsc` error.
+- **Notes:** Repository rules require explicit permission before installing packages; `pnpm install --frozen-lockfile` was not run.

--- a/plans/2-add-windows-support/plans/2-add-windows-support.md
+++ b/plans/2-add-windows-support/plans/2-add-windows-support.md
@@ -133,6 +133,7 @@ No existing `plans/` directory was present before this plan.
 - [ ] Affected build command passes: `pnpm build` blocked because `node_modules` is absent and `tsc` is not installed locally.
 - [ ] Affected tests pass: `pnpm test` returned exit 0 but discovered 0 tests because `dist/` is absent; not accepted as meaningful verification.
 - [ ] Release-quality check considered or run: `pnpm verify` blocked at `pnpm build` for missing `tsc`.
+- [ ] Native Windows IPC round-trip smoke: Windows-only test added; local execution remains pending until a Windows runtime or Windows CI runner is available.
 - [x] Dependency-free diff check passes: `git diff --check`.
 - [x] Relevant `.agents/rules/` checks are satisfied for source/docs changes; no installs, commits, secrets, hooks, or external writes were performed.
 
@@ -175,5 +176,5 @@ No existing `plans/` directory was present before this plan.
 
 ### T8: Run focused and release-quality verification
 - **Status:** blocked
-- **Evidence:** `git diff --check` passed. `pnpm build` failed with `sh: 1: tsc: not found` and the pnpm warning that `node_modules` is missing. `pnpm test` returned exit 0 but found 0 tests because `dist/` is absent. `pnpm verify` failed at `pnpm build` with the same missing `tsc` error.
+- **Evidence:** `git diff --check` passed. `pnpm build` failed with `sh: 1: tsc: not found` and the pnpm warning that `node_modules` is missing. `pnpm test` returned exit 0 but found 0 tests because `dist/` is absent. `pnpm verify` failed at `pnpm build` with the same missing `tsc` error. Native Windows IPC round-trip smoke has been added as a Windows-only test but remains unexecuted locally until a Windows runtime or Windows CI runner is available.
 - **Notes:** Repository rules require explicit permission before installing packages; `pnpm install --frozen-lockfile` was not run.

--- a/plans/2-add-windows-support/resolution-map.md
+++ b/plans/2-add-windows-support/resolution-map.md
@@ -1,0 +1,83 @@
+# PR #9 Resolution Map
+
+Branch: `2-add-windows-support`
+Created: 2026-05-02
+Total comments: 5 | Fixed: 5 | Deferred: 0 | Declined: 0 | Escalated: 0
+
+## Comment 1 | fixed | minor
+
+- **Comment Type:** review-inline
+- **File:** `src/daemon/daemonMain.ts:91`
+- **Comment ID:** `3176229115`
+- **Thread Node ID:** unavailable from MCP response
+- **Author:** `coderabbitai`
+- **Comment:** Treat endpoint-disappeared races as already cleaned up. The async startup cleanup checks existence before `lstat()`, so a concurrent removal can fail startup even though the endpoint is gone.
+- **Independent Assessment:** Valid. `existsSync()` followed by async `lstat()` has a time-of-check/time-of-use race. `ENOENT` during `lstat()` or removal should be a successful no-op for stale endpoint cleanup.
+- **Decision:** fix-as-suggested
+- **Approach:** Remove the pre-`lstat()` existence check in `cleanupIpcEndpoint()`. Catch `ENOENT` from `lstat()` and `rm()` as no-op while preserving all other errors and the UID ownership guard.
+- **Files To Change:** `src/daemon/daemonMain.ts`
+- **Reply Draft:**
+  > **[AI Agent]:** Fixed. Startup cleanup now treats `ENOENT` from the stale IPC endpoint check/removal as already cleaned up while preserving the ownership guard for existing endpoints.
+
+## Comment 2 | fixed | major
+
+- **Comment Type:** review-body
+- **File:** `src/daemon/daemonMain.ts:101`, `src/daemon/daemonMain.ts:117`
+- **Comment ID:** review body `4214547907`
+- **Author:** `coderabbitai[bot]`
+- **Comment:** Preserve the ownership guard during shutdown cleanup. The fatal and exit cleanup paths remove `paths.ipc.cleanupPath` without the UID check used by startup cleanup.
+- **Independent Assessment:** Valid. If startup refuses a foreign-owned stale socket, fatal cleanup should not bypass that refusal by removing the same endpoint without ownership validation.
+- **Decision:** alternative-fix
+- **Approach:** Reuse `cleanupIpcEndpoint()` from async shutdown cleanup so the same UID guard and `ENOENT` handling apply. Add a sync helper for the `exit` handler that performs `lstatSync()`, UID validation, and `unlinkSync()` with `ENOENT` treated as no-op.
+- **Files To Change:** `src/daemon/daemonMain.ts`
+- **Reply Draft:**
+  > **[AI Agent]:** Fixed. Shutdown cleanup now goes through the guarded async cleanup path, and the synchronous `exit` cleanup has its own UID-checked unlink helper.
+
+## Comment 3 | fixed | minor
+
+- **Comment Type:** review-body
+- **File:** `src/__tests__/gitSnapshot.test.ts:76`
+- **Comment ID:** review body `4214547907`
+- **Author:** `coderabbitai[bot]`
+- **Comment:** Split the Windows skip so the large-file path stays covered. The test skip disables large-file fingerprint coverage on Windows even though only symlink setup is platform-specific.
+- **Independent Assessment:** Valid. Large-file fingerprinting is cross-platform and should not be skipped because the symlink assertion may require privileges on Windows.
+- **Decision:** fix-as-suggested
+- **Approach:** Split the combined large-file/symlink test into two tests. Keep the large-file `file-meta:` coverage unskipped and retain the Windows skip only for the symlink-specific test.
+- **Files To Change:** `src/__tests__/gitSnapshot.test.ts`
+- **Reply Draft:**
+  > **[AI Agent]:** Fixed. Large-file fingerprint coverage now runs independently, and only the symlink-specific test is skipped on Windows.
+
+## Comment 4 | fixed | major
+
+- **Comment Type:** review-body
+- **File:** `src/__tests__/diagnostics.test.ts:50`
+- **Comment ID:** review body `4214547907`
+- **Author:** `coderabbitai[bot]`
+- **Comment:** Add one Windows case that executes real mock CLIs. The current Windows diagnostics test covers only missing binaries and not the `.cmd` execution path.
+- **Independent Assessment:** Valid, with a nuance. On a POSIX host, a Windows `.cmd` cannot execute through real `cmd.exe`, but the production path can still be tested deterministically by injecting `platform: 'win32'`, using `PATHEXT`, and setting `ComSpec` to a mock command processor.
+- **Decision:** alternative-fix
+- **Approach:** Add a diagnostics test that writes Windows-style `.cmd` backend shims, sets `PATHEXT`, points `ComSpec` at a mock command processor script, calls `getBackendStatus({ platform: 'win32' })`, and verifies the mock CLIs are executed successfully.
+- **Files To Change:** `src/__tests__/diagnostics.test.ts`
+- **Reply Draft:**
+  > **[AI Agent]:** Fixed. Diagnostics now has a Windows-platform test that resolves `.cmd` mock CLIs via `PATHEXT` and executes them through a mock command processor.
+
+## Comment 5 | fixed | major
+
+- **Comment Type:** review-body
+- **File:** `src/__tests__/ipc.test.ts:15`
+- **Comment ID:** review body `4214547907`
+- **Author:** `coderabbitai[bot]`
+- **Comment:** Add a native Windows IPC round-trip smoke. Linux/macOS CI only covers the named-pipe path shape, not a real Windows `IpcServer`/`IpcClient` exchange.
+- **Independent Assessment:** Valid as a coverage gap. Node named-pipe IPC requires a Windows runtime; simulating the string shape on Linux would not verify the transport contract, but a Windows-only smoke test can be added for Windows CI/developer runs.
+- **Decision:** alternative-fix
+- **Approach:** Add a native Windows-only `IpcServer`/`IpcClient` round-trip test that constructs `daemonIpcEndpoint(root, 'win32')` and runs only when `process.platform === 'win32'`. Keep local Linux verification honest by documenting that this smoke is added but not executed in this workspace.
+- **Files To Change:** `src/__tests__/ipc.test.ts`, `plans/2-add-windows-support/plans/2-add-windows-support.md`
+- **Reply Draft:**
+  > **[AI Agent]:** Fixed. Added a Windows-only IPC round-trip smoke that exercises the real named-pipe endpoint on native Windows runners; it is skipped on non-Windows hosts.
+
+## Verification
+
+- `git diff --check`: pass
+- Conflict marker scan across `src` and `plans/2-add-windows-support`: pass
+- Native Windows IPC smoke: added as a Windows-only test; not executed in this Linux workspace
+- `pnpm build`: blocked because `node_modules` is absent and `tsc` is not installed locally (`sh: 1: tsc: not found`)

--- a/plans/2-add-windows-support/resolution-map.md
+++ b/plans/2-add-windows-support/resolution-map.md
@@ -93,6 +93,7 @@ Total comments: 6 | Fixed: 6 | Deferred: 0 | Declined: 0 | Escalated: 0
 
 - `git diff --check`: pass
 - CI failure in workflow run `25246936259`: diagnosed as the simulated Windows diagnostics test writing lowercase `.cmd` shims while using uppercase `.CMD` in `PATHEXT` on case-sensitive Linux runners; fixed by aligning the simulated extension with the generated shim names.
+- CI failure in workflow run `25247757711`: diagnosed as the mock command processor using `#!/usr/bin/env node` after the test replaced `PATH` with only the simulated Windows bin directory; fixed by using the absolute `process.execPath` shebang in that helper.
 - Conflict marker scan across `src` and `plans/2-add-windows-support`: pass
 - Native Windows IPC smoke: added as a Windows-only test; not executed in this Linux workspace
 - `pnpm build` / `pnpm test`: not rerun locally because `node_modules` is absent and repository instructions require explicit approval before installing packages.

--- a/plans/2-add-windows-support/resolution-map.md
+++ b/plans/2-add-windows-support/resolution-map.md
@@ -2,7 +2,7 @@
 
 Branch: `2-add-windows-support`
 Created: 2026-05-02
-Total comments: 5 | Fixed: 5 | Deferred: 0 | Declined: 0 | Escalated: 0
+Total comments: 6 | Fixed: 6 | Deferred: 0 | Declined: 0 | Escalated: 0
 
 ## Comment 1 | fixed | minor
 
@@ -75,9 +75,24 @@ Total comments: 5 | Fixed: 5 | Deferred: 0 | Declined: 0 | Escalated: 0
 - **Reply Draft:**
   > **[AI Agent]:** Fixed. Added a Windows-only IPC round-trip smoke that exercises the real named-pipe endpoint on native Windows runners; it is skipped on non-Windows hosts.
 
+## Comment 6 | fixed | minor
+
+- **Comment Type:** review-body
+- **File:** `src/__tests__/diagnostics.test.ts:35`
+- **Comment ID:** review body `4214688540`
+- **Author:** `coderabbitai[bot]`
+- **Comment:** Restore `PATH` with `restoreEnv()` too, otherwise an originally unset `PATH` is restored as the string `undefined`.
+- **Independent Assessment:** Valid. `process.env` assignments stringify `undefined`, so the existing direct assignment does not faithfully restore an originally unset environment variable.
+- **Decision:** fix-as-suggested
+- **Approach:** Use `restoreEnv('PATH', originalPath)` in diagnostics test cleanup, matching the other environment variables in the same `afterEach`.
+- **Files To Change:** `src/__tests__/diagnostics.test.ts`
+- **Reply Draft:**
+  > **[AI Agent]:** Fixed. Diagnostics test cleanup now restores `PATH` through the shared `restoreEnv()` helper.
+
 ## Verification
 
 - `git diff --check`: pass
+- CI failure in workflow run `25246936259`: diagnosed as the simulated Windows diagnostics test writing lowercase `.cmd` shims while using uppercase `.CMD` in `PATHEXT` on case-sensitive Linux runners; fixed by aligning the simulated extension with the generated shim names.
 - Conflict marker scan across `src` and `plans/2-add-windows-support`: pass
 - Native Windows IPC smoke: added as a Windows-only test; not executed in this Linux workspace
-- `pnpm build`: blocked because `node_modules` is absent and `tsc` is not installed locally (`sh: 1: tsc: not found`)
+- `pnpm build` / `pnpm test`: not rerun locally because `node_modules` is absent and repository instructions require explicit approval before installing packages.

--- a/plans/2-add-windows-support/reviews/review-2026-05-02.md
+++ b/plans/2-add-windows-support/reviews/review-2026-05-02.md
@@ -1,0 +1,32 @@
+# Review: Add Windows Support Uncommitted Diff
+
+Branch: `2-add-windows-support`
+Date: 2026-05-02
+Scope: `git diff HEAD` plus untracked plan/test files reported by `git status --short`
+
+## Findings
+
+No blocking correctness findings were identified in the uncommitted diff.
+
+## Residual Risk
+
+- Build and meaningful test verification remain blocked because `node_modules`
+  is absent and `tsc` is unavailable locally. `pnpm build` fails with
+  `sh: 1: tsc: not found`.
+- `pnpm test` returned exit 0 but discovered 0 tests because `dist/` is absent,
+  so it is not meaningful evidence for this TypeScript diff.
+- The diff has deterministic unit coverage for Windows branch decisions, but no
+  native Windows runtime smoke has been run in this workspace.
+
+## Context Read
+
+- `AGENTS.md`
+- `.agents/rules/node-typescript.md`
+- `plans/2-add-windows-support/plans/2-add-windows-support.md`
+- Changed source, test, README, and development-docs diffs
+
+## Checks
+
+- `git diff --check`: pass
+- Broad build/test not rerun during review per review-skill guidance; prior
+  implementation evidence records the missing-dependency blocker.

--- a/src/__tests__/backendInvocation.test.ts
+++ b/src/__tests__/backendInvocation.test.ts
@@ -1,9 +1,28 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
+import { chmod, mkdir, mkdtemp, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
 import { ClaudeBackend } from '../backend/claude.js';
 import { CodexBackend } from '../backend/codex.js';
+import { resolveBinary } from '../backend/common.js';
 
 describe('backend invocations', () => {
+  it('resolves Windows PATHEXT command shims from PATH', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'agent-backend-bin-'));
+    const missing = join(root, 'missing');
+    const bin = join(root, 'bin');
+    const command = join(bin, 'codex.CMD');
+    await mkdir(bin);
+    await writeFile(command, '@echo off\r\n');
+    await chmod(command, 0o755);
+
+    assert.equal(
+      await resolveBinary('codex', 'win32', { PATH: `${missing};${bin}`, PATHEXT: '.EXE;.CMD' }),
+      command,
+    );
+  });
+
   it('passes model selection to Codex start and resume', async () => {
     const backend = new CodexBackend();
 

--- a/src/__tests__/daemonPaths.test.ts
+++ b/src/__tests__/daemonPaths.test.ts
@@ -1,0 +1,30 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { join } from 'node:path';
+import { daemonIpcEndpoint } from '../daemon/paths.js';
+
+describe('daemon IPC endpoint paths', () => {
+  it('uses the store-local daemon socket on POSIX platforms', () => {
+    const home = '/tmp/agent-orchestrator-home';
+
+    const endpoint = daemonIpcEndpoint(home, 'linux');
+
+    assert.deepStrictEqual(endpoint, {
+      transport: 'unix_socket',
+      path: join(home, 'daemon.sock'),
+      cleanupPath: join(home, 'daemon.sock'),
+    });
+  });
+
+  it('uses a stable named pipe derived from the store root on Windows', () => {
+    const first = daemonIpcEndpoint('C:\\Users\\agent\\.agent-orchestrator', 'win32');
+    const second = daemonIpcEndpoint('C:/Users/agent/.agent-orchestrator', 'win32');
+    const other = daemonIpcEndpoint('C:\\Users\\agent\\other-store', 'win32');
+
+    assert.equal(first.transport, 'windows_pipe');
+    assert.match(first.path, /^\\\\\.\\pipe\\agent-orchestrator-mcp-[a-f0-9]{16}$/);
+    assert.equal(first.cleanupPath, null);
+    assert.equal(second.path, first.path);
+    assert.notEqual(other.path, first.path);
+  });
+});

--- a/src/__tests__/diagnostics.test.ts
+++ b/src/__tests__/diagnostics.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, beforeEach, afterEach } from 'node:test';
 import assert from 'node:assert/strict';
 import { chmod, mkdir, mkdtemp, writeFile } from 'node:fs/promises';
-import { join } from 'node:path';
+import { delimiter, join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { getBackendStatus } from '../diagnostics.js';
 import { createBackendRegistry } from '../backend/registry.js';
@@ -32,13 +32,26 @@ describe('backend diagnostics', () => {
   });
 
   it('reports missing backend binaries without failing the whole report', async () => {
-    process.env.PATH = '/tmp/agent-orchestrator-no-diagnostics-binaries';
+    const root = await mkdtemp(join(tmpdir(), 'agent-diag-missing-'));
+    process.env.PATH = join(root, 'missing-bin');
 
     const report = await getBackendStatus();
 
     assert.equal(report.posix_supported, true);
     assert.deepStrictEqual(report.backends.map((backend) => backend.status), ['missing', 'missing']);
     assert.ok(report.backends.every((backend) => backend.hints.length > 0));
+  });
+
+  it('runs backend diagnostics on Windows instead of marking everything unsupported', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'agent-diag-win-missing-'));
+    process.env.PATH = join(root, 'missing-bin');
+
+    const report = await getBackendStatus('win32');
+
+    assert.equal(report.platform, 'win32');
+    assert.equal(report.posix_supported, false);
+    assert.deepStrictEqual(report.backends.map((backend) => backend.status), ['missing', 'missing']);
+    assert.ok(report.backends.every((backend) => backend.checks.some((check) => check.name.includes('binary on PATH'))));
   });
 
   it('reports auth_unknown when binaries and required flags exist but auth cannot be proven locally', async () => {
@@ -52,7 +65,7 @@ describe('backend diagnostics', () => {
       ['--version', 'claude 2.3.4'],
       ['--help', 'Usage: claude -p --output-format stream-json --resume --model <session>'],
     ]);
-    process.env.PATH = `${bin}:${originalPath}`;
+    process.env.PATH = prependPath(bin, originalPath);
 
     const report = await getBackendStatus();
 
@@ -72,7 +85,7 @@ describe('backend diagnostics', () => {
       ['--version', 'claude 2.3.4'],
       ['--help', 'Usage: claude -p --output-format stream-json --resume --model <session>'],
     ]);
-    process.env.PATH = `${bin}:${originalPath}`;
+    process.env.PATH = prependPath(bin, originalPath);
     process.env.OPENAI_API_KEY = 'test-openai';
     process.env.ANTHROPIC_API_KEY = 'test-anthropic';
 
@@ -95,7 +108,7 @@ describe('backend diagnostics', () => {
       ['--version', 'claude 2.3.4'],
       ['--help', 'Usage: claude -p --output-format stream-json --resume --model <session>'],
     ]);
-    process.env.PATH = `${bin}:${originalPath}`;
+    process.env.PATH = prependPath(bin, originalPath);
 
     const service = new OrchestratorService(new RunStore(join(root, 'home')), createBackendRegistry());
     await service.initialize();
@@ -116,7 +129,7 @@ describe('backend diagnostics', () => {
       ['--version', 'claude 1.0.0'],
       ['--help', 'Usage: claude -p --output-format stream-json --resume <session>'],
     ]);
-    process.env.PATH = `${bin}:${originalPath}`;
+    process.env.PATH = prependPath(bin, originalPath);
 
     const report = await getBackendStatus();
 
@@ -126,17 +139,26 @@ describe('backend diagnostics', () => {
 });
 
 async function writeMockCli(bin: string, name: string, responses: [string, string][]): Promise<void> {
-  const script = join(bin, name);
   const cases = responses
     .map(([args, output]) => `if (key === ${JSON.stringify(args)}) { console.log(${JSON.stringify(output)}); process.exit(0); }`)
     .join('\n');
-  await writeFile(script, `#!/usr/bin/env node
+  const script = `#!/usr/bin/env node
 const key = process.argv.slice(2).join(' ');
 ${cases}
 console.error('unexpected args: ' + key);
 process.exit(1);
-`);
-  await chmod(script, 0o755);
+`;
+
+  if (process.platform === 'win32') {
+    const scriptPath = join(bin, `${name}.js`);
+    await writeFile(scriptPath, script);
+    await writeFile(join(bin, `${name}.cmd`), `@echo off\r\n"${process.execPath}" "%~dp0\\${name}.js" %*\r\n`);
+    return;
+  }
+
+  const scriptPath = join(bin, name);
+  await writeFile(scriptPath, script);
+  await chmod(scriptPath, 0o755);
 }
 
 function restoreEnv(name: string, value: string | undefined): void {
@@ -145,4 +167,8 @@ function restoreEnv(name: string, value: string | undefined): void {
   } else {
     process.env[name] = value;
   }
+}
+
+function prependPath(entry: string, current: string | undefined): string {
+  return current ? `${entry}${delimiter}${current}` : entry;
 }

--- a/src/__tests__/diagnostics.test.ts
+++ b/src/__tests__/diagnostics.test.ts
@@ -32,7 +32,7 @@ describe('backend diagnostics', () => {
   });
 
   afterEach(() => {
-    process.env.PATH = originalPath;
+    restoreEnv('PATH', originalPath);
     restoreEnv('OPENAI_API_KEY', originalOpenAiKey);
     restoreEnv('CODEX_API_KEY', originalCodexKey);
     restoreEnv('ANTHROPIC_API_KEY', originalAnthropicKey);
@@ -82,7 +82,7 @@ describe('backend diagnostics', () => {
       ['--help', 'Usage: claude -p --output-format stream-json --resume --model <session>'],
     ]);
     process.env.PATH = bin;
-    process.env.PATHEXT = '.CMD';
+    process.env.PATHEXT = '.cmd';
     if (process.platform !== 'win32') {
       const commandProcessor = join(root, 'cmd-proxy.js');
       await writeWindowsCommandProcessor(commandProcessor);

--- a/src/__tests__/diagnostics.test.ts
+++ b/src/__tests__/diagnostics.test.ts
@@ -227,7 +227,7 @@ process.exit(1);
 }
 
 async function writeWindowsCommandProcessor(path: string): Promise<void> {
-  const script = `#!/usr/bin/env node
+  const script = `#!${process.execPath}
 const { basename } = require('node:path');
 
 const commandLine = process.argv.at(-1) || '';

--- a/src/__tests__/diagnostics.test.ts
+++ b/src/__tests__/diagnostics.test.ts
@@ -13,6 +13,9 @@ let originalPath = process.env.PATH;
 let originalOpenAiKey = process.env.OPENAI_API_KEY;
 let originalCodexKey = process.env.CODEX_API_KEY;
 let originalAnthropicKey = process.env.ANTHROPIC_API_KEY;
+let originalPathext = process.env.PATHEXT;
+let originalComSpec = process.env.ComSpec;
+let originalComspec = process.env.COMSPEC;
 
 describe('backend diagnostics', () => {
   beforeEach(() => {
@@ -20,6 +23,9 @@ describe('backend diagnostics', () => {
     originalOpenAiKey = process.env.OPENAI_API_KEY;
     originalCodexKey = process.env.CODEX_API_KEY;
     originalAnthropicKey = process.env.ANTHROPIC_API_KEY;
+    originalPathext = process.env.PATHEXT;
+    originalComSpec = process.env.ComSpec;
+    originalComspec = process.env.COMSPEC;
     delete process.env.OPENAI_API_KEY;
     delete process.env.CODEX_API_KEY;
     delete process.env.ANTHROPIC_API_KEY;
@@ -30,6 +36,9 @@ describe('backend diagnostics', () => {
     restoreEnv('OPENAI_API_KEY', originalOpenAiKey);
     restoreEnv('CODEX_API_KEY', originalCodexKey);
     restoreEnv('ANTHROPIC_API_KEY', originalAnthropicKey);
+    restoreEnv('PATHEXT', originalPathext);
+    restoreEnv('ComSpec', originalComSpec);
+    restoreEnv('COMSPEC', originalComspec);
   });
 
   it('reports missing backend binaries without failing the whole report', async () => {
@@ -57,6 +66,37 @@ describe('backend diagnostics', () => {
     assert.equal(report.posix_supported, false);
     assert.deepStrictEqual(report.backends.map((backend) => backend.status), ['missing', 'missing']);
     assert.ok(report.backends.every((backend) => backend.checks.some((check) => check.name.includes('binary on PATH'))));
+  });
+
+  it('executes Windows cmd backend shims through the command processor', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'agent-diag-win-bin-'));
+    const bin = join(root, 'bin');
+    await mkdir(bin);
+    await writeWindowsMockCli(bin, 'codex', [
+      ['--version', 'codex 1.2.3'],
+      ['exec --help', 'Usage: codex exec --json --cd --skip-git-repo-check --model -'],
+      ['exec resume --help', 'Usage: codex exec resume --json --skip-git-repo-check --model <session> -'],
+    ]);
+    await writeWindowsMockCli(bin, 'claude', [
+      ['--version', 'claude 2.3.4'],
+      ['--help', 'Usage: claude -p --output-format stream-json --resume --model <session>'],
+    ]);
+    process.env.PATH = bin;
+    process.env.PATHEXT = '.CMD';
+    if (process.platform !== 'win32') {
+      const commandProcessor = join(root, 'cmd-proxy.js');
+      await writeWindowsCommandProcessor(commandProcessor);
+      process.env.ComSpec = commandProcessor;
+      delete process.env.COMSPEC;
+    }
+
+    const report = await getBackendStatus({ platform: 'win32' });
+
+    assert.equal(report.platform, 'win32');
+    assert.equal(report.posix_supported, false);
+    assert.deepStrictEqual(report.backends.map((backend) => backend.status), ['auth_unknown', 'auth_unknown']);
+    assert.deepStrictEqual(report.backends.map((backend) => backend.version), ['codex 1.2.3', 'claude 2.3.4']);
+    assert.ok(report.backends.every((backend) => backend.checks.every((check) => check.ok)));
   });
 
   it('reports auth_unknown when binaries and required flags exist but auth cannot be proven locally', async () => {
@@ -168,6 +208,61 @@ process.exit(1);
   const scriptPath = join(bin, name);
   await writeFile(scriptPath, script);
   await chmod(scriptPath, 0o755);
+}
+
+async function writeWindowsMockCli(bin: string, name: string, responses: [string, string][]): Promise<void> {
+  const cases = responses
+    .map(([args, output]) => `if (key === ${JSON.stringify(args)}) { console.log(${JSON.stringify(output)}); process.exit(0); }`)
+    .join('\n');
+  const script = `const key = process.argv.slice(2).join(' ');
+${cases}
+console.error('unexpected args: ' + key);
+process.exit(1);
+`;
+
+  await writeFile(join(bin, `${name}.js`), script);
+  const cmdPath = join(bin, `${name}.cmd`);
+  await writeFile(cmdPath, `@echo off\r\n"${process.execPath}" "%~dp0\\${name}.js" %*\r\n`);
+  if (process.platform !== 'win32') await chmod(cmdPath, 0o755);
+}
+
+async function writeWindowsCommandProcessor(path: string): Promise<void> {
+  const script = `#!/usr/bin/env node
+const { basename } = require('node:path');
+
+const commandLine = process.argv.at(-1) || '';
+const parsed = parseCommandLine(commandLine);
+const binary = basename(parsed.command).replace(/\\.cmd$/i, '').toLowerCase();
+const responses = {
+  codex: {
+    '--version': 'codex 1.2.3',
+    'exec --help': 'Usage: codex exec --json --cd --skip-git-repo-check --model -',
+    'exec resume --help': 'Usage: codex exec resume --json --skip-git-repo-check --model <session> -',
+  },
+  claude: {
+    '--version': 'claude 2.3.4',
+    '--help': 'Usage: claude -p --output-format stream-json --resume --model <session>',
+  },
+};
+const output = responses[binary]?.[parsed.args];
+if (output) {
+  console.log(output);
+  process.exit(0);
+}
+console.error('unexpected command: ' + commandLine);
+process.exit(1);
+
+function parseCommandLine(value) {
+  if (value.startsWith('"')) {
+    const end = value.indexOf('"', 1);
+    return { command: value.slice(1, end), args: value.slice(end + 1).trim() };
+  }
+  const [command, ...rest] = value.split(' ');
+  return { command, args: rest.join(' ').trim() };
+}
+`;
+  await writeFile(path, script);
+  await chmod(path, 0o755);
 }
 
 function restoreEnv(name: string, value: string | undefined): void {

--- a/src/__tests__/gitSnapshot.test.ts
+++ b/src/__tests__/gitSnapshot.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, beforeEach, afterEach } from 'node:test';
 import assert from 'node:assert/strict';
 import { chmod, mkdir, mkdtemp, symlink, unlink, writeFile } from 'node:fs/promises';
-import { join } from 'node:path';
+import { delimiter, join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
@@ -41,7 +41,7 @@ if (args[0] === 'status') {
 process.exit(1);
 `);
     await chmod(git, 0o755);
-    process.env.PATH = `${bin}:${originalPath}`;
+    process.env.PATH = originalPath ? `${bin}${delimiter}${originalPath}` : bin;
 
     const capture = await captureGitSnapshot(root);
     assert.equal(capture.status, 'git_unavailable');
@@ -73,7 +73,7 @@ process.exit(1);
     assert.ok(changed.includes('untracked.txt'));
   });
 
-  it('bounds large file fingerprinting and fingerprints symlinks without following targets', async () => {
+  it('bounds large file fingerprinting and fingerprints symlinks without following targets', { skip: process.platform === 'win32' }, async () => {
     const root = await mkdtemp(join(tmpdir(), 'agent-git-'));
     const repo = join(root, 'repo');
     await mkdir(repo);
@@ -85,18 +85,18 @@ process.exit(1);
     await execFileAsync('git', ['commit', '-m', 'initial'], { cwd: repo });
 
     await writeFile(join(repo, 'large.bin'), Buffer.alloc(1024 * 1024 + 1, 1));
-    await symlink('/dev/zero', join(repo, 'special-link'));
+    await symlink('target-one', join(repo, 'special-link'));
 
     const capture = await captureGitSnapshot(repo);
     assert.equal(capture.status, 'captured');
     assert.ok(capture.snapshot);
     assert.match(capture.snapshot.dirty_fingerprints?.['large.bin'] ?? '', /^file-meta:/);
     assert.match(capture.snapshot.dirty_fingerprints?.['special-link'] ?? '', /^symlink:/);
-    assert.ok(capture.snapshot.dirty_fingerprints?.['special-link']?.includes('/dev/zero'));
+    assert.ok(capture.snapshot.dirty_fingerprints?.['special-link']?.includes('target-one'));
 
     await writeFile(join(repo, 'large.bin'), Buffer.alloc(1024 * 1024 + 2, 2));
     await unlink(join(repo, 'special-link'));
-    await symlink('/dev/null', join(repo, 'special-link'));
+    await symlink('target-two', join(repo, 'special-link'));
 
     const changed = await changedFilesSinceSnapshot(repo, capture.snapshot);
     assert.ok(changed.includes('large.bin'));

--- a/src/__tests__/gitSnapshot.test.ts
+++ b/src/__tests__/gitSnapshot.test.ts
@@ -73,7 +73,7 @@ process.exit(1);
     assert.ok(changed.includes('untracked.txt'));
   });
 
-  it('bounds large file fingerprinting and fingerprints symlinks without following targets', { skip: process.platform === 'win32' }, async () => {
+  it('bounds large file fingerprinting', async () => {
     const root = await mkdtemp(join(tmpdir(), 'agent-git-'));
     const repo = join(root, 'repo');
     await mkdir(repo);
@@ -85,21 +85,41 @@ process.exit(1);
     await execFileAsync('git', ['commit', '-m', 'initial'], { cwd: repo });
 
     await writeFile(join(repo, 'large.bin'), Buffer.alloc(1024 * 1024 + 1, 1));
-    await symlink('target-one', join(repo, 'special-link'));
 
     const capture = await captureGitSnapshot(repo);
     assert.equal(capture.status, 'captured');
     assert.ok(capture.snapshot);
     assert.match(capture.snapshot.dirty_fingerprints?.['large.bin'] ?? '', /^file-meta:/);
+
+    await writeFile(join(repo, 'large.bin'), Buffer.alloc(1024 * 1024 + 2, 2));
+
+    const changed = await changedFilesSinceSnapshot(repo, capture.snapshot);
+    assert.ok(changed.includes('large.bin'));
+  });
+
+  it('fingerprints symlinks without following targets', { skip: process.platform === 'win32' }, async () => {
+    const root = await mkdtemp(join(tmpdir(), 'agent-git-'));
+    const repo = join(root, 'repo');
+    await mkdir(repo);
+    await execFileAsync('git', ['init'], { cwd: repo });
+    await execFileAsync('git', ['config', 'user.email', 'test@example.com'], { cwd: repo });
+    await execFileAsync('git', ['config', 'user.name', 'Test'], { cwd: repo });
+    await writeFile(join(repo, 'tracked.txt'), 'clean\n');
+    await execFileAsync('git', ['add', 'tracked.txt'], { cwd: repo });
+    await execFileAsync('git', ['commit', '-m', 'initial'], { cwd: repo });
+
+    await symlink('target-one', join(repo, 'special-link'));
+
+    const capture = await captureGitSnapshot(repo);
+    assert.equal(capture.status, 'captured');
+    assert.ok(capture.snapshot);
     assert.match(capture.snapshot.dirty_fingerprints?.['special-link'] ?? '', /^symlink:/);
     assert.ok(capture.snapshot.dirty_fingerprints?.['special-link']?.includes('target-one'));
 
-    await writeFile(join(repo, 'large.bin'), Buffer.alloc(1024 * 1024 + 2, 2));
     await unlink(join(repo, 'special-link'));
     await symlink('target-two', join(repo, 'special-link'));
 
     const changed = await changedFilesSinceSnapshot(repo, capture.snapshot);
-    assert.ok(changed.includes('large.bin'));
     assert.ok(changed.includes('special-link'));
   });
 });

--- a/src/__tests__/integration/orchestrator.test.ts
+++ b/src/__tests__/integration/orchestrator.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, beforeEach, afterEach } from 'node:test';
 import assert from 'node:assert/strict';
-import { chmod, mkdtemp, readFile, writeFile } from 'node:fs/promises';
-import { join } from 'node:path';
+import { chmod, mkdir, mkdtemp, readFile, writeFile } from 'node:fs/promises';
+import { delimiter, join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
@@ -150,7 +150,7 @@ describe('agent orchestrator integration with mock CLIs', () => {
     const fixture = await createFixture();
     const repo = await createGitRepo(fixture.root);
     const service = await createService(fixture.home);
-    process.env.PATH = '/tmp/agent-orchestrator-no-binaries';
+    process.env.PATH = join(fixture.root, 'missing-bin');
 
     const start = await service.startRun({ backend: 'codex', prompt: 'hello', cwd: repo });
     assert.equal(start.ok, true);
@@ -183,7 +183,7 @@ async function createFixture(): Promise<{ root: string; home: string }> {
   await writeFile(join(root, 'placeholder'), '');
   await mkMockCli(bin, 'codex', 'codex-session-1');
   await mkMockCli(bin, 'claude', 'claude-session-1');
-  process.env.PATH = `${bin}:${originalPath}`;
+  process.env.PATH = prependPath(bin, originalPath);
   return { root, home };
 }
 
@@ -195,7 +195,7 @@ async function createService(home: string): Promise<OrchestratorService> {
 
 async function createGitRepo(root: string): Promise<string> {
   const repo = join(root, 'repo');
-  await execFileAsync('mkdir', ['-p', repo]);
+  await mkdir(repo, { recursive: true });
   await execFileAsync('git', ['init'], { cwd: repo });
   await execFileAsync('git', ['config', 'user.email', 'test@example.com'], { cwd: repo });
   await execFileAsync('git', ['config', 'user.name', 'Test'], { cwd: repo });
@@ -206,9 +206,8 @@ async function createGitRepo(root: string): Promise<string> {
 }
 
 async function mkMockCli(binDir: string, name: string, sessionId: string): Promise<void> {
-  await execFileAsync('mkdir', ['-p', binDir]);
-  const path = join(binDir, name);
-  await writeFile(path, `#!/usr/bin/env node
+  await mkdir(binDir, { recursive: true });
+  const script = `#!/usr/bin/env node
 const fs = require('fs');
 const path = require('path');
 const { spawn } = require('child_process');
@@ -235,7 +234,7 @@ process.stdin.on('end', () => {
   if (prompt.includes('slow-grandchild')) {
     process.removeAllListeners('SIGTERM');
     process.on('SIGTERM', () => {});
-    const grandchild = spawn('sleep', ['60'], { stdio: 'ignore' });
+    const grandchild = spawn(process.execPath, ['-e', 'setInterval(() => {}, 1000)'], { stdio: 'ignore' });
     fs.writeFileSync(path.join(cwd, 'grandchild.pid'), String(grandchild.pid));
     setInterval(() => {}, 1000);
     return;
@@ -250,7 +249,17 @@ process.stdin.on('end', () => {
   console.log(JSON.stringify({ type: 'assistant', message: { content: [{ type: 'text', text: 'done' }] } }));
   console.log(JSON.stringify({ type: 'result', subtype: 'success', result: 'done', session_id: '${sessionId}' }));
 });
-`);
+`;
+
+  if (process.platform === 'win32') {
+    const scriptPath = join(binDir, `${name}.js`);
+    await writeFile(scriptPath, script);
+    await writeFile(join(binDir, `${name}.cmd`), `@echo off\r\n"${process.execPath}" "%~dp0\\${name}.js" %*\r\n`);
+    return;
+  }
+
+  const path = join(binDir, name);
+  await writeFile(path, script);
   await chmod(path, 0o755);
 }
 
@@ -281,4 +290,8 @@ async function waitForFile(path: string): Promise<void> {
     }
   }
   throw new Error(`Timed out waiting for ${path}`);
+}
+
+function prependPath(entry: string, current: string | undefined): string {
+  return current ? `${entry}${delimiter}${current}` : entry;
 }

--- a/src/__tests__/ipc.test.ts
+++ b/src/__tests__/ipc.test.ts
@@ -4,6 +4,7 @@ import { mkdtemp, rm } from 'node:fs/promises';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { connect } from 'node:net';
+import { daemonIpcEndpoint } from '../daemon/paths.js';
 import { IpcClient, IpcRequestError } from '../ipc/client.js';
 import { IpcServer } from '../ipc/server.js';
 import { encodeFrame, FrameReader, writeFrame } from '../ipc/protocol.js';
@@ -11,10 +12,10 @@ import { encodeFrame, FrameReader, writeFrame } from '../ipc/protocol.js';
 describe('IPC protocol', () => {
   it('round-trips JSON-RPC requests', async () => {
     const root = await mkdtemp(join(tmpdir(), 'agent-ipc-'));
-    const socket = join(root, 'daemon.sock');
-    const server = new IpcServer(socket, async (method, params) => ({ method, params }));
+    const endpoint = daemonIpcEndpoint(root);
+    const server = new IpcServer(endpoint.path, async (method, params) => ({ method, params }));
     await server.listen();
-    const client = new IpcClient(socket);
+    const client = new IpcClient(endpoint.path);
     const result = await client.request('ping', { hello: true });
     assert.deepStrictEqual(result, { method: 'ping', params: { hello: true } });
     await server.close();
@@ -23,11 +24,11 @@ describe('IPC protocol', () => {
 
   it('returns protocol mismatch as an orchestrator error', async () => {
     const root = await mkdtemp(join(tmpdir(), 'agent-ipc-'));
-    const socket = join(root, 'daemon.sock');
-    const server = new IpcServer(socket, async () => ({ ok: true }));
+    const endpoint = daemonIpcEndpoint(root);
+    const server = new IpcServer(endpoint.path, async () => ({ ok: true }));
     await server.listen();
 
-    const raw = connect(socket);
+    const raw = connect(endpoint.path);
     await new Promise<void>((resolve) => raw.once('connect', resolve));
     raw.write(encodeFrame({ protocol_version: 999, id: 'bad', method: 'ping' }));
     const reader = new FrameReader();
@@ -42,10 +43,13 @@ describe('IPC protocol', () => {
   });
 
   it('wraps unavailable daemon as DAEMON_UNAVAILABLE', async () => {
-    const client = new IpcClient('/tmp/agent-orchestrator-missing.sock');
+    const root = await mkdtemp(join(tmpdir(), 'agent-ipc-missing-'));
+    const endpoint = daemonIpcEndpoint(root);
+    const client = new IpcClient(endpoint.path);
     await assert.rejects(
       () => client.request('ping', {}, 50),
       (error) => error instanceof IpcRequestError && error.orchestratorError.code === 'DAEMON_UNAVAILABLE',
     );
+    await rm(root, { recursive: true, force: true });
   });
 });

--- a/src/__tests__/ipc.test.ts
+++ b/src/__tests__/ipc.test.ts
@@ -25,6 +25,19 @@ describe('IPC protocol', () => {
     await rm(root, { recursive: true, force: true });
   });
 
+  it('round-trips JSON-RPC requests over a Windows named pipe', { skip: process.platform !== 'win32' }, async () => {
+    const root = await mkdtemp(join(tmpdir(), 'agent-ipc-win-'));
+    const endpoint = daemonIpcEndpoint(root, 'win32');
+    assert.equal(endpoint.transport, 'windows_pipe');
+    const server = new IpcServer(endpoint.path, async (method, params, context) => ({ method, params, frontend_version: context.frontend_version }));
+    await server.listen();
+    const client = new IpcClient(endpoint.path);
+    const result = await client.request('ping', { hello: 'windows' });
+    assert.deepStrictEqual(result, { method: 'ping', params: { hello: 'windows' }, frontend_version: getPackageVersion() });
+    await server.close();
+    await rm(root, { recursive: true, force: true });
+  });
+
   it('returns protocol mismatch as an orchestrator error', async () => {
     const root = await mkdtemp(join(tmpdir(), 'agent-ipc-'));
     const endpoint = daemonIpcEndpoint(root);

--- a/src/__tests__/processManager.test.ts
+++ b/src/__tests__/processManager.test.ts
@@ -1,10 +1,11 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
+import type { ChildProcess } from 'node:child_process';
 import { chmod, mkdtemp, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { CodexBackend } from '../backend/codex.js';
-import { ProcessManager } from '../processManager.js';
+import { prepareWorkerSpawn, ProcessManager, terminateProcessTree } from '../processManager.js';
 import { RunStore } from '../runStore.js';
 import type { RunMeta, TerminalRunStatus, WorkerResult } from '../contract.js';
 
@@ -24,6 +25,66 @@ class ThrowingTerminalStore extends RunStore {
 }
 
 describe('ProcessManager', () => {
+  it('wraps Windows cmd shims with the command processor', () => {
+    assert.deepStrictEqual(
+      prepareWorkerSpawn('C:\\Tools\\codex.cmd', ['exec', '--model', 'gpt-5.2', '-'], 'win32', 'cmd.exe'),
+      {
+        command: 'cmd.exe',
+        args: ['/d', '/s', '/c', 'C:\\Tools\\codex.cmd exec --model gpt-5.2 -'],
+      },
+    );
+    assert.deepStrictEqual(
+      prepareWorkerSpawn('/usr/bin/codex', ['exec', '-'], 'linux'),
+      { command: '/usr/bin/codex', args: ['exec', '-'] },
+    );
+  });
+
+  it('terminates POSIX process groups with escalating signals', () => {
+    const calls: { pid: number; signal: NodeJS.Signals }[] = [];
+
+    terminateProcessTree(1234, false, 'linux', (pid, signal) => {
+      calls.push({ pid, signal });
+    });
+    terminateProcessTree(1234, true, 'linux', (pid, signal) => {
+      calls.push({ pid, signal });
+    });
+
+    assert.deepStrictEqual(calls, [
+      { pid: -1234, signal: 'SIGTERM' },
+      { pid: -1234, signal: 'SIGKILL' },
+    ]);
+  });
+
+  it('terminates Windows process trees with taskkill', () => {
+    const calls: { command: string; args: string[]; options: { stdio: 'ignore'; windowsHide: true } }[] = [];
+    const child = {
+      on() {
+        return child;
+      },
+      unref() {
+        return child;
+      },
+    } as unknown as ChildProcess;
+
+    terminateProcessTree(4321, false, 'win32', () => {
+      throw new Error('process.kill should not be used on Windows');
+    }, (command, args, options) => {
+      calls.push({ command, args, options });
+      return child;
+    });
+    terminateProcessTree(4321, true, 'win32', () => {
+      throw new Error('process.kill should not be used on Windows');
+    }, (command, args, options) => {
+      calls.push({ command, args, options });
+      return child;
+    });
+
+    assert.deepStrictEqual(calls, [
+      { command: 'taskkill', args: ['/PID', '4321', '/T'], options: { stdio: 'ignore', windowsHide: true } },
+      { command: 'taskkill', args: ['/PID', '4321', '/T', '/F'], options: { stdio: 'ignore', windowsHide: true } },
+    ]);
+  });
+
   it('settles completion even when terminal finalization throws', async () => {
     const root = await mkdtemp(join(tmpdir(), 'agent-process-'));
     const cli = join(root, 'worker.js');

--- a/src/backend/common.ts
+++ b/src/backend/common.ts
@@ -1,14 +1,19 @@
 import { access } from 'node:fs/promises';
 import { constants } from 'node:fs';
-import { delimiter, isAbsolute, join } from 'node:path';
+import { delimiter, extname, isAbsolute, join } from 'node:path';
 import type { WorkerBackend, WorkerInvocation, BackendStartInput, FinalizeContext, FinalizedWorkerResult, ParsedBackendEvent } from './WorkerBackend.js';
 import { WorkerResultSchema } from '../contract.js';
 import { deriveObservedResult } from './resultDerivation.js';
 
-export async function resolveBinary(binary: string): Promise<string | null> {
+export async function resolveBinary(
+  binary: string,
+  platform: NodeJS.Platform = process.platform,
+  env: NodeJS.ProcessEnv = process.env,
+): Promise<string | null> {
+  const pathValue = env.PATH ?? env.Path ?? '';
   const candidates = binary.includes('/') || binary.includes('\\')
     ? [binary]
-    : (process.env.PATH ?? '').split(delimiter).filter(Boolean).map((dir) => join(dir, binary));
+    : pathValue.split(pathDelimiter(platform)).filter(Boolean).flatMap((dir) => binaryCandidates(dir, binary, platform, env));
 
   for (const candidate of candidates) {
     try {
@@ -21,6 +26,21 @@ export async function resolveBinary(binary: string): Promise<string | null> {
   }
 
   return null;
+}
+
+function pathDelimiter(platform: NodeJS.Platform): string {
+  return platform === 'win32' ? ';' : delimiter;
+}
+
+function binaryCandidates(dir: string, binary: string, platform: NodeJS.Platform, env: NodeJS.ProcessEnv): string[] {
+  const exact = join(dir, binary);
+  if (platform !== 'win32' || extname(binary)) return [exact];
+
+  const extensions = (env.PATHEXT || env.Pathext || '.COM;.EXE;.BAT;.CMD')
+    .split(';')
+    .map((extension) => extension.trim())
+    .filter(Boolean);
+  return [exact, ...extensions.map((extension) => join(dir, `${binary}${extension}`))];
 }
 
 export function invocation(

--- a/src/daemon/daemonCli.ts
+++ b/src/daemon/daemonCli.ts
@@ -49,7 +49,7 @@ async function start(): Promise<void> {
 }
 
 async function stop(force: boolean): Promise<void> {
-  const client = new IpcClient(paths.socket);
+  const client = new IpcClient(paths.ipc.path);
   try {
     const result = await client.request('shutdown', { force }, 10_000) as { ok: boolean; error?: { details?: { active_runs?: unknown } } };
     if (!result.ok) {
@@ -66,7 +66,7 @@ async function stop(force: boolean): Promise<void> {
 }
 
 async function status(): Promise<void> {
-  const client = new IpcClient(paths.socket);
+  const client = new IpcClient(paths.ipc.path);
   try {
     const pingResult = await client.request('ping', {}) as { ok: true; pong: true; daemon_pid: number };
     const listResult = await client.request('list_runs', {}) as { ok: true; runs: { status: string }[] };
@@ -92,7 +92,7 @@ async function prune(): Promise<void> {
   };
   let result: PruneRunsResult;
   if (await ping()) {
-    const client = new IpcClient(paths.socket);
+    const client = new IpcClient(paths.ipc.path);
     result = await client.request('prune_runs', params, 30_000) as PruneRunsResult;
   } else {
     result = await new RunStore(paths.home).pruneTerminalRuns(params.older_than_days, params.dry_run);
@@ -108,7 +108,7 @@ async function prune(): Promise<void> {
 
 async function ping(): Promise<boolean> {
   try {
-    const client = new IpcClient(paths.socket);
+    const client = new IpcClient(paths.ipc.path);
     await client.request('ping', {}, 1000);
     return true;
   } catch {

--- a/src/daemon/daemonMain.ts
+++ b/src/daemon/daemonMain.ts
@@ -12,11 +12,6 @@ const paths = daemonPaths();
 let pidFd: number | null = null;
 let ipcServer: IpcServer | null = null;
 
-if (process.platform === 'win32') {
-  process.stderr.write('agent-orchestrator daemon is POSIX-only in v1; Unix sockets are required.\n');
-  process.exit(1);
-}
-
 function log(message: string): void {
   const line = `[${new Date().toISOString()}] ${message}\n`;
   appendFileSync(paths.log, line, { mode: 0o600 });
@@ -26,21 +21,25 @@ function log(message: string): void {
 async function main(): Promise<void> {
   await ensureSecureRoot(paths.home);
   acquirePidFile();
-  await cleanupSocket();
+  await cleanupIpcEndpoint();
 
   const store = new RunStore(paths.home);
   const service = new OrchestratorService(store, createBackendRegistry(), log);
   await service.initialize();
 
-  ipcServer = new IpcServer(paths.socket, async (method, params) => service.dispatch(method, params));
-  const oldUmask = process.umask(0o177);
-  try {
+  ipcServer = new IpcServer(paths.ipc.path, async (method, params) => service.dispatch(method, params));
+  if (paths.ipc.transport === 'unix_socket') {
+    const oldUmask = process.umask(0o177);
+    try {
+      await ipcServer.listen();
+    } finally {
+      process.umask(oldUmask);
+    }
+  } else {
     await ipcServer.listen();
-  } finally {
-    process.umask(oldUmask);
   }
 
-  log(`daemon started pid=${process.pid} socket=${paths.socket}`);
+  log(`daemon started pid=${process.pid} ipc=${paths.ipc.path}`);
 
   const forceShutdown = () => {
     void service.shutdown({ force: true });
@@ -82,14 +81,14 @@ function isPidAlive(pid: number): boolean {
   }
 }
 
-async function cleanupSocket(): Promise<void> {
-  if (!existsSync(paths.socket)) return;
-  const info = await lstat(paths.socket);
+async function cleanupIpcEndpoint(): Promise<void> {
+  if (!paths.ipc.cleanupPath || !existsSync(paths.ipc.cleanupPath)) return;
+  const info = await lstat(paths.ipc.cleanupPath);
   const uid = process.getuid?.();
   if (typeof uid === 'number' && info.uid !== uid) {
-    throw new Error(`Refusing to remove foreign-owned socket ${paths.socket} owned by uid ${info.uid}`);
+    throw new Error(`Refusing to remove foreign-owned IPC endpoint ${paths.ipc.cleanupPath} owned by uid ${info.uid}`);
   }
-  await rm(paths.socket, { force: true });
+  await rm(paths.ipc.cleanupPath, { force: true });
 }
 
 async function cleanup(): Promise<void> {
@@ -99,7 +98,7 @@ async function cleanup(): Promise<void> {
     // Ignore during process shutdown.
   }
   try {
-    await rm(paths.socket, { force: true });
+    if (paths.ipc.cleanupPath) await rm(paths.ipc.cleanupPath, { force: true });
   } catch {
     // Ignore during process shutdown.
   }
@@ -115,7 +114,7 @@ process.on('exit', () => {
   try {
     if (pidFd !== null) closeSync(pidFd);
     if (existsSync(paths.pid) && readExistingPid() === process.pid) unlinkSync(paths.pid);
-    if (existsSync(paths.socket)) unlinkSync(paths.socket);
+    if (paths.ipc.cleanupPath && existsSync(paths.ipc.cleanupPath)) unlinkSync(paths.ipc.cleanupPath);
   } catch {
     // Process is exiting; best effort only.
   }

--- a/src/daemon/daemonMain.ts
+++ b/src/daemon/daemonMain.ts
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import { closeSync, existsSync, openSync, readFileSync, unlinkSync, writeFileSync } from 'node:fs';
+import { closeSync, existsSync, lstatSync, openSync, readFileSync, unlinkSync, writeFileSync, type Stats } from 'node:fs';
 import { lstat, rm } from 'node:fs/promises';
 import { appendFileSync } from 'node:fs';
 import { IpcServer } from '../ipc/server.js';
@@ -82,13 +82,26 @@ function isPidAlive(pid: number): boolean {
 }
 
 async function cleanupIpcEndpoint(): Promise<void> {
-  if (!paths.ipc.cleanupPath || !existsSync(paths.ipc.cleanupPath)) return;
-  const info = await lstat(paths.ipc.cleanupPath);
+  const cleanupPath = paths.ipc.cleanupPath;
+  if (!cleanupPath) return;
+
+  let info: Stats;
+  try {
+    info = await lstat(cleanupPath);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return;
+    throw error;
+  }
+
   const uid = process.getuid?.();
   if (typeof uid === 'number' && info.uid !== uid) {
-    throw new Error(`Refusing to remove foreign-owned IPC endpoint ${paths.ipc.cleanupPath} owned by uid ${info.uid}`);
+    throw new Error(`Refusing to remove foreign-owned IPC endpoint ${cleanupPath} owned by uid ${info.uid}`);
   }
-  await rm(paths.ipc.cleanupPath, { force: true });
+  try {
+    await rm(cleanupPath, { force: true });
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
+  }
 }
 
 async function cleanup(): Promise<void> {
@@ -98,7 +111,7 @@ async function cleanup(): Promise<void> {
     // Ignore during process shutdown.
   }
   try {
-    if (paths.ipc.cleanupPath) await rm(paths.ipc.cleanupPath, { force: true });
+    await cleanupIpcEndpoint();
   } catch {
     // Ignore during process shutdown.
   }
@@ -114,11 +127,31 @@ process.on('exit', () => {
   try {
     if (pidFd !== null) closeSync(pidFd);
     if (existsSync(paths.pid) && readExistingPid() === process.pid) unlinkSync(paths.pid);
-    if (paths.ipc.cleanupPath && existsSync(paths.ipc.cleanupPath)) unlinkSync(paths.ipc.cleanupPath);
+    if (paths.ipc.cleanupPath) unlinkOwnedIpcEndpointSync(paths.ipc.cleanupPath);
   } catch {
     // Process is exiting; best effort only.
   }
 });
+
+function unlinkOwnedIpcEndpointSync(cleanupPath: string): void {
+  let info: Stats;
+  try {
+    info = lstatSync(cleanupPath);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return;
+    throw error;
+  }
+
+  const uid = process.getuid?.();
+  if (typeof uid === 'number' && info.uid !== uid) {
+    throw new Error(`Refusing to remove foreign-owned IPC endpoint ${cleanupPath} owned by uid ${info.uid}`);
+  }
+  try {
+    unlinkSync(cleanupPath);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
+  }
+}
 
 main().catch(async (error) => {
   log(`fatal: ${error instanceof Error ? error.stack ?? error.message : String(error)}`);

--- a/src/daemon/paths.ts
+++ b/src/daemon/paths.ts
@@ -1,9 +1,18 @@
-import { join } from 'node:path';
+import { createHash } from 'node:crypto';
+import { join, resolve } from 'node:path';
 import { resolveStoreRoot } from '../runStore.js';
+
+export type DaemonIpcTransport = 'unix_socket' | 'windows_pipe';
+
+export interface DaemonIpcEndpoint {
+  transport: DaemonIpcTransport;
+  path: string;
+  cleanupPath: string | null;
+}
 
 export interface DaemonPaths {
   home: string;
-  socket: string;
+  ipc: DaemonIpcEndpoint;
   pid: string;
   log: string;
 }
@@ -12,8 +21,33 @@ export function daemonPaths(): DaemonPaths {
   const home = resolveStoreRoot();
   return {
     home,
-    socket: join(home, 'daemon.sock'),
+    ipc: daemonIpcEndpoint(home),
     pid: join(home, 'daemon.pid'),
     log: join(home, 'daemon.log'),
   };
+}
+
+export function daemonIpcEndpoint(home: string, platform: NodeJS.Platform = process.platform): DaemonIpcEndpoint {
+  if (platform === 'win32') {
+    const hash = createHash('sha256')
+      .update(normalizeStoreRootForPipe(home))
+      .digest('hex')
+      .slice(0, 16);
+    return {
+      transport: 'windows_pipe',
+      path: `\\\\.\\pipe\\agent-orchestrator-mcp-${hash}`,
+      cleanupPath: null,
+    };
+  }
+
+  const socketPath = join(home, 'daemon.sock');
+  return {
+    transport: 'unix_socket',
+    path: socketPath,
+    cleanupPath: socketPath,
+  };
+}
+
+function normalizeStoreRootForPipe(home: string): string {
+  return resolve(home).replaceAll('/', '\\').toLowerCase();
 }

--- a/src/diagnostics.ts
+++ b/src/diagnostics.ts
@@ -5,6 +5,7 @@ import { promisify } from 'node:util';
 import type { Backend, BackendDiagnostic, BackendStatusReport } from './contract.js';
 import { resolveBinary } from './backend/common.js';
 import { daemonPaths } from './daemon/paths.js';
+import { prepareWorkerSpawn } from './processManager.js';
 
 const execFileAsync = promisify(execFile);
 const commandTimeoutMs = 2_000;
@@ -58,14 +59,14 @@ const definitions: BackendCheckDefinition[] = [
   },
 ];
 
-export async function getBackendStatus(): Promise<BackendStatusReport> {
+export async function getBackendStatus(platform: NodeJS.Platform = process.platform): Promise<BackendStatusReport> {
   const paths = daemonPaths();
   const runStore = await checkRunStore(paths.home);
-  const posixSupported = process.platform !== 'win32';
-  const backends = await Promise.all(definitions.map((definition) => diagnoseBackend(definition, posixSupported)));
+  const posixSupported = platform !== 'win32';
+  const backends = await Promise.all(definitions.map((definition) => diagnoseBackend(definition, platform)));
 
   return {
-    platform: process.platform,
+    platform,
     node_version: process.version,
     posix_supported: posixSupported,
     run_store: runStore,
@@ -105,23 +106,10 @@ export function formatBackendStatus(report: BackendStatusReport): string {
   return `${lines.join('\n')}\n`;
 }
 
-async function diagnoseBackend(definition: BackendCheckDefinition, posixSupported: boolean): Promise<BackendDiagnostic> {
+async function diagnoseBackend(definition: BackendCheckDefinition, platform: NodeJS.Platform): Promise<BackendDiagnostic> {
   const checks: BackendDiagnostic['checks'] = [];
   const hints: string[] = [];
-  const path = await resolveBinary(definition.binary);
-
-  if (!posixSupported) {
-    return {
-      name: definition.name,
-      binary: definition.binary,
-      status: 'unsupported',
-      path,
-      version: null,
-      auth: { status: 'unknown', hint: 'Windows named-pipe support is not implemented in v1.' },
-      checks: [{ name: 'POSIX platform support', ok: false, message: 'Unix sockets and POSIX process groups are required.' }],
-      hints: ['Use Linux, macOS, or WSL for v1.'],
-    };
-  }
+  const path = await resolveBinary(definition.binary, platform);
 
   if (!path) {
     return {
@@ -137,9 +125,9 @@ async function diagnoseBackend(definition: BackendCheckDefinition, posixSupporte
   }
 
   checks.push({ name: `${definition.binary} binary on PATH`, ok: true, message: path });
-  const version = await readVersion(path);
+  const version = await readVersion(path, platform);
   for (const required of definition.requiredHelp) {
-    const output = await runCommand(path, required.args);
+    const output = await runCommand(path, required.args, platform);
     if (!output.ok) {
       checks.push({ name: required.name, ok: false, message: output.message });
       hints.push(`Upgrade ${definition.binary}; failed to verify ${required.args.join(' ')}.`);
@@ -181,8 +169,8 @@ async function diagnoseBackend(definition: BackendCheckDefinition, posixSupporte
   };
 }
 
-async function readVersion(binaryPath: string): Promise<string | null> {
-  const output = await runCommand(binaryPath, ['--version']);
+async function readVersion(binaryPath: string, platform: NodeJS.Platform): Promise<string | null> {
+  const output = await runCommand(binaryPath, ['--version'], platform);
   if (!output.ok) return null;
   return output.text.split('\n').map((line) => line.trim()).find(Boolean) ?? null;
 }
@@ -199,9 +187,10 @@ function detectAuth(definition: BackendCheckDefinition): BackendDiagnostic['auth
   };
 }
 
-async function runCommand(binaryPath: string, args: string[]): Promise<{ ok: true; text: string } | { ok: false; message: string }> {
+async function runCommand(binaryPath: string, args: string[], platform: NodeJS.Platform): Promise<{ ok: true; text: string } | { ok: false; message: string }> {
   try {
-    const result = await execFileAsync(binaryPath, args, {
+    const prepared = prepareWorkerSpawn(binaryPath, args, platform);
+    const result = await execFileAsync(prepared.command, prepared.args, {
       timeout: commandTimeoutMs,
       maxBuffer: 512 * 1024,
       env: { ...process.env, NO_COLOR: '1', TERM: 'dumb' },
@@ -227,7 +216,7 @@ async function checkRunStore(path: string): Promise<BackendStatusReport['run_sto
     return { path, accessible: true };
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
-      return { path, accessible: true, message: 'directory does not exist yet; the daemon will create it with 0700 permissions' };
+      return { path, accessible: true, message: 'directory does not exist yet; the daemon will create it with user-only permissions where supported' };
     }
 
     return {

--- a/src/processManager.ts
+++ b/src/processManager.ts
@@ -1,4 +1,4 @@
-import { spawn, type ChildProcessWithoutNullStreams } from 'node:child_process';
+import { spawn, type ChildProcess, type ChildProcessWithoutNullStreams } from 'node:child_process';
 import { createWriteStream } from 'node:fs';
 import { realpath } from 'node:fs/promises';
 import { isAbsolute, relative, resolve, sep } from 'node:path';
@@ -16,6 +16,14 @@ export interface ManagedRun {
   cancel(status: Extract<RunStatus, 'cancelled' | 'timed_out'>): void;
 }
 
+export type ProcessKill = (pid: number, signal: NodeJS.Signals) => void;
+export type TaskkillSpawn = (command: string, args: string[], options: { stdio: 'ignore'; windowsHide: true }) => ChildProcess;
+
+export interface PreparedWorkerSpawn {
+  command: string;
+  args: string[];
+}
+
 export class ProcessManager {
   constructor(private readonly store: RunStore) {}
 
@@ -26,7 +34,8 @@ export class ProcessManager {
       NO_COLOR: '1',
       TERM: 'dumb',
     };
-    const child = spawn(invocation.command, invocation.args, {
+    const preparedSpawn = prepareWorkerSpawn(invocation.command, invocation.args);
+    const child = spawn(preparedSpawn.command, preparedSpawn.args, {
       cwd: invocation.cwd,
       env,
       shell: false,
@@ -35,7 +44,7 @@ export class ProcessManager {
     });
 
     const workerPid = child.pid ?? null;
-    const workerPgid = workerPid;
+    const workerPgid = process.platform === 'win32' ? null : workerPid;
     await this.store.updateMeta(runId, (meta) => ({
       ...meta,
       started_at: meta.started_at ?? new Date().toISOString(),
@@ -86,19 +95,11 @@ export class ProcessManager {
     const cancel = (status: Extract<RunStatus, 'cancelled' | 'timed_out'>) => {
       if (terminalOverride) return;
       terminalOverride = status;
-      const pgid = child.pid ? -child.pid : null;
-      if (pgid !== null) {
-        try {
-          process.kill(pgid, 'SIGTERM');
-        } catch {
-          // The process may already have exited.
-        }
+      const pid = child.pid;
+      if (pid) {
+        terminateProcessTree(pid, false);
         killTimer = setTimeout(() => {
-          try {
-            process.kill(pgid, 'SIGKILL');
-          } catch {
-            // Already gone.
-          }
+          terminateProcessTree(pid, true);
         }, 5_000);
       }
     };
@@ -273,4 +274,60 @@ function relativeInside(cwd: string, file: string): string | null {
   const relativePath = relative(cwd, file);
   if (!relativePath || relativePath === '..' || relativePath.startsWith(`..${sep}`) || isAbsolute(relativePath)) return null;
   return relativePath;
+}
+
+export function terminateProcessTree(
+  pid: number,
+  force: boolean,
+  platform: NodeJS.Platform = process.platform,
+  killProcess: ProcessKill = process.kill,
+  spawnTaskkill: TaskkillSpawn = spawnTaskkillProcess,
+): void {
+  if (pid <= 0) return;
+
+  if (platform === 'win32') {
+    const args = ['/PID', String(pid), '/T'];
+    if (force) args.push('/F');
+    const child = spawnTaskkill('taskkill', args, { stdio: 'ignore', windowsHide: true });
+    child.on('error', () => {
+      // The process may already have exited, or taskkill may be unavailable.
+    });
+    child.unref();
+    return;
+  }
+
+  try {
+    killProcess(-pid, force ? 'SIGKILL' : 'SIGTERM');
+  } catch {
+    // The process may already have exited.
+  }
+}
+
+function spawnTaskkillProcess(command: string, args: string[], options: { stdio: 'ignore'; windowsHide: true }): ChildProcess {
+  return spawn(command, args, options);
+}
+
+export function prepareWorkerSpawn(
+  command: string,
+  args: string[],
+  platform: NodeJS.Platform = process.platform,
+  commandProcessor = process.env.ComSpec || process.env.COMSPEC || 'cmd.exe',
+): PreparedWorkerSpawn {
+  if (platform === 'win32' && /\.(?:bat|cmd)$/i.test(command)) {
+    return {
+      command: commandProcessor,
+      args: ['/d', '/s', '/c', quoteCmdCommand([command, ...args])],
+    };
+  }
+
+  return { command, args };
+}
+
+function quoteCmdCommand(args: string[]): string {
+  return args.map(quoteCmdArg).join(' ');
+}
+
+function quoteCmdArg(arg: string): string {
+  const escaped = arg.replaceAll('%', '%%').replace(/(["^&|<>()])/g, '^$1');
+  return escaped.length === 0 || /[\s]/.test(escaped) ? `"${escaped}"` : escaped;
 }

--- a/src/runStore.ts
+++ b/src/runStore.ts
@@ -426,9 +426,11 @@ export function resolveStoreRoot(): string {
   return process.env.AGENT_ORCHESTRATOR_HOME || join(homedir(), '.agent-orchestrator');
 }
 
-export async function ensureSecureRoot(root: string): Promise<void> {
+export async function ensureSecureRoot(root: string, platform: NodeJS.Platform = process.platform): Promise<void> {
   await mkdir(root, { recursive: true, mode: rootMode });
   const info = await stat(root);
+  if (platform === 'win32') return;
+
   const getuid = process.getuid?.();
   if (typeof getuid === 'number' && info.uid !== getuid) {
     throw new Error(`Agent orchestrator home ${root} is owned by uid ${info.uid}, expected ${getuid}`);

--- a/src/server.ts
+++ b/src/server.ts
@@ -14,7 +14,7 @@ import { orchestratorError, wrapErr } from './contract.js';
 import { ipcTimeoutForTool } from './toolTimeout.js';
 
 const paths = daemonPaths();
-const client = new IpcClient(paths.socket);
+const client = new IpcClient(paths.ipc.path);
 
 const tools = [
   {


### PR DESCRIPTION
## Summary

- Add a cross-platform daemon IPC endpoint abstraction with Unix sockets on POSIX and per-store named pipes on Windows.
- Enable daemon startup on Windows and route daemon CLI / MCP server IPC through the new endpoint.
- Add Windows-aware worker spawning, PATHEXT binary resolution, and process-tree cancellation through `taskkill`.
- Harden affected tests and update docs for Windows named-pipe and POSIX-specific behavior.

## Issue

Closes #2

## Verification

- [x] `git diff --check`
- [ ] `pnpm build` - blocked locally because `node_modules` is absent and `tsc` is not installed (`sh: 1: tsc: not found`).
- [ ] `pnpm test` - returned exit 0 locally but discovered 0 tests because `dist/` is absent, so this is not meaningful verification.
- [ ] `pnpm verify` - blocked locally at `pnpm build` for the same missing `tsc` issue.

## Review

- Local review artifact: `plans/2-add-windows-support/reviews/review-2026-05-02.md`
- Finding: no blocking correctness findings; residual risk is dependency-blocked local verification and no native Windows runtime smoke in this workspace.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Cross-platform daemon IPC (POSIX socket on Unix/macOS, named-pipe on Windows) and platform-aware worker cancellation (POSIX process-group vs. Windows taskkill).

* **Documentation**
  * Docs, README, architecture and operational notes updated with platform-specific IPC, lifecycle, diagnostics, security, and kill instructions.

* **Tests**
  * Added/expanded cross-platform tests for IPC endpoints, binary resolution, PATH/PATHEXT handling, process termination, and diagnostics.

* **Bug Fixes**
  * Improved IPC startup/cleanup behavior and platform-aware run-store permission handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->