### PR TITLE
Add observability dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,10 @@ When installed locally or globally, use:
 
 ```bash
 agent-orchestrator-mcp-daemon status
+agent-orchestrator-mcp-daemon status --verbose
+agent-orchestrator-mcp-daemon runs
+agent-orchestrator-mcp-daemon runs --json --prompts
+agent-orchestrator-mcp-daemon watch
 agent-orchestrator-mcp-daemon start
 agent-orchestrator-mcp-daemon stop
 agent-orchestrator-mcp-daemon stop --force
@@ -158,6 +162,8 @@ With `npx`, target the daemon bin explicitly:
 
 ```bash
 npx -y --package @ralphkrauss/agent-orchestrator-mcp@latest agent-orchestrator-mcp-daemon status
+npx -y --package @ralphkrauss/agent-orchestrator-mcp@latest agent-orchestrator-mcp-daemon runs
+npx -y --package @ralphkrauss/agent-orchestrator-mcp@latest agent-orchestrator-mcp-daemon watch
 npx -y --package @ralphkrauss/agent-orchestrator-mcp@latest agent-orchestrator-mcp-daemon stop --force
 npx -y --package @ralphkrauss/agent-orchestrator-mcp@latest agent-orchestrator-mcp-daemon prune --older-than-days 30 --dry-run
 ```
@@ -165,6 +171,53 @@ npx -y --package @ralphkrauss/agent-orchestrator-mcp@latest agent-orchestrator-m
 `stop` refuses while runs are active and prints the active run IDs. `stop --force` cancels active runs through the normal cancellation path, waits for terminal statuses, and exits. Direct `SIGTERM`/`SIGINT` to the daemon behaves like `stop --force`; `SIGKILL` cannot be caught and any in-flight runs become `orphaned` on next daemon startup.
 
 `prune` deletes only terminal runs with `finished_at` older than the requested age. Use `--dry-run` first to inspect the matching run IDs.
+
+## Observability
+
+Use the daemon CLI to inspect sessions and runs:
+
+```bash
+agent-orchestrator-mcp-daemon status --verbose
+agent-orchestrator-mcp-daemon runs
+agent-orchestrator-mcp-daemon runs --json
+agent-orchestrator-mcp-daemon runs --json --prompts
+agent-orchestrator-mcp-daemon watch
+```
+
+`watch` opens an interactive terminal dashboard. Use arrow keys to move through
+sessions and prompts, Enter to open details, Backspace or Escape to return, and
+`q` to quit. Detail views include the raw prompt, recent activity, model/source,
+session-resume audit state, artifact paths, and size indicators.
+
+The dashboard groups runs by backend session ID when available and falls back to
+the parent/child run chain while a backend session is still pending. Follow-up
+runs record both the requested session ID and the backend-observed session ID so
+the dashboard can warn when a resume appears to start or report a different
+session.
+
+Prompts are stored as `prompt.txt` in each private run directory so operators can
+inspect exactly what was sent to a worker. The run store is local and permission
+restricted, but prompts may contain sensitive instructions or secrets supplied by
+callers. Do not pass API keys or other credentials in prompts unless you are
+comfortable with them being written to the local run store.
+
+For human-readable dashboard labels, pass metadata on `start_run` or
+`send_followup`:
+
+```json
+{
+  "metadata": {
+    "session_title": "Release readiness",
+    "session_summary": "Prepare and verify the npm package",
+    "prompt_title": "Run release checks",
+    "prompt_summary": "Build, test, and inspect publish readiness"
+  }
+}
+```
+
+`title` and `summary` are also accepted as shorthand. Follow-up runs inherit the
+session title and summary from the parent unless overridden. Prompt title and
+summary are per run.
 
 ## Run Store
 
@@ -180,6 +233,7 @@ Default location:
     <run-id>/
       meta.json
       events.jsonl
+      prompt.txt
       stdout.log
       stderr.log
       result.json
@@ -228,18 +282,37 @@ Expected operational failures use `{ ok: false, error }`. MCP `isError: true` is
 | Tool | Input | Success payload |
 |---|---|---|
 | `get_backend_status` | `{}` | `{ status: BackendStatusReport }` |
-| `start_run` | `{ backend: "codex" \| "claude", prompt: string, cwd: string, model?: string, metadata?: object, execution_timeout_seconds?: number }` | `{ run_id: string }` |
+| `get_observability_snapshot` | `{ limit?: number, include_prompts?: boolean, recent_event_limit?: number, diagnostics?: boolean }` | `{ snapshot: ObservabilitySnapshot }` |
+| `start_run` | `{ backend: "codex" \| "claude", prompt: string, cwd: string, model?: string, reasoning_effort?: string, service_tier?: string, metadata?: object, execution_timeout_seconds?: number }` | `{ run_id: string }` |
 | `list_runs` | `{}` | `{ runs: RunSummary[] }` |
 | `get_run_status` | `{ run_id: string }` | `{ run_summary: RunSummary }` |
 | `get_run_events` | `{ run_id: string, after_sequence?: number, limit?: number }` | `{ events: WorkerEvent[], next_sequence: number, has_more: boolean }` |
 | `wait_for_run` | `{ run_id: string, wait_seconds: number }` | Terminal status or `{ status: "still_running", wait_exceeded: true, run_summary }` |
 | `get_run_result` | `{ run_id: string }` | `{ run_summary: RunSummary, result: WorkerResult \| null }` |
-| `send_followup` | `{ run_id: string, prompt: string, model?: string, execution_timeout_seconds?: number }` | `{ run_id: string }` for a new child run |
+| `send_followup` | `{ run_id: string, prompt: string, model?: string, reasoning_effort?: string, service_tier?: string, metadata?: object, execution_timeout_seconds?: number }` | `{ run_id: string }` for a new child run |
 | `cancel_run` | `{ run_id: string }` | `{ accepted: true, status: RunStatus }` |
 
 Most worker preparation failures are run failures rather than envelope failures. For example, if `codex` is missing, `start_run` creates a durable run and that run lands in `failed` with `WORKER_BINARY_MISSING` details.
 
-`model` is passed through to the selected worker CLI as provided. Codex and Claude model names change over time, so the orchestrator validates only that the value is a non-empty string. Follow-up runs inherit the parent run model unless a new `model` is supplied.
+`model` is passed through to the selected worker CLI as provided. Codex model
+names change over time, so Codex validates only that the value is a non-empty
+string. Claude aliases such as `opus` and `sonnet` are rejected when supplied
+explicitly; pass a direct model id such as `claude-opus-4-7` or
+`claude-opus-4-7[1m]` so the dashboard and worker invocation are auditable.
+Follow-up runs inherit the parent run model unless a new `model` is supplied.
+
+`reasoning_effort` is mapped to Codex `model_reasoning_effort` or Claude
+`--effort`. Codex accepts `none`, `minimal`, `low`, `medium`, `high`, and
+`xhigh`. Claude accepts `low`, `medium`, `high`, `xhigh`, and `max` on supported
+direct model ids; `xhigh` is accepted only for Opus 4.7 to avoid Claude Code's
+documented fallback to `high` on older models. `service_tier` is Codex-only:
+`fast` and `flex` are passed through, while `normal` runs Codex without loading
+the user's config so a global fast setting is not inherited.
+
+The observability snapshot includes additive fields for model source, display
+metadata, raw prompt artifacts, activity summaries, artifact sizes, and
+session-resume audit state. Older runs without these fields load with
+`legacy_unknown` or `null` defaults.
 
 ## Operational Notes
 

--- a/docs/development/mcp-tooling.md
+++ b/docs/development/mcp-tooling.md
@@ -142,6 +142,9 @@ daemon socket is not already responding. For manual lifecycle checks, use:
 ```bash
 just orchestrator-doctor
 just orchestrator-status
+just orchestrator-status --verbose
+just orchestrator-runs
+just orchestrator-watch
 just orchestrator-start
 just orchestrator-restart
 just orchestrator-stop

--- a/justfile
+++ b/justfile
@@ -48,9 +48,17 @@ orchestrator-help: orchestrator-build
 orchestrator-doctor: orchestrator-build
     node dist/cli.js doctor
 
-# Show the current daemon status.
-orchestrator-status: orchestrator-build
-    node dist/daemonCli.js status
+# Show the current daemon status. Pass --verbose or --json for observability output.
+orchestrator-status *args: orchestrator-build
+    node dist/daemonCli.js status {{args}}
+
+# Show session and run observability output.
+orchestrator-runs *args: orchestrator-build
+    node dist/daemonCli.js runs {{args}}
+
+# Open the interactive terminal observability dashboard.
+orchestrator-watch *args: orchestrator-build
+    node dist/daemonCli.js watch {{args}}
 
 # Explicitly start the daemon. MCP clients also auto-start it via node dist/cli.js.
 orchestrator-start: orchestrator-build

--- a/plans/4-add-observability/plan.md
+++ b/plans/4-add-observability/plan.md
@@ -1,0 +1,10 @@
+# Plan Index
+
+Branch: `4-add-observability`
+Updated: 2026-05-02
+
+## Sub-Plans
+
+| Plan | Scope | Status | File |
+|---|---|---|---|
+| Observability Snapshot And Terminal Dashboard | Add a shared observability snapshot, MCP access, and human CLI views including an interactive persistent watch dashboard. | implementation complete; verified | `plans/4-add-observability/plans/4-observability-dashboard.md` |

--- a/plans/4-add-observability/plans/4-observability-dashboard.md
+++ b/plans/4-add-observability/plans/4-observability-dashboard.md
@@ -184,5 +184,5 @@ Existing architecture already has durable run metadata, event logs, stdout/stder
 ### OBS-9: Verify affected checks
 
 - **Status:** complete
-- **Evidence:** `pnpm build` passed. `pnpm test` passed with 52 tests across 14 suites. `git diff --check` passed.
+- **Evidence:** `pnpm build` passed. `pnpm test` passed with 70 tests total, 69 passed and 1 skipped. `git diff --check` passed.
 - **Notes:** Hardening pass addressed prompt creation atomicity, event-summary refresh cost, MCP tool registration tests, CLI formatter tests, full prompt history counts under limited snapshots, and observed model mismatch warnings.

--- a/plans/4-add-observability/plans/4-observability-dashboard.md
+++ b/plans/4-add-observability/plans/4-observability-dashboard.md
@@ -1,0 +1,188 @@
+# Observability Snapshot And Terminal Dashboard
+
+Branch: `4-add-observability`
+Plan Slug: `observability-dashboard`
+Parent Issue: #4
+Created: 2026-05-02
+Status: implementation complete; verified
+
+## Context
+
+Issue #4 asks for a way to see whether the orchestrator is healthy, which models are being used, which sessions are running, how large runs are, what they are about, the last interaction, and whether follow-ups resume existing backend sessions instead of starting new sessions.
+
+Sources read:
+
+- `AGENTS.md`
+- `.agents/rules/node-typescript.md`
+- `.agents/rules/mcp-tool-configs.md`
+- `.agents/rules/ai-workspace-projections.md`
+- GitHub issue #4 and issue comments
+- `package.json`
+- `README.md`
+- `docs/development/mcp-tooling.md`
+- `src/contract.ts`
+- `src/orchestratorService.ts`
+- `src/runStore.ts`
+- `src/processManager.ts`
+- `src/server.ts`
+- `src/cli.ts`
+- `src/daemon/daemonCli.ts`
+- `src/daemon/daemonMain.ts`
+- `src/daemon/paths.ts`
+- `src/diagnostics.ts`
+- `src/toolTimeout.ts`
+- `src/backend/WorkerBackend.ts`
+- `src/backend/codex.ts`
+- `src/backend/claude.ts`
+- `src/backend/resultDerivation.ts`
+- `src/__tests__/contract.test.ts`
+- `src/__tests__/runStore.test.ts`
+- `src/__tests__/diagnostics.test.ts`
+- `src/__tests__/integration/orchestrator.test.ts`
+
+Existing architecture already has durable run metadata, event logs, stdout/stderr artifacts, MCP run tools, backend diagnostics, and daemon lifecycle commands. The missing layer is a user-oriented summary that derives operational status, activity, size, model, and session-resume signals from those primitives.
+
+## Decisions
+
+| # | Decision | Choice | Rationale | Rejected Alternatives |
+|---|---|---|---|---|
+| 1 | Primary display | Terminal-first observability with a persistent `watch` dashboard mode. | Fits the existing daemon CLI, works over SSH, avoids browser security and dependency complexity, and directly answers the request to leave a dashboard open. | Web dashboard as the first slice; raw run-store docs only. |
+| 2 | Data source | Create one shared observability snapshot contract used by CLI, watch mode, and MCP. | Keeps human and agent views consistent and testable. | Build CLI formatting directly from ad hoc store reads; separate MCP and CLI data models. |
+| 3 | Dashboard interaction | Implement `watch` as an interactive terminal dashboard with periodic snapshot polling, arrow-key navigation, Enter-to-open run details, Backspace/Escape-to-return, and `q` to quit. | Gives users a leave-open dashboard and a way to dive into active runs without introducing a browser server or UI dependency. | Static refresh-only watch mode; streaming IPC subscriptions; curses-style dependency; web sockets. |
+| 4 | Backend diagnostics in watch mode | Keep expensive backend diagnostics out of the default refresh path; allow explicit `--diagnostics` for one-shot or slow refresh use. | Current diagnostics shell out to backend CLIs and should not run every dashboard tick by default. | Always run `getBackendStatus()` on every refresh. |
+| 5 | Raw prompt visibility | Persist raw start/follow-up prompts in each private run directory and show them in run detail views. | Users explicitly need to inspect what was asked of each agent. The existing run store is local, user-owned, and permission-restricted, so this fits the package's trusted-local model. | Only derive safe topics from metadata; omit prompts from observability entirely. |
+| 6 | Model visibility | Add additive model/source metadata where needed and display `model` plus source: explicit, inherited, backend default/unknown, or legacy unknown. | The issue explicitly asks to verify model usage; requested model and inheritance must be distinguishable. | Only show the current nullable `model` field. |
+| 7 | Session resume visibility | Add additive requested/observed session tracking and warnings for mismatches. | Current `session_id` is enough to resume, but it cannot prove whether a follow-up emitted the same backend session because follow-up runs start with `session_id` already set. | Infer resume correctness from parent/child links only. |
+| 8 | Size indicators | Show event count and artifact byte sizes for `events.jsonl`, `stdout.log`, `stderr.log`, and `result.json`; treat token/context sizes as opportunistic only when backend events expose them. | These sizes are available today and useful for detecting runaway runs. Token counts are not guaranteed across Codex and Claude streams. | Promise exact model context/token size in v1. |
+| 9 | Public API stability | Add new fields/tools/methods without changing existing tool behavior. | Keeps package behavior stable while expanding observability. | Rename or repurpose existing `list_runs`/`get_run_status` responses. |
+| 10 | TUI implementation style | Use Node built-ins for raw-mode key handling and ANSI rendering. | Avoids dependency changes and keeps the package aligned with the repository's plain TypeScript style. | Add Ink/Blessed/curses dependency in the first slice. |
+| 11 | Human-readable metadata | Standardize display metadata from `metadata.title`, `metadata.summary`, `metadata.session_title`, `metadata.session_summary`, `metadata.prompt_title`, and `metadata.prompt_summary`, with raw-prompt fallbacks when fields are missing. | Gives each prompt/run a readable title and summary while letting supervisors provide better labels without changing existing MCP input shape. | Add many new top-level input fields; require a model call to generate summaries. |
+| 12 | Session summaries | Derive session groups from backend session IDs and parent/child run chains, then show per-session prompt history with updated prompt titles, summaries, statuses, models, and last activity. | Users need to understand what is happening across an entire resumed session, not just isolated run IDs. | Treat every run as independent in the dashboard. |
+
+## Scope
+
+### In Scope
+
+- Add a typed observability snapshot schema and RPC/MCP method.
+- Add run activity summaries: last event, last interaction preview, event count, artifact sizes, duration, and recent error count.
+- Persist raw prompts for start and follow-up runs as private run artifacts.
+- Add standardized human-readable display metadata for sessions and individual prompts/runs.
+- Add session-level grouping with updated summaries of prompts in each session.
+- Add model visibility with source information where the orchestrator can know it.
+- Add requested and observed backend session IDs for resume auditing.
+- Add terminal CLI observability commands, including a persistent watch/dashboard mode.
+- Add interactive terminal navigation for the dashboard: session list, run/prompt list, detail view, raw prompt, recent events, and artifact paths.
+- Add JSON output for scriptable CLI observability commands.
+- Update README usage and MCP tool documentation.
+- Add focused tests for contract schema, store-derived snapshot data, resume/session metadata, CLI formatting, and MCP registration.
+
+### Out Of Scope
+
+- Browser/web dashboard.
+- Authentication, permissions, or secret handling changes.
+- Persisting non-prompt secret-bearing request bodies or environment data.
+- Exact token/context-size accounting unless already present in backend event payloads.
+- Changing follow-up session selection behavior based on observed session mismatches.
+- Cross-worktree isolation or concurrent edit prevention.
+
+## Risks And Edge Cases
+
+| # | Scenario | Mitigation | Covered By |
+|---|---|---|---|
+| 1 | Large event logs make dashboard refresh slow. | Use sequence files and tail-oriented reads where possible; allow `--limit`; avoid loading stdout/stderr contents. | RunStore/observability tests with many events. |
+| 2 | Backend diagnostics are too expensive for frequent watch refreshes. | Do not run diagnostics by default in watch mode; add explicit opt-in. | CLI tests and docs. |
+| 3 | Terminal output flickers or unreadable on narrow terminals. | Use plain, compact tables; clear/repaint only when TTY; fall back to repeated snapshots when not TTY. | CLI formatter tests plus manual smoke. |
+| 4 | Existing runs lack new metadata fields. | Add schema defaults such as `unknown`/`null` and derive best-effort warnings. | Contract backward-compat tests. |
+| 5 | Follow-up backend emits a different session ID. | Record observed session separately and show a warning without changing resume behavior. | Integration test with mock CLI session mismatch. |
+| 6 | Prompt-derived topic leaks sensitive data in list views. | Keep raw prompts in detail views and explicit JSON/detail payloads; use compact prompt previews or metadata titles in list views. | Formatter tests and docs review. |
+| 7 | Daemon stopped while dashboard is open. | Show stopped/unavailable state and retry on next refresh. | CLI watch helper tests or manual smoke. |
+| 8 | MCP contract drift after adding a new tool. | Update `RpcMethodSchema`, server tool list, README table, and tests in one change. | Contract and MCP registration tests. |
+| 9 | Raw-mode terminal is left in a bad state after errors or Ctrl-C. | Centralize TTY setup/cleanup and restore raw mode/cursor state in `finally` and signal handlers. | TUI helper tests plus manual smoke. |
+| 10 | Detail view leaks too much raw event data. | Show bounded recent events and previews by default; expose artifact paths for full stdout/stderr/events inspection. | Formatter tests and docs. |
+| 11 | Raw prompts can contain secrets or sensitive instructions. | Store prompts only in the existing `0700`/`0600` run store, show them intentionally in detail views, document the behavior clearly, and do not include environment variables or other secret-bearing process data. | Store permission tests, docs review, and formatter tests. |
+| 12 | A run has no observed backend session ID yet. | Group it under its root run chain until the backend reports a session ID, then present the canonical session ID when available. | Snapshot derivation tests for pre-session and post-session runs. |
+| 13 | Human metadata is missing or inconsistent across follow-ups. | Use run metadata when present; inherit session title/summary from parent/root when absent; fall back to raw prompt first line and run ID. | Metadata derivation tests. |
+
+## Implementation Tasks
+
+| Task ID | Title | Depends On | Status | Acceptance Criteria |
+|---|---|---|---|---|
+| OBS-1 | Define observability contract | none | implemented; verified | `src/contract.ts` includes additive schemas/types for snapshot input/output, model source, session audit state, prompt metadata, session metadata, artifact sizes, and run activity; older run summaries parse with defaults; no existing tool response contracts are broken. |
+| OBS-2 | Record prompts, display metadata, model source, and session audit metadata | OBS-1 | implemented; verified | `startRun` and `sendFollowup` persist raw prompts in private per-run artifacts; run metadata is normalized into prompt/run title, prompt/run summary, session title, and session summary fields; `startRun` records explicit vs backend-default model source; `sendFollowup` records explicit vs inherited/default model source; process event parsing records observed backend session ID separately from requested session ID; mismatches are representable without changing existing `session_id` behavior. |
+| OBS-3 | Add store-derived observability snapshot builder | OBS-1, OBS-2 | implemented; verified | A module derives run summaries and session summaries with last event/activity, duration, event count, artifact byte sizes, raw prompt/detail prompt preview, prompt title/summary, session title/summary, per-session prompt history, recent errors, model display, and session warnings from `RunStore`; it handles missing/legacy files gracefully. |
+| OBS-4 | Expose snapshot through daemon RPC and MCP | OBS-3 | implemented; verified | `get_observability_snapshot` is added to `RpcMethodSchema`, `OrchestratorService.dispatch`, `src/server.ts`, timeout handling as needed, and README MCP tool docs; MCP response uses the standard `{ ok: true }`/`{ ok: false }` envelope. |
+| OBS-5 | Add human CLI commands and JSON output | OBS-4 | implemented; verified | CLI supports compact session/run/status views and `--json`; commands show daemon state, active sessions, active prompts/runs, prompt titles/summaries, model/source, session audit state, last activity, size, and recent errors; stopped daemon state is handled cleanly. |
+| OBS-6 | Add interactive terminal dashboard mode | OBS-5 | implemented; verified | A `watch` command repeatedly refreshes the snapshot, supports interval and limit options, can be left open, handles Ctrl-C, supports arrow-key selection across sessions and prompts, Enter opens a run detail view with the raw prompt and recent activity, Backspace/Escape returns to the previous list, `q` exits, and stdout falls back sensibly when not a TTY. |
+| OBS-7 | Update docs and examples | OBS-5, OBS-6 | implemented; verified | README documents observability commands, dashboard mode, JSON output, raw prompt storage/visibility, metadata fields for session/prompt titles and summaries, and model/session interpretation. |
+| OBS-8 | Add focused tests | OBS-1, OBS-2, OBS-3, OBS-4, OBS-5 | implemented; verified | Tests cover schema defaults, prompt persistence, prompt write failure atomicity, display metadata, session grouping, full session history counts under detail limits, observed model mismatch warnings, snapshot derivation, artifact sizing, model inheritance, observed session mismatch recording, lightweight event summaries, MCP tool registration, and CLI formatter behavior. |
+| OBS-9 | Verify affected checks | OBS-8 | complete | `pnpm build` passes; `pnpm test` passes; `git diff --check` passes. |
+
+## Rule Candidates
+
+| # | Candidate | Scope | Create After |
+|---|---|---|---|
+| 1 | Raw prompt observability must be documented and stored only in the private run store. | Repository observability/privacy convention. | After OBS-7 if this pattern becomes a recurring design rule. |
+
+## Quality Gates
+
+- [x] `pnpm build` passes.
+- [x] `pnpm test` passes.
+- [x] Relevant `.agents/rules/` checks are satisfied.
+- [x] `git diff --check` passes.
+- [ ] `pnpm verify` passes before release-quality handoff or PR if requested.
+
+## Execution Log
+
+### OBS-1: Define observability contract
+
+- **Status:** implemented; verified
+- **Evidence:** Added additive schemas/types in `src/contract.ts` for model source, run display metadata, observability snapshots, session audit state, prompt/activity/artifact/session summaries, and `get_observability_snapshot`.
+- **Notes:** Backward-compatible defaults are covered by source tests and `pnpm build`/`pnpm test` pass.
+
+### OBS-2: Record prompts, display metadata, model source, and session audit metadata
+
+- **Status:** implemented; verified
+- **Evidence:** Updated `src/runStore.ts`, `src/orchestratorService.ts`, and `src/processManager.ts` to write `prompt.txt` during run creation, persist display metadata/model source/requested session ID, and record observed backend session IDs from worker events.
+- **Notes:** `send_followup` now accepts additive `metadata` for per-prompt titles/summaries and inherits session display fields from the parent. Run metadata is written last so a prompt write failure does not publish a durable `running` run without its raw prompt.
+
+### OBS-3: Add store-derived observability snapshot builder
+
+- **Status:** implemented; verified
+- **Evidence:** Added `src/observability.ts` to derive sessions, runs, prompts, model/source data, session audit warnings, artifact sizes, durations, recent events, and recent errors from `RunStore`.
+- **Notes:** Snapshot builder reads prompt previews by default and includes full raw prompt text only when requested. Dashboard snapshots now use `RunStore.readEventSummary()` so refreshes avoid loading full event logs for visible runs. Session prompt counts are derived from the full run metadata set even when detailed runs are limited.
+
+### OBS-4: Expose snapshot through daemon RPC and MCP
+
+- **Status:** implemented; verified
+- **Evidence:** Added `get_observability_snapshot` to `RpcMethodSchema`, `OrchestratorService.dispatch`, and `src/server.ts`; updated `send_followup` MCP schema with additive `metadata`; extracted MCP tool definitions to `src/mcpTools.ts`.
+- **Notes:** Snapshot uses the existing standard tool response envelope and has focused registration coverage in `src/__tests__/mcpTools.test.ts`.
+
+### OBS-5: Add human CLI commands and JSON output
+
+- **Status:** implemented; verified
+- **Evidence:** Updated `src/daemon/daemonCli.ts` with `status --verbose`, `runs`, `runs --json`, `--prompts`, and local-store fallback when the daemon is stopped; extracted formatter helpers to `src/daemon/observabilityFormat.ts`.
+- **Notes:** `src/cli.ts` help and `justfile` development recipes now include the new observability commands. Formatter behavior is covered by `src/__tests__/observabilityFormat.test.ts`.
+
+### OBS-6: Add interactive terminal dashboard mode
+
+- **Status:** implemented; verified
+- **Evidence:** Added `agent-orchestrator-mcp-daemon watch` with periodic snapshot polling, raw-mode arrow navigation, Enter detail drill-down, Backspace/Escape return, `q` exit, and non-TTY fallback.
+- **Notes:** Implementation uses Node built-ins and ANSI output only.
+
+### OBS-7: Update docs and examples
+
+- **Status:** implemented; verified
+- **Evidence:** Updated `README.md` with observability commands, raw prompt storage behavior, metadata fields, session grouping semantics, and MCP tool docs; updated `docs/development/mcp-tooling.md`.
+- **Notes:** Docs explicitly warn that raw prompts are stored in the private run store.
+
+### OBS-8: Add focused tests
+
+- **Status:** implemented; verified
+- **Evidence:** Updated `src/__tests__/contract.test.ts`, `src/__tests__/runStore.test.ts`, and `src/__tests__/integration/orchestrator.test.ts`; added `src/__tests__/observability.test.ts`, `src/__tests__/mcpTools.test.ts`, and `src/__tests__/observabilityFormat.test.ts`.
+- **Notes:** Tests cover schema defaults, prompt persistence, prompt write failure atomicity, display metadata, session grouping, full session history counts under detail limits, observed model mismatch warnings, snapshot derivation, artifact sizing, model inheritance, observed session mismatch recording, lightweight event summaries, MCP tool registration, and CLI formatter behavior.
+
+### OBS-9: Verify affected checks
+
+- **Status:** complete
+- **Evidence:** `pnpm build` passed. `pnpm test` passed with 52 tests across 14 suites. `git diff --check` passed.
+- **Notes:** Hardening pass addressed prompt creation atomicity, event-summary refresh cost, MCP tool registration tests, CLI formatter tests, full prompt history counts under limited snapshots, and observed model mismatch warnings.

--- a/plans/4-add-observability/resolution-map.md
+++ b/plans/4-add-observability/resolution-map.md
@@ -1,0 +1,92 @@
+# PR #12 Resolution Map
+
+Branch: `4-add-observability`
+Created: 2026-05-02
+Total comments: 5 | Fixed: 5 | To defer: 0 | To decline: 0 | To escalate: 0
+
+## Comment 1 | fixed | minor
+
+- **Comment Type:** review-inline
+- **File:** `plans/4-add-observability/plans/4-observability-dashboard.md:188`
+- **Comment ID:** `discussion_r3176428857`
+- **Review ID:** `4214779327`
+- **Thread Node ID:** unavailable
+- **Author:** `coderabbitai[bot]`
+- **Comment:** Update the recorded `pnpm test` evidence. Line 187 still says `pnpm test` passed with `52 tests across 14 suites`, but the PR verification section for this branch now records `69 passed, 1 skipped`.
+- **Independent Assessment:** Valid. The final local verification after the stale-daemon fix ran `pnpm test` with 70 tests: 69 passed and 1 skipped. The plan artifact still records older evidence and should match the current branch state.
+- **Decision:** fix-as-suggested
+- **Approach:** Update the OBS-9 execution log evidence to record `pnpm test` as 69 passed and 1 skipped. Keep the existing build and diff-check evidence.
+- **Files To Change:** `plans/4-add-observability/plans/4-observability-dashboard.md`
+- **Reply Draft:**
+  > **[AI Agent]:** Fixed. The plan evidence now reflects the latest `pnpm test` result: 69 passed and 1 skipped. <!-- agent-orchestrator:pr12:c1 -->
+
+## Comment 2 | fixed | minor
+
+- **Comment Type:** review-inline
+- **File:** `src/cli.ts:28`
+- **Comment ID:** `discussion_r3176428859`
+- **Review ID:** `4214779327`
+- **Thread Node ID:** unavailable
+- **Author:** `coderabbitai[bot]`
+- **Comment:** Document `status --json` in the top-level help.
+- **Independent Assessment:** Valid. `src/daemon/daemonCli.ts` supports `status --json`, and the top-level CLI help advertises `status --verbose` but not the JSON form.
+- **Decision:** fix-as-suggested
+- **Approach:** Add `agent-orchestrator-mcp-daemon status --json` to the daemon lifecycle help block in `src/cli.ts`. Update the CLI help test if needed.
+- **Files To Change:** `src/cli.ts`, `src/__tests__/daemonCli.test.ts`
+- **Reply Draft:**
+  > **[AI Agent]:** Fixed. Top-level help now advertises `agent-orchestrator-mcp-daemon status --json`, and the help test asserts it. <!-- agent-orchestrator:pr12:c2 -->
+
+## Comment 3 | fixed | minor
+
+- **Comment Type:** review-body
+- **File:** `src/contract.ts:192`
+- **Comment ID:** `review-body-nitpick-1`
+- **Review ID:** `4214779327`
+- **Thread Node ID:** unavailable
+- **Author:** `coderabbitai[bot]`
+- **Comment:** Narrow `RunModelSettingsSchema` to the enum types, or explicitly document arbitrary persisted strings if intentional.
+- **Independent Assessment:** Valid. Runtime inputs already validate `reasoning_effort` and `service_tier` through `ReasoningEffortSchema` and `ServiceTierSchema`; keeping persisted settings as arbitrary strings weakens the shared contract without an explicit forward-compatibility decision.
+- **Decision:** fix-as-suggested
+- **Approach:** Change `RunModelSettingsSchema.reasoning_effort` to `ReasoningEffortSchema.nullable().optional().default(null)` and `service_tier` to `ServiceTierSchema.nullable().optional().default(null)`. Leave `mode` as string/null because it is an internal display mode currently set to `normal`.
+- **Files To Change:** `src/contract.ts`
+- **Reply Draft:**
+  > **[AI Agent]:** Fixed. `RunModelSettingsSchema` now uses the same `ReasoningEffortSchema` and `ServiceTierSchema` enums as the public inputs. <!-- agent-orchestrator:pr12:c3 -->
+
+## Comment 4 | fixed | minor
+
+- **Comment Type:** review-body
+- **File:** `src/__tests__/integration/orchestrator.test.ts:147`
+- **Comment ID:** `review-body-nitpick-2`
+- **Review ID:** `4214779327`
+- **Thread Node ID:** unavailable
+- **Author:** `coderabbitai[bot]`
+- **Comment:** Assert the specific validation failure instead of only `ok === false`.
+- **Independent Assessment:** Valid. The test currently proves the requests fail, but an unrelated error would still satisfy the assertions.
+- **Decision:** fix-as-suggested
+- **Approach:** Add a small assertion helper for failed tool responses and assert `INVALID_INPUT` plus the expected validation-message pattern for each rejected model-setting case.
+- **Files To Change:** `src/__tests__/integration/orchestrator.test.ts`
+- **Reply Draft:**
+  > **[AI Agent]:** Fixed. The model-setting validation test now asserts `INVALID_INPUT` and the expected message for each rejected case. <!-- agent-orchestrator:pr12:c4 -->
+
+## Comment 5 | fixed | minor
+
+- **Comment Type:** review-body
+- **File:** `src/__tests__/daemonCli.test.ts:48`
+- **Comment ID:** `review-body-nitpick-3`
+- **Review ID:** `4214779327`
+- **Thread Node ID:** unavailable
+- **Author:** `coderabbitai[bot]`
+- **Comment:** Add stale-daemon coverage for `watch` too.
+- **Independent Assessment:** Valid. In non-TTY mode, `watch` uses the same snapshot path and exits after one render; it is cheap to cover and directly exercises the stale-daemon dashboard surface.
+- **Decision:** fix-as-suggested
+- **Approach:** Extend the stale-daemon daemon CLI test to run `watch` under `execFile` and assert the mismatch error plus empty snapshot count.
+- **Files To Change:** `src/__tests__/daemonCli.test.ts`
+- **Reply Draft:**
+  > **[AI Agent]:** Fixed. The stale-daemon CLI test now covers non-TTY `watch` in addition to `runs` and `status --verbose`. <!-- agent-orchestrator:pr12:c5 -->
+
+## Verification
+
+- `pnpm build`
+- `node --test dist/__tests__/daemonCli.test.js dist/__tests__/contract.test.js dist/__tests__/integration/orchestrator.test.js`
+- `pnpm test` (70 tests total, 69 passed, 1 skipped)
+- `git diff --check`

--- a/plans/4-add-observability/reviews/review-2026-05-02-followup.md
+++ b/plans/4-add-observability/reviews/review-2026-05-02-followup.md
@@ -1,0 +1,46 @@
+# Review 2026-05-02 Follow-up
+
+Scope: uncommitted changes for issue #4 observability dashboard and model metadata.
+
+## Findings
+
+### P2 - Follow-ups after a session mismatch resume the stale requested session
+
+`sendFollowup` validates, records, and resumes with `parent.meta.session_id`.
+For resumed runs, `session_id` is prefilled with the requested session, while
+`observed_session_id` stores the backend-reported effective session. If a
+backend reports a different session after a resume or fork-like fallback, the
+dashboard groups the child under the observed session, but another follow-up
+from that child will still call `backend.resume(parent.meta.session_id, ...)`
+and branch back to the old chat instead of continuing the observed chat.
+
+Affected code:
+
+- `src/orchestratorService.ts:141` rejects follow-up when `session_id` is null
+  without considering `observed_session_id`.
+- `src/orchestratorService.ts:165` and `src/orchestratorService.ts:166` store
+  the next run's requested session from `parent.meta.session_id`.
+- `src/orchestratorService.ts:176` resumes `parent.meta.session_id`.
+
+Recommendation: derive a single `resumeSessionId` as
+`parent.meta.observed_session_id ?? parent.meta.session_id`, use it for the
+follow-up validity check, `requested_session_id`, initial `session_id`, and
+the backend resume call. Add a regression test where a parent has
+`session_id='session-1'` and `observed_session_id='session-2'`, then assert the
+next backend invocation resumes `session-2`.
+
+## Checks
+
+- Read the changed source, tests, docs, AGENTS instructions, and relevant rules.
+- Checked local CLI support with `codex exec --help`, `codex exec resume --help`,
+  and `claude --help`.
+- Ran `pnpm exec tsc --noEmit`.
+- Ran `git diff --check`.
+
+## Resolution
+
+Fixed after review. `sendFollowup` now derives the resume target from
+`parent.meta.observed_session_id ?? parent.meta.session_id` and uses that value
+for validation, `session_id`, `requested_session_id`, and the backend resume
+call. The integration test now covers a session mismatch followed by another
+follow-up and asserts the second follow-up resumes the observed session.

--- a/plans/4-add-observability/reviews/review-2026-05-02-merge.md
+++ b/plans/4-add-observability/reviews/review-2026-05-02-merge.md
@@ -1,0 +1,48 @@
+# Merge Commit Review: f632a00
+
+Date: 2026-05-02
+Branch: `4-add-observability`
+Scope: merge commit `f632a00fb11e1a45d4600e1e79ffc043d6ef04b8`
+
+## Finding
+
+### P2: Dashboard CLI does not apply the daemon version preflight
+
+`src/daemon/daemonCli.ts` uses `ping()` only as a boolean connectivity check
+before calling `get_observability_snapshot` for `runs`, `watch`, and
+`status --verbose/--json`. This path does not call `checkDaemonVersion`, unlike
+the MCP frontend in `src/server.ts`, so an old daemon that still responds to
+`ping` but does not expose the new dashboard method can still fail with a stale
+method/schema error instead of the structured `DAEMON_VERSION_MISMATCH` restart
+hint that the merged main branch introduced.
+
+Relevant locations:
+
+- `src/daemon/daemonCli.ts:98`
+- `src/daemon/daemonCli.ts:133`
+- `src/daemon/daemonCli.ts:142`
+- `src/daemon/daemonCli.ts:280`
+- `src/server.ts:95`
+- `src/daemonVersion.ts:8`
+
+Suggested fix: have the daemon CLI snapshot path request `ping`, run
+`checkDaemonVersion`, and either print a clear mismatch/restart message or
+return a snapshot envelope with the mismatch in `error`. Add a daemon CLI
+regression test for a ping-responsive stale daemon covering at least `runs` and
+`status --verbose`.
+
+Resolution: fixed after review. The dashboard snapshot path now checks
+`ping` with `checkDaemonVersion`, falls back to a local store snapshot on
+mismatch, and surfaces the structured restart message in the dashboard output.
+`src/__tests__/daemonCli.test.ts` covers stale-daemon `runs` and
+`status --verbose`.
+
+## Notes
+
+- The conflict resolutions correctly preserve Windows IPC usage through
+  `paths.ipc.path` in the daemon CLI and daemon main.
+- `processManager.ts` keeps Windows command-shim wrapping and cancellation while
+  preserving observability metadata such as `worker_invocation`, model settings,
+  and observed backend model/session IDs.
+- I did not run the full test suite during this review. The branch had already
+  passed `pnpm build` and `pnpm test` after the merge before push.

--- a/plans/4-add-observability/reviews/review-2026-05-02.md
+++ b/plans/4-add-observability/reviews/review-2026-05-02.md
@@ -1,0 +1,21 @@
+# Review 2026-05-02
+
+Scope: uncommitted changes for branch `4-add-observability`.
+
+## Findings
+
+1. `src/observability.ts:41` and `src/observability.ts:202` derive session prompt counts only from the globally limited run slice. The dashboard labels `PROMPTS` as history length, but `watch --limit 20` can show at most 20 prompts for a long session and can undercount older turns. Fix by deriving session counts from the full run metadata set or by renaming the column to make the limit explicit.
+
+2. `src/processManager.ts:161` to `src/processManager.ts:169` ignores observed model names whenever an explicit/requested model is already stored. If a backend reports a different effective model because of fallback or alias behavior, the dashboard still shows the requested model without any warning. Fix by persisting requested and observed model separately, or at least warning when the observed model differs from the stored explicit model.
+
+3. `plans/4-add-observability/plans/4-observability-dashboard.md:7` and `plans/4-add-observability/plans/4-observability-dashboard.md:126` to `plans/4-add-observability/plans/4-observability-dashboard.md:188` still say verification is blocked even though the branch has since been built and tested. Update the plan artifact before handoff so the recorded evidence matches the current state.
+
+## Verification
+
+Review-only pass. I did not rerun build or tests during this review.
+
+## Resolution
+
+- Fixed full prompt history counting under limited detailed snapshots.
+- Fixed observed model persistence and requested/observed mismatch warnings.
+- Updated plan verification evidence after `pnpm build`, `pnpm test`, and `git diff --check` passed.

--- a/src/__tests__/backendInvocation.test.ts
+++ b/src/__tests__/backendInvocation.test.ts
@@ -8,12 +8,22 @@ describe('backend invocations', () => {
     const backend = new CodexBackend();
 
     assert.deepStrictEqual(
-      (await backend.start({ prompt: 'work', cwd: '/repo', model: 'gpt-5.2' })).args,
-      ['exec', '--json', '--skip-git-repo-check', '--cd', '/repo', '--model', 'gpt-5.2', '-'],
+      (await backend.start({
+        prompt: 'work',
+        cwd: '/repo',
+        model: 'gpt-5.2',
+        modelSettings: { reasoning_effort: 'xhigh', service_tier: 'fast', mode: null },
+      })).args,
+      ['exec', '--json', '--skip-git-repo-check', '--cd', '/repo', '--model', 'gpt-5.2', '-c', 'model_reasoning_effort="xhigh"', '-c', 'service_tier="fast"', '-'],
     );
     assert.deepStrictEqual(
-      (await backend.resume('session-1', { prompt: 'continue', cwd: '/repo', model: 'gpt-5.4' })).args,
-      ['exec', 'resume', '--json', '--skip-git-repo-check', '--model', 'gpt-5.4', 'session-1', '-'],
+      (await backend.resume('session-1', {
+        prompt: 'continue',
+        cwd: '/repo',
+        model: 'gpt-5.4',
+        modelSettings: { reasoning_effort: 'medium', service_tier: null, mode: 'normal' },
+      })).args,
+      ['exec', 'resume', '--json', '--skip-git-repo-check', '--ignore-user-config', '--model', 'gpt-5.4', '-c', 'model_reasoning_effort="medium"', 'session-1', '-'],
     );
   });
 
@@ -21,12 +31,22 @@ describe('backend invocations', () => {
     const backend = new ClaudeBackend();
 
     assert.deepStrictEqual(
-      (await backend.start({ prompt: 'work', cwd: '/repo', model: 'sonnet' })).args,
-      ['-p', '--output-format', 'stream-json', '--verbose', '--model', 'sonnet'],
+      (await backend.start({
+        prompt: 'work',
+        cwd: '/repo',
+        model: 'claude-opus-4-7',
+        modelSettings: { reasoning_effort: 'xhigh', service_tier: null, mode: null },
+      })).args,
+      ['-p', '--output-format', 'stream-json', '--verbose', '--model', 'claude-opus-4-7', '--effort', 'xhigh'],
     );
     assert.deepStrictEqual(
-      (await backend.resume('session-1', { prompt: 'continue', cwd: '/repo', model: 'opus' })).args,
-      ['-p', '--resume', 'session-1', '--output-format', 'stream-json', '--verbose', '--model', 'opus'],
+      (await backend.resume('session-1', {
+        prompt: 'continue',
+        cwd: '/repo',
+        model: 'claude-opus-4-7[1m]',
+        modelSettings: { reasoning_effort: 'max', service_tier: null, mode: null },
+      })).args,
+      ['-p', '--resume', 'session-1', '--output-format', 'stream-json', '--verbose', '--model', 'claude-opus-4-7[1m]', '--effort', 'max'],
     );
   });
 });

--- a/src/__tests__/contract.test.ts
+++ b/src/__tests__/contract.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { BackendStatusReportSchema, WorkerResultSchema, RunSummarySchema, wrapErr, wrapOk, orchestratorError } from '../contract.js';
+import { BackendStatusReportSchema, ObservabilitySnapshotSchema, WorkerResultSchema, RunSummarySchema, wrapErr, wrapOk, orchestratorError } from '../contract.js';
 import { deriveObservedResult } from '../backend/resultDerivation.js';
 
 describe('contract schemas and envelopes', () => {
@@ -87,6 +87,132 @@ describe('contract schemas and envelopes', () => {
       metadata: {},
     });
     assert.equal(parsed.model, null);
+    assert.equal(parsed.model_source, 'legacy_unknown');
+    assert.deepStrictEqual(parsed.model_settings, { reasoning_effort: null, service_tier: null, mode: null });
+    assert.equal(parsed.worker_invocation, null);
+    assert.equal(parsed.requested_session_id, null);
+    assert.equal(parsed.observed_session_id, null);
+    assert.equal(parsed.observed_model, null);
+    assert.deepStrictEqual(parsed.display, {
+      session_title: null,
+      session_summary: null,
+      prompt_title: null,
+      prompt_summary: null,
+    });
+  });
+
+  it('accepts observability snapshots', () => {
+    ObservabilitySnapshotSchema.parse({
+      generated_at: new Date().toISOString(),
+      daemon_pid: 123,
+      store_root: '/tmp/store',
+      backend_status: null,
+      sessions: [{
+        session_key: 'codex:session-1',
+        session_id: 'session-1',
+        root_run_id: 'run-1',
+        backend: 'codex',
+        cwd: '/tmp/repo',
+        workspace: {
+          cwd: '/tmp/repo',
+          repository_root: '/tmp/repo',
+          repository_name: 'repo',
+          branch: 'main',
+          dirty_count: 0,
+          label: 'repo:main',
+        },
+        title: 'Implement feature',
+        summary: 'working on observability',
+        status: 'running',
+        created_at: new Date().toISOString(),
+        updated_at: new Date().toISOString(),
+        run_count: 1,
+        running_count: 1,
+        models: [{ name: 'gpt-5.2', source: 'explicit' }],
+        settings: [{ reasoning_effort: 'xhigh', service_tier: 'fast', mode: null }],
+        warnings: [],
+        prompts: [{
+          run_id: 'run-1',
+          status: 'running',
+          title: 'Implement feature',
+          summary: 'working on observability',
+          preview: 'raw prompt preview',
+          model: { name: 'gpt-5.2', source: 'explicit' },
+          settings: { reasoning_effort: 'xhigh', service_tier: 'fast', mode: null },
+          created_at: new Date().toISOString(),
+          last_activity_at: null,
+        }],
+      }],
+      runs: [{
+        run: {
+          run_id: 'run-1',
+          backend: 'codex',
+          status: 'running',
+          parent_run_id: null,
+          session_id: 'session-1',
+          model: 'gpt-5.2',
+          model_source: 'explicit',
+          requested_session_id: null,
+          observed_session_id: 'session-1',
+          observed_model: 'gpt-5.2',
+          display: {
+            session_title: 'Implement feature',
+            session_summary: 'working on observability',
+            prompt_title: 'Implement feature',
+            prompt_summary: 'working on observability',
+          },
+          cwd: '/tmp/repo',
+          created_at: new Date().toISOString(),
+          started_at: null,
+          finished_at: null,
+          worker_pid: null,
+          worker_pgid: null,
+          daemon_pid_at_spawn: null,
+          worker_invocation: {
+            command: '/usr/local/bin/codex',
+            args: ['exec', '--model', 'gpt-5.2', '-'],
+          },
+          git_snapshot_status: 'not_a_repo',
+          git_snapshot: null,
+          model_settings: { reasoning_effort: 'xhigh', service_tier: 'fast', mode: null },
+          metadata: {},
+        },
+        prompt: {
+          title: 'Implement feature',
+          summary: 'working on observability',
+          preview: 'raw prompt preview',
+          text: null,
+          path: '/tmp/store/runs/run-1/prompt.txt',
+          bytes: 18,
+        },
+        response: {
+          status: 'completed',
+          summary: 'Implemented feature',
+          path: '/tmp/store/runs/run-1/result.json',
+          bytes: 120,
+        },
+        model: { name: 'gpt-5.2', source: 'explicit', requested_name: 'gpt-5.2', observed_name: 'gpt-5.2' },
+        settings: { reasoning_effort: 'xhigh', service_tier: 'fast', mode: null },
+        session: {
+          requested_session_id: null,
+          observed_session_id: 'session-1',
+          effective_session_id: 'session-1',
+          status: 'new_session',
+          warnings: [],
+        },
+        activity: {
+          last_event_sequence: 0,
+          last_event_at: null,
+          last_event_type: null,
+          last_interaction_preview: null,
+          event_count: 0,
+          recent_errors: [],
+          recent_events: [],
+        },
+        artifacts: [{ name: 'prompt.txt', path: '/tmp/store/runs/run-1/prompt.txt', exists: true, bytes: 18 }],
+        duration_seconds: null,
+      }],
+    });
   });
 
   it('wraps ok and error envelopes', () => {

--- a/src/__tests__/daemonCli.test.ts
+++ b/src/__tests__/daemonCli.test.ts
@@ -74,6 +74,15 @@ describe('daemon CLI', () => {
       assert.match(staleStatus.stdout, /version_match=false/);
       assert.match(staleStatus.stdout, /runs=unavailable/);
 
+      const staleRuns = await execFileAsync(process.execPath, [daemonCliPath, 'runs'], { env, timeout: 10_000 });
+      assert.match(staleRuns.stdout, /agent-orchestrator daemon: running pid=/);
+      assert.match(staleRuns.stdout, /error: Frontend package version .* does not match daemon package version 0\.0\.0-stale/);
+      assert.match(staleRuns.stdout, /sessions: 0 runs: 0/);
+
+      const staleVerboseStatus = await execFileAsync(process.execPath, [daemonCliPath, 'status', '--verbose'], { env, timeout: 10_000 });
+      assert.match(staleVerboseStatus.stdout, /agent-orchestrator daemon: running pid=/);
+      assert.match(staleVerboseStatus.stdout, /error: Frontend package version .* does not match daemon package version 0\.0\.0-stale/);
+
       const restart = await execFileAsync(process.execPath, [daemonCliPath, 'restart'], { env, timeout: 10_000 });
       assert.match(restart.stdout, /agent-orchestrator daemon stopping/);
       assert.match(restart.stdout, /agent-orchestrator daemon started pid=/);

--- a/src/__tests__/daemonCli.test.ts
+++ b/src/__tests__/daemonCli.test.ts
@@ -19,6 +19,7 @@ describe('daemon CLI', () => {
     const result = await execFileAsync(process.execPath, [cliPath, '--help'], { timeout: 5_000 });
 
     assert.match(result.stdout, /agent-orchestrator-mcp-daemon restart \[--force\]/);
+    assert.match(result.stdout, /agent-orchestrator-mcp-daemon status --json/);
     assert.match(result.stdout, /agent-orchestrator-mcp-daemon runs \[--json\] \[--prompts\]/);
     assert.match(result.stdout, /agent-orchestrator-mcp-daemon watch \[--interval-ms <ms>\] \[--limit <n>\]/);
   });
@@ -82,6 +83,11 @@ describe('daemon CLI', () => {
       const staleVerboseStatus = await execFileAsync(process.execPath, [daemonCliPath, 'status', '--verbose'], { env, timeout: 10_000 });
       assert.match(staleVerboseStatus.stdout, /agent-orchestrator daemon: running pid=/);
       assert.match(staleVerboseStatus.stdout, /error: Frontend package version .* does not match daemon package version 0\.0\.0-stale/);
+
+      const staleWatch = await execFileAsync(process.execPath, [daemonCliPath, 'watch'], { env, timeout: 10_000 });
+      assert.match(staleWatch.stdout, /agent-orchestrator daemon: running pid=/);
+      assert.match(staleWatch.stdout, /error: Frontend package version .* does not match daemon package version 0\.0\.0-stale/);
+      assert.match(staleWatch.stdout, /sessions: 0 runs: 0/);
 
       const restart = await execFileAsync(process.execPath, [daemonCliPath, 'restart'], { env, timeout: 10_000 });
       assert.match(restart.stdout, /agent-orchestrator daemon stopping/);

--- a/src/__tests__/gitSnapshot.test.ts
+++ b/src/__tests__/gitSnapshot.test.ts
@@ -64,6 +64,8 @@ process.exit(1);
     const capture = await captureGitSnapshot(repo);
     assert.equal(capture.status, 'captured');
     assert.ok(capture.snapshot);
+    assert.equal(capture.snapshot.root, repo);
+    assert.equal(capture.snapshot.branch, (await execFileAsync('git', ['branch', '--show-current'], { cwd: repo })).stdout.trim() || null);
 
     await writeFile(join(repo, 'tracked.txt'), 'dirty after\n');
     await writeFile(join(repo, 'untracked.txt'), 'untracked after\n');

--- a/src/__tests__/integration/orchestrator.test.ts
+++ b/src/__tests__/integration/orchestrator.test.ts
@@ -80,15 +80,36 @@ describe('agent orchestrator integration with mock CLIs', () => {
     const repo = await createGitRepo(fixture.root);
     const service = await createService(fixture.home);
 
-    const start = await service.startRun({ backend: 'codex', prompt: 'hello', cwd: repo, model: 'gpt-5.2' });
+    const start = await service.startRun({
+      backend: 'codex',
+      prompt: 'hello',
+      cwd: repo,
+      model: 'gpt-5.2',
+      reasoning_effort: 'xhigh',
+      service_tier: 'fast',
+      metadata: {
+        session_title: 'Model session',
+        prompt_title: 'Initial model prompt',
+      },
+    });
     const parentId = start.ok ? (start as unknown as { run_id: string }).run_id : '';
     await service.waitForRun({ run_id: parentId, wait_seconds: 5 });
 
-    const inherited = await service.sendFollowup({ run_id: parentId, prompt: 'follow up' });
+    const inherited = await service.sendFollowup({
+      run_id: parentId,
+      prompt: 'follow up',
+      metadata: { prompt_title: 'Inherited model prompt' },
+    });
     const inheritedId = inherited.ok ? (inherited as unknown as { run_id: string }).run_id : '';
     await service.waitForRun({ run_id: inheritedId, wait_seconds: 5 });
 
-    const overridden = await service.sendFollowup({ run_id: parentId, prompt: 'follow up override', model: 'gpt-5.4' });
+    const overridden = await service.sendFollowup({
+      run_id: parentId,
+      prompt: 'follow up override',
+      model: 'gpt-5.4',
+      reasoning_effort: 'medium',
+      service_tier: 'normal',
+    });
     const overriddenId = overridden.ok ? (overridden as unknown as { run_id: string }).run_id : '';
     await service.waitForRun({ run_id: overriddenId, wait_seconds: 5 });
 
@@ -98,11 +119,135 @@ describe('agent orchestrator integration with mock CLIs', () => {
     assert.equal(parent.ok && (parent as unknown as { run_summary: { model: string } }).run_summary.model, 'gpt-5.2');
     assert.equal(childInherited.ok && (childInherited as unknown as { run_summary: { model: string } }).run_summary.model, 'gpt-5.2');
     assert.equal(childOverridden.ok && (childOverridden as unknown as { run_summary: { model: string } }).run_summary.model, 'gpt-5.4');
+    assert.equal(parent.ok && (parent as unknown as { run_summary: { model_source: string; display: { session_title: string; prompt_title: string }; observed_session_id: string } }).run_summary.model_source, 'explicit');
+    assert.equal(childInherited.ok && (childInherited as unknown as { run_summary: { model_source: string; requested_session_id: string; display: { session_title: string; prompt_title: string } } }).run_summary.model_source, 'inherited');
+    assert.equal(childInherited.ok && (childInherited as unknown as { run_summary: { requested_session_id: string } }).run_summary.requested_session_id, 'codex-session-1');
+    assert.deepStrictEqual(parent.ok && (parent as unknown as { run_summary: { model_settings: unknown } }).run_summary.model_settings, { reasoning_effort: 'xhigh', service_tier: 'fast', mode: null });
+    assert.deepStrictEqual(childInherited.ok && (childInherited as unknown as { run_summary: { model_settings: unknown } }).run_summary.model_settings, { reasoning_effort: 'xhigh', service_tier: 'fast', mode: null });
+    assert.deepStrictEqual(childOverridden.ok && (childOverridden as unknown as { run_summary: { model_settings: unknown } }).run_summary.model_settings, { reasoning_effort: 'medium', service_tier: null, mode: 'normal' });
+    assert.deepStrictEqual(
+      parent.ok && (parent as unknown as { run_summary: { worker_invocation: { args: string[] } } }).run_summary.worker_invocation.args,
+      ['exec', '--json', '--skip-git-repo-check', '--cd', repo, '--model', 'gpt-5.2', '-c', 'model_reasoning_effort="xhigh"', '-c', 'service_tier="fast"', '-'],
+    );
+    assert.equal(parent.ok && (parent as unknown as { run_summary: { display: { session_title: string; prompt_title: string } } }).run_summary.display.session_title, 'Model session');
+    assert.equal(childInherited.ok && (childInherited as unknown as { run_summary: { display: { session_title: string; prompt_title: string } } }).run_summary.display.prompt_title, 'Inherited model prompt');
+    assert.equal(await service.store.readPrompt(parentId), 'hello');
 
     const args = await readJsonLines<string[]>(join(repo, 'codex-args.jsonl'));
-    assert.deepStrictEqual(args[0], ['exec', '--json', '--skip-git-repo-check', '--cd', repo, '--model', 'gpt-5.2', '-']);
-    assert.deepStrictEqual(args[1], ['exec', 'resume', '--json', '--skip-git-repo-check', '--model', 'gpt-5.2', 'codex-session-1', '-']);
-    assert.deepStrictEqual(args[2], ['exec', 'resume', '--json', '--skip-git-repo-check', '--model', 'gpt-5.4', 'codex-session-1', '-']);
+    assert.deepStrictEqual(args[0], ['exec', '--json', '--skip-git-repo-check', '--cd', repo, '--model', 'gpt-5.2', '-c', 'model_reasoning_effort="xhigh"', '-c', 'service_tier="fast"', '-']);
+    assert.deepStrictEqual(args[1], ['exec', 'resume', '--json', '--skip-git-repo-check', '--model', 'gpt-5.2', '-c', 'model_reasoning_effort="xhigh"', '-c', 'service_tier="fast"', 'codex-session-1', '-']);
+    assert.deepStrictEqual(args[2], ['exec', 'resume', '--json', '--skip-git-repo-check', '--ignore-user-config', '--model', 'gpt-5.4', '-c', 'model_reasoning_effort="medium"', 'codex-session-1', '-']);
+  });
+
+  it('rejects model settings that a backend cannot apply', async () => {
+    const fixture = await createFixture();
+    const repo = await createGitRepo(fixture.root);
+    const service = await createService(fixture.home);
+
+    const claudeTier = await service.startRun({
+      backend: 'claude',
+      prompt: 'hello',
+      cwd: repo,
+      model: 'claude-opus-4-7',
+      service_tier: 'fast',
+    });
+    assert.equal(claudeTier.ok, false);
+
+    const claudeAlias = await service.startRun({
+      backend: 'claude',
+      prompt: 'hello',
+      cwd: repo,
+      model: 'opus',
+    });
+    assert.equal(claudeAlias.ok, false);
+
+    const claudeUnknownEffortModel = await service.startRun({
+      backend: 'claude',
+      prompt: 'hello',
+      cwd: repo,
+      model: 'claude-sonnet-4-5',
+      reasoning_effort: 'high',
+    });
+    assert.equal(claudeUnknownEffortModel.ok, false);
+
+    const claudeXhighFallback = await service.startRun({
+      backend: 'claude',
+      prompt: 'hello',
+      cwd: repo,
+      model: 'claude-sonnet-4-6',
+      reasoning_effort: 'xhigh',
+    });
+    assert.equal(claudeXhighFallback.ok, false);
+
+    const claudeMax = await service.startRun({
+      backend: 'claude',
+      prompt: 'hello',
+      cwd: repo,
+      model: 'claude-opus-4-7',
+      reasoning_effort: 'max',
+    });
+    assert.equal(claudeMax.ok, true);
+    if (claudeMax.ok) {
+      await service.waitForRun({ run_id: (claudeMax as unknown as { run_id: string }).run_id, wait_seconds: 5 });
+    }
+
+    const codexMax = await service.startRun({
+      backend: 'codex',
+      prompt: 'hello',
+      cwd: repo,
+      model: 'gpt-5.5',
+      reasoning_effort: 'max',
+    });
+    assert.equal(codexMax.ok, false);
+  });
+
+  it('records requested and observed backend session ids separately for resume auditing', async () => {
+    const fixture = await createFixture();
+    const repo = await createGitRepo(fixture.root);
+    const service = await createService(fixture.home);
+
+    const start = await service.startRun({ backend: 'claude', prompt: 'hello', cwd: repo });
+    const parentId = start.ok ? (start as unknown as { run_id: string }).run_id : '';
+    await service.waitForRun({ run_id: parentId, wait_seconds: 5 });
+
+    const follow = await service.sendFollowup({ run_id: parentId, prompt: 'session-mismatch' });
+    const childId = follow.ok ? (follow as unknown as { run_id: string }).run_id : '';
+    await service.waitForRun({ run_id: childId, wait_seconds: 5 });
+
+    const child = await service.getRunStatus({ run_id: childId });
+    assert.equal(child.ok, true);
+    const summary = child.ok ? (child as unknown as {
+      run_summary: {
+        session_id: string;
+        requested_session_id: string;
+        observed_session_id: string;
+      };
+    }).run_summary : null;
+    assert.equal(summary?.session_id, 'claude-session-1');
+    assert.equal(summary?.requested_session_id, 'claude-session-1');
+    assert.equal(summary?.observed_session_id, 'claude-session-mismatch');
+
+    const followObserved = await service.sendFollowup({ run_id: childId, prompt: 'continue observed session' });
+    const observedChildId = followObserved.ok ? (followObserved as unknown as { run_id: string }).run_id : '';
+    await service.waitForRun({ run_id: observedChildId, wait_seconds: 5 });
+
+    const observedChild = await service.getRunStatus({ run_id: observedChildId });
+    assert.equal(observedChild.ok, true);
+    const observedSummary = observedChild.ok ? (observedChild as unknown as {
+      run_summary: {
+        session_id: string;
+        requested_session_id: string;
+        observed_session_id: string;
+        worker_invocation: { args: string[] };
+      };
+    }).run_summary : null;
+    assert.equal(observedSummary?.session_id, 'claude-session-mismatch');
+    assert.equal(observedSummary?.requested_session_id, 'claude-session-mismatch');
+    assert.equal(observedSummary?.observed_session_id, 'claude-session-mismatch');
+    assert.deepStrictEqual(
+      observedSummary?.worker_invocation.args.slice(0, 3),
+      ['-p', '--resume', 'claude-session-mismatch'],
+    );
   });
 
   it('normalizes event-derived absolute files under cwd before unioning with git files', async () => {
@@ -217,8 +362,10 @@ process.stdin.on('data', chunk => prompt += chunk);
 process.stdin.on('end', () => {
   process.on('SIGTERM', () => process.exit(0));
   const cwd = process.cwd();
-  fs.appendFileSync(path.join(cwd, '${name}-args.jsonl'), JSON.stringify(process.argv.slice(2)) + '\\n');
-  console.log(JSON.stringify({ type: 'system', subtype: 'init', session_id: '${sessionId}' }));
+  const args = process.argv.slice(2);
+  const activeSessionId = prompt.includes('session-mismatch') ? '${sessionId.replace('-1', '-mismatch')}' : resumedSessionId(args) ?? '${sessionId}';
+  fs.appendFileSync(path.join(cwd, '${name}-args.jsonl'), JSON.stringify(args) + '\\n');
+  console.log(JSON.stringify({ type: 'system', subtype: 'init', session_id: activeSessionId }));
   if (prompt.includes('event-file') && !prompt.includes('absolute-event-file')) {
     console.log(JSON.stringify({ type: 'assistant', message: { content: [{ type: 'tool_use', name: 'Write', input: { file_path: 'event.txt' } }] } }));
   }
@@ -242,14 +389,23 @@ process.stdin.on('end', () => {
   }
   if (prompt.includes('slow')) {
     setTimeout(() => {
-      console.log(JSON.stringify({ type: 'result', subtype: 'success', result: 'slow done', session_id: '${sessionId}' }));
+      console.log(JSON.stringify({ type: 'result', subtype: 'success', result: 'slow done', session_id: activeSessionId }));
       process.exit(0);
     }, 10000);
     return;
   }
   console.log(JSON.stringify({ type: 'assistant', message: { content: [{ type: 'text', text: 'done' }] } }));
-  console.log(JSON.stringify({ type: 'result', subtype: 'success', result: 'done', session_id: '${sessionId}' }));
+  console.log(JSON.stringify({ type: 'result', subtype: 'success', result: 'done', session_id: activeSessionId }));
 });
+
+function resumedSessionId(args) {
+  const resumeFlag = args.indexOf('--resume');
+  if (resumeFlag >= 0 && args[resumeFlag + 1]) return args[resumeFlag + 1];
+  const resumeCommand = args.indexOf('resume');
+  const promptDash = args.lastIndexOf('-');
+  if (resumeCommand >= 0 && promptDash > resumeCommand + 1) return args[promptDash - 1];
+  return null;
+}
 `);
   await chmod(path, 0o755);
 }

--- a/src/__tests__/integration/orchestrator.test.ts
+++ b/src/__tests__/integration/orchestrator.test.ts
@@ -151,7 +151,7 @@ describe('agent orchestrator integration with mock CLIs', () => {
       model: 'claude-opus-4-7',
       service_tier: 'fast',
     });
-    assert.equal(claudeTier.ok, false);
+    assertInvalidInput(claudeTier, /Claude does not support service_tier/);
 
     const claudeAlias = await service.startRun({
       backend: 'claude',
@@ -159,7 +159,7 @@ describe('agent orchestrator integration with mock CLIs', () => {
       cwd: repo,
       model: 'opus',
     });
-    assert.equal(claudeAlias.ok, false);
+    assertInvalidInput(claudeAlias, /Claude model must be a direct model id/);
 
     const claudeUnknownEffortModel = await service.startRun({
       backend: 'claude',
@@ -168,7 +168,7 @@ describe('agent orchestrator integration with mock CLIs', () => {
       model: 'claude-sonnet-4-5',
       reasoning_effort: 'high',
     });
-    assert.equal(claudeUnknownEffortModel.ok, false);
+    assertInvalidInput(claudeUnknownEffortModel, /Claude effort levels are documented/);
 
     const claudeXhighFallback = await service.startRun({
       backend: 'claude',
@@ -177,7 +177,7 @@ describe('agent orchestrator integration with mock CLIs', () => {
       model: 'claude-sonnet-4-6',
       reasoning_effort: 'xhigh',
     });
-    assert.equal(claudeXhighFallback.ok, false);
+    assertInvalidInput(claudeXhighFallback, /Claude xhigh effort requires claude-opus-4-7/);
 
     const claudeMax = await service.startRun({
       backend: 'claude',
@@ -198,7 +198,7 @@ describe('agent orchestrator integration with mock CLIs', () => {
       model: 'gpt-5.5',
       reasoning_effort: 'max',
     });
-    assert.equal(codexMax.ok, false);
+    assertInvalidInput(codexMax, /Codex reasoning_effort must be one of/);
   });
 
   it('records requested and observed backend session ids separately for resume auditing', async () => {
@@ -450,4 +450,11 @@ async function waitForFile(path: string): Promise<void> {
 
 function prependPath(entry: string, current: string | undefined): string {
   return current ? `${entry}${delimiter}${current}` : entry;
+}
+
+function assertInvalidInput(result: unknown, message: RegExp): void {
+  const response = result as { ok: boolean; error?: { code: string; message: string } };
+  assert.equal(response.ok, false);
+  assert.equal(response.error?.code, 'INVALID_INPUT');
+  assert.match(response.error?.message ?? '', message);
 }

--- a/src/__tests__/mcpTools.test.ts
+++ b/src/__tests__/mcpTools.test.ts
@@ -1,0 +1,41 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { RpcMethodSchema } from '../contract.js';
+import { tools } from '../mcpTools.js';
+
+type ObjectSchema = {
+  properties: Record<string, unknown>;
+  required?: readonly string[];
+};
+
+describe('MCP tool registration', () => {
+  it('registers every exposed tool as a known RPC method', () => {
+    const rpcMethods = new Set<string>(RpcMethodSchema.options);
+    for (const tool of tools) {
+      assert.equal(rpcMethods.has(tool.name), true, `${tool.name} is not an RPC method`);
+    }
+  });
+
+  it('exposes follow-up metadata and observability snapshot arguments', () => {
+    const start = schemaFor('start_run');
+    assert.equal(Object.hasOwn(start.properties, 'reasoning_effort'), true);
+    assert.equal(Object.hasOwn(start.properties, 'service_tier'), true);
+
+    const followup = schemaFor('send_followup');
+    assert.equal(Object.hasOwn(followup.properties, 'metadata'), true);
+    assert.equal(Object.hasOwn(followup.properties, 'reasoning_effort'), true);
+    assert.equal(Object.hasOwn(followup.properties, 'service_tier'), true);
+    assert.deepStrictEqual(followup.required, ['run_id', 'prompt']);
+
+    const observability = schemaFor('get_observability_snapshot');
+    assert.equal(Object.hasOwn(observability.properties, 'include_prompts'), true);
+    assert.equal(Object.hasOwn(observability.properties, 'recent_event_limit'), true);
+    assert.equal(Object.hasOwn(observability.properties, 'diagnostics'), true);
+  });
+});
+
+function schemaFor(name: string): ObjectSchema {
+  const tool = tools.find((item) => item.name === name);
+  assert.ok(tool, `missing tool ${name}`);
+  return tool.inputSchema as ObjectSchema;
+}

--- a/src/__tests__/observability.test.ts
+++ b/src/__tests__/observability.test.ts
@@ -1,0 +1,234 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtemp, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { buildObservabilitySnapshot } from '../observability.js';
+import { RunStore } from '../runStore.js';
+
+describe('observability snapshot builder', () => {
+  it('derives sessions, prompt metadata, artifact sizes, and activity from the run store', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'agent-observe-'));
+    const store = new RunStore(root);
+    const parent = await store.createRun({
+      backend: 'codex',
+      cwd: root,
+      prompt: 'Build the dashboard\nwith a terminal view.',
+      model: 'gpt-5.2',
+      model_source: 'explicit',
+      observed_session_id: 'session-1',
+      session_id: 'session-1',
+      display: {
+        session_title: 'Observability work',
+        session_summary: 'Build dashboard visibility',
+        prompt_title: 'Start dashboard',
+        prompt_summary: 'Initial implementation',
+      },
+    });
+    await store.appendEvent(parent.run_id, { type: 'assistant_message', payload: { text: 'I am implementing the dashboard.' } });
+    await store.markTerminal(parent.run_id, 'completed', [], {
+      status: 'completed',
+      summary: 'Dashboard implementation complete.',
+      files_changed: [],
+      commands_run: [],
+      artifacts: store.defaultArtifacts(parent.run_id),
+      errors: [],
+    });
+
+    const child = await store.createRun({
+      backend: 'codex',
+      cwd: root,
+      prompt: 'Add an interactive detail view.',
+      parent_run_id: parent.run_id,
+      session_id: 'session-1',
+      requested_session_id: 'session-1',
+      observed_session_id: 'session-2',
+      model: 'gpt-5.2',
+      model_source: 'inherited',
+      model_settings: { reasoning_effort: 'xhigh', service_tier: 'fast', mode: null },
+      display: {
+        session_title: 'Observability work',
+        session_summary: 'Build dashboard visibility',
+        prompt_title: 'Add details',
+        prompt_summary: 'Interactive detail view',
+      },
+    });
+    for (let index = 0; index < 25; index += 1) {
+      await store.appendEvent(child.run_id, { type: 'lifecycle', payload: { index } });
+    }
+    await store.appendEvent(child.run_id, { type: 'tool_use', payload: { name: 'Bash', input: { command: 'pnpm build' } } });
+
+    const snapshot = await buildObservabilitySnapshot(store, {
+      limit: 50,
+      includePrompts: true,
+      recentEventLimit: 3,
+      daemonPid: 123,
+      backendStatus: null,
+    });
+
+    assert.equal(snapshot.daemon_pid, 123);
+    assert.equal(snapshot.runs.length, 2);
+    assert.equal(snapshot.sessions.length, 2);
+    const childRun = snapshot.runs.find((run) => run.run.run_id === child.run_id);
+    assert.equal(childRun?.prompt.title, 'Add details');
+    assert.equal(childRun?.prompt.text, 'Add an interactive detail view.');
+    assert.deepStrictEqual(childRun?.settings, { reasoning_effort: 'xhigh', service_tier: 'fast', mode: null });
+    assert.equal(childRun?.session.status, 'mismatch');
+    assert.ok(childRun?.session.warnings[0]?.includes('session-1'));
+    assert.equal(childRun?.activity.event_count, 26);
+    assert.equal(childRun?.activity.recent_events.length, 3);
+    assert.equal(childRun?.activity.recent_events.at(-1)?.seq, 26);
+    assert.equal(childRun?.activity.last_interaction_preview, 'Bash: pnpm build');
+    assert.ok(childRun?.artifacts.some((artifact) => artifact.name === 'prompt.txt' && artifact.exists && artifact.bytes));
+
+    const parentRun = snapshot.runs.find((run) => run.run.run_id === parent.run_id);
+    assert.equal(parentRun?.response.status, 'completed');
+    assert.equal(parentRun?.response.summary, 'Dashboard implementation complete.');
+
+    const parentSession = snapshot.sessions.find((session) => session.session_id === 'session-1');
+    assert.equal(parentSession?.title, 'Observability work');
+    assert.equal(parentSession?.prompts[0]?.title, 'Start dashboard');
+    assert.equal(parentSession?.workspace.cwd, root);
+    assert.equal(parentSession?.workspace.repository_root, null);
+
+    const childSession = snapshot.sessions.find((session) => session.session_id === 'session-2');
+    assert.deepStrictEqual(childSession?.settings, [{ reasoning_effort: 'xhigh', service_tier: 'fast', mode: null }]);
+    assert.deepStrictEqual(childSession?.prompts[0]?.settings, { reasoning_effort: 'xhigh', service_tier: 'fast', mode: null });
+  });
+
+  it('uses the last assistant message as the final response when result summaries are empty', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'agent-observe-'));
+    const store = new RunStore(root);
+    const run = await store.createRun({ backend: 'codex', cwd: root, prompt: 'Run a smoke test.' });
+    await store.appendEvent(run.run_id, { type: 'assistant_message', payload: { text: 'Smoke test complete; no files were changed.' } });
+    await store.markTerminal(run.run_id, 'completed');
+    await writeFile(store.eventSeqPath(run.run_id), '1\n');
+
+    const snapshot = await buildObservabilitySnapshot(store, {
+      limit: 10,
+      includePrompts: true,
+      recentEventLimit: 5,
+      daemonPid: null,
+      backendStatus: null,
+    });
+
+    assert.equal(snapshot.runs[0]?.response.status, 'completed');
+    assert.equal(snapshot.runs[0]?.response.summary, 'Smoke test complete; no files were changed.');
+    assert.equal(snapshot.runs[0]?.activity.event_count, 2);
+  });
+
+  it('omits full prompt text unless requested but keeps a preview and title fallback', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'agent-observe-'));
+    const store = new RunStore(root);
+    const run = await store.createRun({
+      backend: 'claude',
+      cwd: root,
+      prompt: 'Summarize this session for a human operator.',
+      metadata: { requested_reasoning_effort: 'xhigh', requested_service_tier: 'fast' },
+    });
+
+    const snapshot = await buildObservabilitySnapshot(store, {
+      limit: 10,
+      includePrompts: false,
+      recentEventLimit: 0,
+      daemonPid: null,
+      backendStatus: null,
+    });
+
+    assert.equal(snapshot.runs[0]?.prompt.text, null);
+    assert.equal(snapshot.runs[0]?.prompt.preview, 'Summarize this session for a human operator.');
+    assert.equal(snapshot.runs[0]?.prompt.title, 'Summarize this session for a human operator.');
+    assert.deepStrictEqual(snapshot.runs[0]?.settings, { reasoning_effort: null, service_tier: null, mode: null });
+  });
+
+  it('counts full session history even when detailed runs are limited', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'agent-observe-'));
+    const store = new RunStore(root);
+    for (let index = 1; index <= 3; index += 1) {
+      await store.createRun({
+        backend: 'codex',
+        cwd: root,
+        prompt: `Prompt ${index}`,
+        session_id: 'session-limited',
+        observed_session_id: 'session-limited',
+        display: {
+          session_title: 'Limited history chat',
+          session_summary: null,
+          prompt_title: `Prompt ${index}`,
+          prompt_summary: null,
+        },
+      });
+    }
+
+    const snapshot = await buildObservabilitySnapshot(store, {
+      limit: 1,
+      includePrompts: false,
+      recentEventLimit: 0,
+      daemonPid: null,
+      backendStatus: null,
+    });
+
+    assert.equal(snapshot.runs.length, 1);
+    assert.equal(snapshot.sessions.length, 1);
+    assert.equal(snapshot.sessions[0]?.run_count, 3);
+    assert.equal(snapshot.sessions[0]?.prompts.length, 1);
+  });
+
+  it('shows observed backend model and warns when it differs from the requested model', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'agent-observe-'));
+    const store = new RunStore(root);
+    await store.createRun({
+      backend: 'claude',
+      cwd: root,
+      prompt: 'Use the requested model.',
+      model: 'claude-sonnet-4-6',
+      model_source: 'explicit',
+      observed_model: 'claude-opus-4-7',
+      session_id: 'session-model',
+      observed_session_id: 'session-model',
+    });
+
+    const snapshot = await buildObservabilitySnapshot(store, {
+      limit: 10,
+      includePrompts: false,
+      recentEventLimit: 0,
+      daemonPid: null,
+      backendStatus: null,
+    });
+
+    assert.equal(snapshot.runs[0]?.model.name, 'claude-opus-4-7');
+    assert.equal(snapshot.runs[0]?.model.requested_name, 'claude-sonnet-4-6');
+    assert.equal(snapshot.runs[0]?.model.observed_name, 'claude-opus-4-7');
+    assert.ok(snapshot.sessions[0]?.warnings.some((warning) => warning.includes('requested model claude-sonnet-4-6')));
+  });
+
+  it('derives readable workspace labels for repo worktrees', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'agent-observe-'));
+    const store = new RunStore(root);
+    await store.createRun({
+      backend: 'codex',
+      cwd: '/tmp/worktrees-agent-orchestrator-mcp/4-add-observability',
+      prompt: 'Show the workspace label.',
+      git_snapshot_status: 'captured',
+      git_snapshot: {
+        sha: '0123456789abcdef0123456789abcdef01234567',
+        root: '/tmp/worktrees-agent-orchestrator-mcp/4-add-observability',
+        branch: '4-add-observability',
+        dirty_count: 2,
+        dirty: ['src/observability.ts', 'src/daemon/observabilityFormat.ts'],
+        dirty_fingerprints: {},
+      },
+    });
+
+    const snapshot = await buildObservabilitySnapshot(store, {
+      limit: 10,
+      includePrompts: false,
+      recentEventLimit: 0,
+      daemonPid: null,
+      backendStatus: null,
+    });
+
+    assert.equal(snapshot.sessions[0]?.workspace.repository_name, 'agent-orchestrator-mcp');
+    assert.equal(snapshot.sessions[0]?.workspace.label, 'agent-orchestrator-mcp:4-add-observability*');
+  });
+});

--- a/src/__tests__/observabilityFormat.test.ts
+++ b/src/__tests__/observabilityFormat.test.ts
@@ -1,0 +1,270 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { ObservabilitySnapshotSchema } from '../contract.js';
+import {
+  clampDashboardState,
+  formatSnapshot,
+  renderDashboard,
+  type SnapshotEnvelope,
+} from '../daemon/observabilityFormat.js';
+
+describe('observability CLI formatting', () => {
+  it('renders session, model, run, and raw prompt metadata', () => {
+    const envelope = sampleEnvelope();
+
+    const formatted = formatSnapshot(envelope);
+    assert.match(formatted, /Terminal dashboard \[running\]/);
+    assert.match(formatted, /model=gpt-5\.2 \(explicit\)/);
+    assert.match(formatted, /effort=xhigh tier=fast/);
+    assert.match(formatted, /prompts=1 workspace=repo:main/);
+    assert.match(formatted, /session=session-1/);
+
+    const detail = renderDashboard(envelope, { view: 'detail', selectedSession: 0, selectedPrompt: 0 }, 120, 40);
+    assert.match(detail, /\x1b\[[0-9;]*m/);
+    const plain = stripAnsi(detail);
+    assert.match(plain, /View: Detail > Terminal dashboard > Open dashboard \| Prompt 1\/1/);
+    assert.match(plain, /Keys: Up\/Down switches prompt in Terminal dashboard/);
+    assert.match(plain, /Title: Open dashboard/);
+    assert.match(plain, /Model: gpt-5\.2 \(explicit\)/);
+    assert.match(plain, /Reasoning: xhigh/);
+    assert.match(plain, /Service Tier: fast/);
+    assert.match(plain, /Invocation: \/usr\/local\/bin\/codex exec --model gpt-5\.2 -/);
+    assert.match(plain, /Git: repo:main clean/);
+    assert.match(plain, /User Prompt/);
+    assert.match(plain, /Raw prompt body with details/);
+    assert.match(plain, /Final Response \[completed\]/);
+    assert.match(plain, /Final response body with outcome/);
+    assert.match(plain, /#1 2026-05-02 00:00:01 assistant_message/);
+  });
+
+  it('keeps dashboard list screens to one row per item', () => {
+    const envelope = sampleEnvelope();
+
+    const sessions = stripAnsi(renderDashboard(envelope, { view: 'sessions', selectedSession: 0, selectedPrompt: 0 }, 160, 40));
+    assert.match(sessions, /View: Sessions 1\/1/);
+    assert.match(sessions, /Keys: Up\/Down choose chat, Enter opens prompts/);
+    assert.match(sessions, /AGENT\s+STATUS\s+PROMPTS\s+MODEL\s+EFFORT\s+TIER\s+WORKSPACE\s+CHAT/);
+    assert.match(sessions, /> codex\s+running\s+1\s+gpt-5\.2\s+xhigh\s+fast\s+repo:main\s+Terminal dashboard/);
+    assert.doesNotMatch(sessions, /^  Inspect live worker prompts$/m);
+    assert.doesNotMatch(sessions, /^  session=session-1$/m);
+
+    const prompts = stripAnsi(renderDashboard(envelope, { view: 'prompts', selectedSession: 0, selectedPrompt: 0 }, 120, 40));
+    assert.match(prompts, /View: Sessions > Terminal dashboard \| Prompt 1\/1/);
+    assert.match(prompts, /Keys: Up\/Down choose prompt, Enter opens detail/);
+    assert.match(prompts, /STATUS\s+MODEL\s+EFFORT\s+TIER\s+LAST\s+PROMPT/);
+    assert.match(prompts, /> running\s+gpt-5\.2\s+xhigh\s+fast\s+2026-05-02 00:00:01 Open dashboard/);
+    assert.doesNotMatch(prompts, /^  Show the prompt detail view$/m);
+    assert.doesNotMatch(prompts, /^  Raw prompt body with details$/m);
+  });
+
+  it('shows latest prompt model and compacts worktree workspace labels', () => {
+    const envelope = sampleEnvelope();
+    const session = envelope.snapshot.sessions[0]!;
+    session.run_count = 2;
+    session.models = [
+      { name: 'gpt-5.2', source: 'explicit', requested_name: 'gpt-5.2', observed_name: null },
+      { name: 'gpt-5.5', source: 'explicit', requested_name: 'gpt-5.5', observed_name: null },
+    ];
+    session.settings = [
+      { reasoning_effort: 'low', service_tier: 'normal', mode: null },
+      { reasoning_effort: 'xhigh', service_tier: 'fast', mode: null },
+    ];
+    session.workspace = {
+      cwd: '/tmp/worktrees-agent-orchestrator-mcp/4-add-observability',
+      repository_root: '/tmp/worktrees-agent-orchestrator-mcp/4-add-observability',
+      repository_name: 'agent-orchestrator-mcp',
+      branch: '4-add-observability',
+      dirty_count: 3,
+      label: 'agent-orchestrator-mcp:4-add-observability*',
+    };
+    session.prompts.push({
+      run_id: 'run-2',
+      status: 'completed',
+      title: 'Second prompt',
+      summary: null,
+      preview: 'Second raw prompt',
+      model: { name: 'gpt-5.5', source: 'explicit', requested_name: 'gpt-5.5', observed_name: null },
+      settings: { reasoning_effort: 'xhigh', service_tier: 'fast', mode: null },
+      created_at: '2026-05-02T00:00:02.000Z',
+      last_activity_at: '2026-05-02T00:00:03.000Z',
+    });
+
+    const sessions = stripAnsi(renderDashboard(envelope, { view: 'sessions', selectedSession: 0, selectedPrompt: 0 }, 160, 40));
+    assert.match(sessions, /> codex\s+running\s+2\s+gpt-5\.5\s+xhigh\s+fast\s+ao-mcp:4-add-observability\*\s+Terminal dashboard/);
+    assert.doesNotMatch(sessions, /gpt-5\.2 \+1/);
+
+    const prompts = stripAnsi(renderDashboard(envelope, { view: 'prompts', selectedSession: 0, selectedPrompt: 0 }, 160, 40));
+    assert.match(prompts, /prompts=2/);
+    assert.doesNotMatch(prompts, /shown=/);
+  });
+
+  it('renders limited prompt lists and observed model mismatches clearly', () => {
+    const envelope = sampleEnvelope();
+    const session = envelope.snapshot.sessions[0]!;
+    const run = envelope.snapshot.runs[0]!;
+    session.run_count = 3;
+    session.warnings = ['requested model gpt-5.2 but backend reported gpt-5.5'];
+    session.models = [{ name: 'gpt-5.5', source: 'explicit', requested_name: 'gpt-5.2', observed_name: 'gpt-5.5' }];
+    session.prompts[0]!.model = { name: 'gpt-5.5', source: 'explicit', requested_name: 'gpt-5.2', observed_name: 'gpt-5.5' };
+    run.model = { name: 'gpt-5.5', source: 'explicit', requested_name: 'gpt-5.2', observed_name: 'gpt-5.5' };
+
+    const prompts = stripAnsi(renderDashboard(envelope, { view: 'prompts', selectedSession: 0, selectedPrompt: 0 }, 160, 40));
+    assert.match(prompts, /prompts=3 shown=1/);
+    assert.match(prompts, /Warning: requested model gpt-5\.2 but backend reported gpt-5\.5/);
+
+    const detail = stripAnsi(renderDashboard(envelope, { view: 'detail', selectedSession: 0, selectedPrompt: 0 }, 160, 40));
+    assert.match(detail, /Model: gpt-5\.5 \(explicit, requested gpt-5\.2\)/);
+  });
+
+  it('clamps stale dashboard selections', () => {
+    const envelope = sampleEnvelope();
+    assert.deepStrictEqual(
+      clampDashboardState({ view: 'detail', selectedSession: 99, selectedPrompt: 99 }, envelope.snapshot),
+      { view: 'detail', selectedSession: 0, selectedPrompt: 0 },
+    );
+    assert.deepStrictEqual(
+      clampDashboardState({ view: 'prompts', selectedSession: 0, selectedPrompt: 0 }, {
+        ...envelope.snapshot,
+        sessions: [],
+      }),
+      { view: 'sessions', selectedSession: 0, selectedPrompt: 0 },
+    );
+  });
+});
+
+function sampleEnvelope(): SnapshotEnvelope {
+  const now = '2026-05-02T00:00:00.000Z';
+  const snapshot = ObservabilitySnapshotSchema.parse({
+    generated_at: now,
+    daemon_pid: 42,
+    store_root: '/tmp/agent-store',
+    backend_status: null,
+    sessions: [{
+      session_key: 'codex:session-1',
+      session_id: 'session-1',
+      root_run_id: 'run-1',
+      backend: 'codex',
+      cwd: '/tmp/repo',
+      workspace: {
+        cwd: '/tmp/repo',
+        repository_root: '/tmp/repo',
+        repository_name: 'repo',
+        branch: 'main',
+        dirty_count: 0,
+        label: 'repo:main',
+      },
+      title: 'Terminal dashboard',
+      summary: 'Inspect live worker prompts',
+      status: 'running',
+      created_at: now,
+      updated_at: '2026-05-02T00:00:01.000Z',
+      run_count: 1,
+      running_count: 1,
+      models: [{ name: 'gpt-5.2', source: 'explicit' }],
+      settings: [{ reasoning_effort: 'xhigh', service_tier: 'fast', mode: null }],
+      warnings: [],
+      prompts: [{
+        run_id: 'run-1',
+        status: 'running',
+        title: 'Open dashboard',
+        summary: 'Show the prompt detail view',
+        preview: 'Raw prompt body with details',
+        model: { name: 'gpt-5.2', source: 'explicit' },
+        settings: { reasoning_effort: 'xhigh', service_tier: 'fast', mode: null },
+        created_at: now,
+        last_activity_at: '2026-05-02T00:00:01.000Z',
+      }],
+    }],
+    runs: [{
+      run: {
+        run_id: 'run-1',
+        backend: 'codex',
+        status: 'running',
+        parent_run_id: null,
+        session_id: 'session-1',
+        model: 'gpt-5.2',
+        model_source: 'explicit',
+        requested_session_id: null,
+        observed_session_id: 'session-1',
+        display: {
+          session_title: 'Terminal dashboard',
+          session_summary: 'Inspect live worker prompts',
+          prompt_title: 'Open dashboard',
+          prompt_summary: 'Show the prompt detail view',
+        },
+        cwd: '/tmp/repo',
+        created_at: now,
+        started_at: now,
+        finished_at: null,
+        worker_pid: 123,
+        worker_pgid: 123,
+        daemon_pid_at_spawn: 42,
+        worker_invocation: {
+          command: '/usr/local/bin/codex',
+          args: ['exec', '--model', 'gpt-5.2', '-'],
+        },
+        git_snapshot_status: 'captured',
+        git_snapshot: {
+          sha: '0123456789abcdef0123456789abcdef01234567',
+          root: '/tmp/repo',
+          branch: 'main',
+          dirty_count: 0,
+          dirty: [],
+          dirty_fingerprints: {},
+        },
+        model_settings: { reasoning_effort: 'xhigh', service_tier: 'fast', mode: null },
+        metadata: {},
+      },
+      prompt: {
+        title: 'Open dashboard',
+        summary: 'Show the prompt detail view',
+        preview: 'Raw prompt body with details',
+        text: 'Raw prompt body with details and enough context to inspect.',
+        path: '/tmp/agent-store/runs/run-1/prompt.txt',
+        bytes: 56,
+      },
+      response: {
+        status: 'completed',
+        summary: 'Final response body with outcome.',
+        path: '/tmp/agent-store/runs/run-1/result.json',
+        bytes: 128,
+      },
+      model: { name: 'gpt-5.2', source: 'explicit' },
+      settings: { reasoning_effort: 'xhigh', service_tier: 'fast', mode: null },
+      session: {
+        requested_session_id: null,
+        observed_session_id: 'session-1',
+        effective_session_id: 'session-1',
+        status: 'new_session',
+        warnings: [],
+      },
+      activity: {
+        last_event_sequence: 1,
+        last_event_at: '2026-05-02T00:00:01.000Z',
+        last_event_type: 'assistant_message',
+        last_interaction_preview: 'Working on it.',
+        event_count: 1,
+        recent_errors: [],
+        recent_events: [{
+          seq: 1,
+          ts: '2026-05-02T00:00:01.000Z',
+          type: 'assistant_message',
+          payload: { text: 'Working on it.' },
+        }],
+      },
+      artifacts: [{
+        name: 'prompt.txt',
+        path: '/tmp/agent-store/runs/run-1/prompt.txt',
+        exists: true,
+        bytes: 56,
+      }],
+      duration_seconds: 1,
+    }],
+  });
+
+  return { running: true, snapshot };
+}
+
+function stripAnsi(value: string): string {
+  return value.replace(/\x1b\[[0-9;]*m/g, '');
+}

--- a/src/__tests__/processManager.test.ts
+++ b/src/__tests__/processManager.test.ts
@@ -3,6 +3,7 @@ import assert from 'node:assert/strict';
 import { chmod, mkdtemp, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
+import { ClaudeBackend } from '../backend/claude.js';
 import { CodexBackend } from '../backend/codex.js';
 import { ProcessManager } from '../processManager.js';
 import { RunStore } from '../runStore.js';
@@ -51,5 +52,44 @@ process.stdin.on('end', () => {
       new Promise<string>((resolve) => setTimeout(() => resolve('timed out'), 2_000)),
     ]);
     assert.equal(outcome, 'settled');
+  });
+
+  it('records observed backend-default model names from worker events', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'agent-process-'));
+    const cli = join(root, 'worker.js');
+    await writeFile(cli, `#!/usr/bin/env node
+process.stdin.on('data', () => {});
+process.stdin.on('end', () => {
+  console.log(JSON.stringify({ type: 'system', session_id: 'session-1' }));
+  console.log(JSON.stringify({
+    type: 'assistant',
+    session_id: 'session-1',
+    message: {
+      model: 'claude-opus-4-7',
+      content: [{ type: 'text', text: 'done' }]
+    }
+  }));
+  console.log(JSON.stringify({ type: 'result', subtype: 'success', result: 'done', session_id: 'session-1' }));
+  process.exit(0);
+});
+`);
+    await chmod(cli, 0o755);
+
+    const store = new RunStore(root);
+    const run = await store.createRun({ backend: 'claude', cwd: root, model_source: 'backend_default' });
+    const manager = new ProcessManager(store);
+    const managed = await manager.start(run.run_id, new ClaudeBackend(), {
+      command: cli,
+      args: [],
+      cwd: root,
+      stdinPayload: 'finish',
+    });
+
+    await managed.completion;
+    const meta = await store.loadMeta(run.run_id);
+    assert.equal(meta.model, 'claude-opus-4-7');
+    assert.equal(meta.observed_model, 'claude-opus-4-7');
+    assert.equal(meta.model_source, 'backend_default');
+    assert.deepStrictEqual(meta.worker_invocation, { command: cli, args: [] });
   });
 });

--- a/src/__tests__/runStore.test.ts
+++ b/src/__tests__/runStore.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdtemp, stat, utimes, writeFile } from 'node:fs/promises';
+import { mkdtemp, readFile, stat, utimes, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { RunStore } from '../runStore.js';
@@ -9,13 +9,17 @@ describe('RunStore', () => {
   it('creates, reloads, lists, paginates events, and marks terminal atomically', async () => {
     const root = await mkdtemp(join(tmpdir(), 'agent-store-'));
     const store = new RunStore(root);
-    const run = await store.createRun({ backend: 'codex', cwd: root, metadata: { task: 'T2' } });
+    const run = await store.createRun({ backend: 'codex', cwd: root, prompt: 'raw prompt text', metadata: { task: 'T2' } });
     await store.appendEvent(run.run_id, { type: 'lifecycle', payload: { status: 'one' } });
     await store.appendEvent(run.run_id, { type: 'assistant_message', payload: { text: 'hello' } });
 
     const loaded = await store.loadRun(run.run_id);
     assert.equal(loaded?.meta.metadata.task, 'T2');
+    assert.deepStrictEqual(loaded?.meta.model_settings, { reasoning_effort: null, service_tier: null, mode: null });
+    assert.equal(loaded?.meta.worker_invocation, null);
     assert.equal(loaded?.events.length, 2);
+    assert.equal(await store.readPrompt(run.run_id), 'raw prompt text');
+    assert.ok(store.defaultArtifacts(run.run_id).some((artifact) => artifact.name === 'prompt.txt'));
 
     const page = await store.readEvents(run.run_id, 1, 1);
     assert.equal(page.events.length, 1);
@@ -32,6 +36,15 @@ describe('RunStore', () => {
     const listed = await store.listRuns();
     assert.equal(listed[0]?.run_id, run.run_id);
     assert.equal((await stat(root)).mode & 0o777, 0o700);
+  });
+
+  it('does not publish a run if initial prompt persistence fails', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'agent-store-'));
+    const store = new RunStore(root);
+    store.promptPath = () => join(root, 'missing-directory', 'prompt.txt');
+
+    await assert.rejects(() => store.createRun({ backend: 'codex', cwd: root, prompt: 'must be durable' }));
+    assert.deepStrictEqual(await store.listRuns(), []);
   });
 
   it('serializes concurrent event appends without sequence collisions', async () => {
@@ -59,6 +72,22 @@ describe('RunStore', () => {
     assert.equal(page.events[0]?.seq, 101);
     assert.equal(page.next_sequence, 110);
     assert.equal(page.has_more, true);
+    const summary = await store.readEventSummary(run.run_id, 5);
+    assert.equal(summary.event_count, 150);
+    assert.equal(summary.last_event?.seq, 150);
+    assert.deepStrictEqual(summary.recent_events.map((event) => event.seq), [146, 147, 148, 149, 150]);
+
+    const largeRun = await store.createRun({ backend: 'codex', cwd: root });
+    await store.appendEvent(largeRun.run_id, { type: 'assistant_message', payload: { text: 'x'.repeat(80_000) } });
+    for (let index = 0; index < 20; index += 1) {
+      await store.appendEvent(largeRun.run_id, { type: 'lifecycle', payload: { index } });
+    }
+    const eventLog = await readFile(store.eventsPath(largeRun.run_id), 'utf8');
+    const firstNewline = eventLog.indexOf('\n');
+    await writeFile(store.eventsPath(largeRun.run_id), `not-json ${'x'.repeat(80_000)}${eventLog.slice(firstNewline)}`);
+    const tailSummary = await store.readEventSummary(largeRun.run_id, 3);
+    assert.equal(tailSummary.event_count, 21);
+    assert.deepStrictEqual(tailSummary.recent_events.map((event) => event.seq), [19, 20, 21]);
 
     const oldTerminal = await store.createRun({ backend: 'codex', cwd: root });
     await store.markTerminal(oldTerminal.run_id, 'completed');
@@ -79,6 +108,34 @@ describe('RunStore', () => {
     assert.equal(await store.loadRun(oldTerminal.run_id), null);
     assert.equal((await store.loadRun(freshTerminal.run_id))?.meta.status, 'completed');
     assert.equal((await store.loadRun(running.run_id))?.meta.status, 'running');
+  });
+
+  it('persists observability metadata with backward-compatible defaults', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'agent-store-'));
+    const store = new RunStore(root);
+    const run = await store.createRun({
+      backend: 'codex',
+      cwd: root,
+      model: 'gpt-5.2',
+      model_source: 'explicit',
+      model_settings: { reasoning_effort: 'xhigh', service_tier: 'fast', mode: null },
+      requested_session_id: 'session-1',
+      observed_session_id: 'session-1',
+      display: {
+        session_title: 'Session title',
+        session_summary: 'Session summary',
+        prompt_title: 'Prompt title',
+        prompt_summary: 'Prompt summary',
+      },
+    });
+
+    const loaded = await store.loadMeta(run.run_id);
+    assert.equal(loaded.model_source, 'explicit');
+    assert.deepStrictEqual(loaded.model_settings, { reasoning_effort: 'xhigh', service_tier: 'fast', mode: null });
+    assert.equal(loaded.requested_session_id, 'session-1');
+    assert.equal(loaded.observed_session_id, 'session-1');
+    assert.equal(loaded.display.session_title, 'Session title');
+    assert.equal(loaded.display.prompt_title, 'Prompt title');
   });
 
   it('reclaims a stale per-run lock left by a dead process', async () => {

--- a/src/backend/WorkerBackend.ts
+++ b/src/backend/WorkerBackend.ts
@@ -1,5 +1,6 @@
 import type {
   Backend,
+  RunModelSettings,
   RunStatus,
   WorkerEvent,
   WorkerResult,
@@ -17,6 +18,7 @@ export interface BackendStartInput {
   prompt: string;
   cwd: string;
   model?: string | null;
+  modelSettings: RunModelSettings;
 }
 
 export interface ParsedBackendEvent {

--- a/src/backend/claude.ts
+++ b/src/backend/claude.ts
@@ -6,11 +6,11 @@ export class ClaudeBackend extends BaseBackend {
   readonly binary = 'claude';
 
   async start(input: BackendStartInput): Promise<WorkerInvocation> {
-    return invocation(this.binary, ['-p', '--output-format', 'stream-json', '--verbose', ...modelArgs(input.model)], input);
+    return invocation(this.binary, ['-p', '--output-format', 'stream-json', '--verbose', ...modelArgs(input.model), ...modelSettingsArgs(input.modelSettings)], input);
   }
 
   async resume(sessionId: string, input: BackendStartInput): Promise<WorkerInvocation> {
-    return invocation(this.binary, ['-p', '--resume', sessionId, '--output-format', 'stream-json', '--verbose', ...modelArgs(input.model)], input);
+    return invocation(this.binary, ['-p', '--resume', sessionId, '--output-format', 'stream-json', '--verbose', ...modelArgs(input.model), ...modelSettingsArgs(input.modelSettings)], input);
   }
 
   parseEvent(raw: unknown): ParsedBackendEvent {
@@ -75,4 +75,8 @@ export class ClaudeBackend extends BaseBackend {
 
 function modelArgs(model: string | null | undefined): string[] {
   return model ? ['--model', model] : [];
+}
+
+function modelSettingsArgs(settings: BackendStartInput['modelSettings']): string[] {
+  return settings.reasoning_effort ? ['--effort', settings.reasoning_effort] : [];
 }

--- a/src/backend/codex.ts
+++ b/src/backend/codex.ts
@@ -10,9 +10,11 @@ export class CodexBackend extends BaseBackend {
       'exec',
       '--json',
       '--skip-git-repo-check',
+      ...userConfigArgs(input.modelSettings),
       '--cd',
       input.cwd,
       ...modelArgs(input.model),
+      ...modelSettingsArgs(input.modelSettings),
       '-',
     ], input);
   }
@@ -23,7 +25,9 @@ export class CodexBackend extends BaseBackend {
       'resume',
       '--json',
       '--skip-git-repo-check',
+      ...userConfigArgs(input.modelSettings),
       ...modelArgs(input.model),
+      ...modelSettingsArgs(input.modelSettings),
       sessionId,
       '-',
     ], input);
@@ -133,4 +137,19 @@ export class CodexBackend extends BaseBackend {
 
 function modelArgs(model: string | null | undefined): string[] {
   return model ? ['--model', model] : [];
+}
+
+function userConfigArgs(settings: BackendStartInput['modelSettings']): string[] {
+  return settings.mode === 'normal' ? ['--ignore-user-config'] : [];
+}
+
+function modelSettingsArgs(settings: BackendStartInput['modelSettings']): string[] {
+  const args: string[] = [];
+  if (settings.reasoning_effort) {
+    args.push('-c', `model_reasoning_effort="${settings.reasoning_effort}"`);
+  }
+  if (settings.service_tier) {
+    args.push('-c', `service_tier="${settings.service_tier}"`);
+  }
+  return args;
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -23,6 +23,9 @@ Usage:
 
 Daemon lifecycle:
   agent-orchestrator-mcp-daemon status
+  agent-orchestrator-mcp-daemon status --verbose
+  agent-orchestrator-mcp-daemon runs [--json] [--prompts]
+  agent-orchestrator-mcp-daemon watch [--interval-ms <ms>] [--limit <n>]
   agent-orchestrator-mcp-daemon start
   agent-orchestrator-mcp-daemon stop [--force]
   agent-orchestrator-mcp-daemon prune --older-than-days <days> [--dry-run]

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -24,6 +24,7 @@ Usage:
 Daemon lifecycle:
   agent-orchestrator-mcp-daemon status
   agent-orchestrator-mcp-daemon status --verbose
+  agent-orchestrator-mcp-daemon status --json
   agent-orchestrator-mcp-daemon runs [--json] [--prompts]
   agent-orchestrator-mcp-daemon watch [--interval-ms <ms>] [--limit <n>]
   agent-orchestrator-mcp-daemon start

--- a/src/contract.ts
+++ b/src/contract.ts
@@ -32,6 +32,14 @@ export type WorkerResultStatus = z.infer<typeof WorkerResultStatusSchema>;
 export const BackendSchema = z.enum(['codex', 'claude']);
 export type Backend = z.infer<typeof BackendSchema>;
 
+export const ModelSourceSchema = z.enum([
+  'explicit',
+  'inherited',
+  'backend_default',
+  'legacy_unknown',
+]);
+export type ModelSource = z.infer<typeof ModelSourceSchema>;
+
 export const BackendAvailabilityStatusSchema = z.enum([
   'available',
   'missing',
@@ -86,6 +94,8 @@ export type GitSnapshotStatus = z.infer<typeof GitSnapshotStatusSchema>;
 
 export const GitSnapshotSchema = z.object({
   sha: z.string(),
+  root: z.string().nullable().optional().default(null),
+  branch: z.string().nullable().optional().default(null),
   dirty_count: z.number().int().nonnegative(),
   dirty: z.array(z.string()).optional(),
   dirty_fingerprints: z.record(z.string()).optional(),
@@ -111,10 +121,13 @@ export const OrchestratorErrorSchema = z.object({
 });
 export type OrchestratorError = z.infer<typeof OrchestratorErrorSchema>;
 
+export const WorkerEventTypeSchema = z.enum(['assistant_message', 'tool_use', 'tool_result', 'error', 'lifecycle']);
+export type WorkerEventType = z.infer<typeof WorkerEventTypeSchema>;
+
 export const WorkerEventSchema = z.object({
   seq: z.number().int().positive(),
   ts: z.string(),
-  type: z.enum(['assistant_message', 'tool_use', 'tool_result', 'error', 'lifecycle']),
+  type: WorkerEventTypeSchema,
   payload: z.record(z.unknown()),
 });
 export type WorkerEvent = z.infer<typeof WorkerEventSchema>;
@@ -132,6 +145,58 @@ export const WorkerResultSchema = z.object({
 });
 export type WorkerResult = z.infer<typeof WorkerResultSchema>;
 
+const defaultRunDisplayMetadata = {
+  session_title: null,
+  session_summary: null,
+  prompt_title: null,
+  prompt_summary: null,
+};
+
+export const RunDisplayMetadataSchema = z.object({
+  session_title: z.string().nullable().optional().default(null),
+  session_summary: z.string().nullable().optional().default(null),
+  prompt_title: z.string().nullable().optional().default(null),
+  prompt_summary: z.string().nullable().optional().default(null),
+}).default(defaultRunDisplayMetadata);
+export type RunDisplayMetadata = z.infer<typeof RunDisplayMetadataSchema>;
+
+export const ReasoningEffortSchema = z.enum([
+  'none',
+  'minimal',
+  'low',
+  'medium',
+  'high',
+  'xhigh',
+  'max',
+]);
+export type ReasoningEffort = z.infer<typeof ReasoningEffortSchema>;
+
+export const ServiceTierSchema = z.enum([
+  'fast',
+  'flex',
+  'normal',
+]);
+export type ServiceTier = z.infer<typeof ServiceTierSchema>;
+
+const defaultRunModelSettings = {
+  reasoning_effort: null,
+  service_tier: null,
+  mode: null,
+};
+
+export const RunModelSettingsSchema = z.object({
+  reasoning_effort: z.string().nullable().optional().default(null),
+  service_tier: z.string().nullable().optional().default(null),
+  mode: z.string().nullable().optional().default(null),
+}).default(defaultRunModelSettings);
+export type RunModelSettings = z.infer<typeof RunModelSettingsSchema>;
+
+export const RunWorkerInvocationSchema = z.object({
+  command: z.string(),
+  args: z.array(z.string()),
+}).nullable().default(null);
+export type RunWorkerInvocation = z.infer<typeof RunWorkerInvocationSchema>;
+
 export const RunSummarySchema = z.object({
   run_id: z.string(),
   backend: BackendSchema,
@@ -139,6 +204,12 @@ export const RunSummarySchema = z.object({
   parent_run_id: z.string().nullable(),
   session_id: z.string().nullable(),
   model: z.string().nullable().optional().default(null),
+  model_source: ModelSourceSchema.optional().default('legacy_unknown'),
+  model_settings: RunModelSettingsSchema.optional().default(defaultRunModelSettings),
+  requested_session_id: z.string().nullable().optional().default(null),
+  observed_session_id: z.string().nullable().optional().default(null),
+  observed_model: z.string().nullable().optional().default(null),
+  display: RunDisplayMetadataSchema.optional().default(defaultRunDisplayMetadata),
   cwd: z.string(),
   created_at: z.string(),
   started_at: z.string().nullable(),
@@ -146,6 +217,7 @@ export const RunSummarySchema = z.object({
   worker_pid: z.number().int().nullable(),
   worker_pgid: z.number().int().nullable(),
   daemon_pid_at_spawn: z.number().int().nullable(),
+  worker_invocation: RunWorkerInvocationSchema.optional().default(null),
   git_snapshot_status: GitSnapshotStatusSchema,
   git_snapshot: GitSnapshotSchema.nullable(),
   metadata: z.record(z.unknown()),
@@ -183,6 +255,8 @@ export const StartRunInputSchema = z.object({
   prompt: z.string().min(1),
   cwd: z.string().min(1),
   model: z.string().trim().min(1).optional(),
+  reasoning_effort: ReasoningEffortSchema.optional(),
+  service_tier: ServiceTierSchema.optional(),
   metadata: z.record(z.unknown()).optional().default({}),
   execution_timeout_seconds: z.number().int().positive().optional(),
 });
@@ -193,6 +267,9 @@ export const SendFollowupInputSchema = z.object({
   run_id: z.string().min(1),
   prompt: z.string().min(1),
   model: z.string().trim().min(1).optional(),
+  reasoning_effort: ReasoningEffortSchema.optional(),
+  service_tier: ServiceTierSchema.optional(),
+  metadata: z.record(z.unknown()).optional().default({}),
   execution_timeout_seconds: z.number().int().positive().optional(),
 });
 export type SendFollowupInput = z.input<typeof SendFollowupInputSchema>;
@@ -228,6 +305,148 @@ export const PruneRunsInputSchema = z.object({
 });
 export type PruneRunsInput = z.input<typeof PruneRunsInputSchema>;
 
+export const GetObservabilitySnapshotInputSchema = z.object({
+  limit: z.number().int().positive().max(500).optional().default(50),
+  include_prompts: z.boolean().optional().default(false),
+  recent_event_limit: z.number().int().nonnegative().max(50).optional().default(5),
+  diagnostics: z.boolean().optional().default(false),
+});
+export type GetObservabilitySnapshotInput = z.input<typeof GetObservabilitySnapshotInputSchema>;
+export type GetObservabilitySnapshot = z.output<typeof GetObservabilitySnapshotInputSchema>;
+
+export const ObservabilityArtifactSchema = z.object({
+  name: z.string(),
+  path: z.string(),
+  exists: z.boolean(),
+  bytes: z.number().int().nonnegative().nullable(),
+});
+export type ObservabilityArtifact = z.infer<typeof ObservabilityArtifactSchema>;
+
+export const ObservabilityPromptSchema = z.object({
+  title: z.string(),
+  summary: z.string().nullable(),
+  preview: z.string(),
+  text: z.string().nullable(),
+  path: z.string().nullable(),
+  bytes: z.number().int().nonnegative().nullable(),
+});
+export type ObservabilityPrompt = z.infer<typeof ObservabilityPromptSchema>;
+
+export const ObservabilityResponseSchema = z.object({
+  status: WorkerResultStatusSchema.nullable(),
+  summary: z.string().nullable(),
+  path: z.string().nullable(),
+  bytes: z.number().int().nonnegative().nullable(),
+});
+export type ObservabilityResponse = z.infer<typeof ObservabilityResponseSchema>;
+
+export const ObservabilityActivitySchema = z.object({
+  last_event_sequence: z.number().int().nonnegative(),
+  last_event_at: z.string().nullable(),
+  last_event_type: WorkerEventTypeSchema.nullable(),
+  last_interaction_preview: z.string().nullable(),
+  event_count: z.number().int().nonnegative(),
+  recent_errors: z.array(z.string()),
+  recent_events: z.array(WorkerEventSchema),
+});
+export type ObservabilityActivity = z.infer<typeof ObservabilityActivitySchema>;
+
+export const ObservabilitySessionAuditStatusSchema = z.enum([
+  'new_session',
+  'pending',
+  'resumed',
+  'mismatch',
+  'unknown',
+]);
+export type ObservabilitySessionAuditStatus = z.infer<typeof ObservabilitySessionAuditStatusSchema>;
+
+export const ObservabilitySessionAuditSchema = z.object({
+  requested_session_id: z.string().nullable(),
+  observed_session_id: z.string().nullable(),
+  effective_session_id: z.string().nullable(),
+  status: ObservabilitySessionAuditStatusSchema,
+  warnings: z.array(z.string()),
+});
+export type ObservabilitySessionAudit = z.infer<typeof ObservabilitySessionAuditSchema>;
+
+export const ObservabilityModelSchema = z.object({
+  name: z.string().nullable(),
+  source: ModelSourceSchema,
+  requested_name: z.string().nullable().optional().default(null),
+  observed_name: z.string().nullable().optional().default(null),
+});
+export type ObservabilityModel = z.infer<typeof ObservabilityModelSchema>;
+
+export const ObservabilityRunSettingsSchema = RunModelSettingsSchema;
+export type ObservabilityRunSettings = z.infer<typeof ObservabilityRunSettingsSchema>;
+
+export const ObservabilityRunSchema = z.object({
+  run: RunSummarySchema,
+  prompt: ObservabilityPromptSchema,
+  response: ObservabilityResponseSchema,
+  model: ObservabilityModelSchema,
+  settings: ObservabilityRunSettingsSchema,
+  session: ObservabilitySessionAuditSchema,
+  activity: ObservabilityActivitySchema,
+  artifacts: z.array(ObservabilityArtifactSchema),
+  duration_seconds: z.number().int().nonnegative().nullable(),
+});
+export type ObservabilityRun = z.infer<typeof ObservabilityRunSchema>;
+
+export const ObservabilitySessionPromptSchema = z.object({
+  run_id: z.string(),
+  status: RunStatusSchema,
+  title: z.string(),
+  summary: z.string().nullable(),
+  preview: z.string(),
+  model: ObservabilityModelSchema,
+  settings: ObservabilityRunSettingsSchema,
+  created_at: z.string(),
+  last_activity_at: z.string().nullable(),
+});
+export type ObservabilitySessionPrompt = z.infer<typeof ObservabilitySessionPromptSchema>;
+
+export const ObservabilityWorkspaceSchema = z.object({
+  cwd: z.string(),
+  repository_root: z.string().nullable(),
+  repository_name: z.string().nullable(),
+  branch: z.string().nullable(),
+  dirty_count: z.number().int().nonnegative().nullable(),
+  label: z.string(),
+});
+export type ObservabilityWorkspace = z.infer<typeof ObservabilityWorkspaceSchema>;
+
+export const ObservabilitySessionSchema = z.object({
+  session_key: z.string(),
+  session_id: z.string().nullable(),
+  root_run_id: z.string(),
+  backend: BackendSchema,
+  cwd: z.string(),
+  workspace: ObservabilityWorkspaceSchema,
+  title: z.string(),
+  summary: z.string().nullable(),
+  status: RunStatusSchema,
+  created_at: z.string(),
+  updated_at: z.string(),
+  run_count: z.number().int().nonnegative(),
+  running_count: z.number().int().nonnegative(),
+  models: z.array(ObservabilityModelSchema),
+  settings: z.array(ObservabilityRunSettingsSchema),
+  warnings: z.array(z.string()),
+  prompts: z.array(ObservabilitySessionPromptSchema),
+});
+export type ObservabilitySession = z.infer<typeof ObservabilitySessionSchema>;
+
+export const ObservabilitySnapshotSchema = z.object({
+  generated_at: z.string(),
+  daemon_pid: z.number().int().nullable(),
+  store_root: z.string(),
+  sessions: z.array(ObservabilitySessionSchema),
+  runs: z.array(ObservabilityRunSchema),
+  backend_status: BackendStatusReportSchema.nullable().optional().default(null),
+});
+export type ObservabilitySnapshot = z.infer<typeof ObservabilitySnapshotSchema>;
+
 export const RpcMethodSchema = z.enum([
   'ping',
   'shutdown',
@@ -241,6 +460,7 @@ export const RpcMethodSchema = z.enum([
   'send_followup',
   'cancel_run',
   'get_backend_status',
+  'get_observability_snapshot',
 ]);
 export type RpcMethod = z.infer<typeof RpcMethodSchema>;
 

--- a/src/contract.ts
+++ b/src/contract.ts
@@ -190,8 +190,8 @@ const defaultRunModelSettings = {
 };
 
 export const RunModelSettingsSchema = z.object({
-  reasoning_effort: z.string().nullable().optional().default(null),
-  service_tier: z.string().nullable().optional().default(null),
+  reasoning_effort: ReasoningEffortSchema.nullable().optional().default(null),
+  service_tier: ServiceTierSchema.nullable().optional().default(null),
   mode: z.string().nullable().optional().default(null),
 }).default(defaultRunModelSettings);
 export type RunModelSettings = z.infer<typeof RunModelSettingsSchema>;

--- a/src/daemon/daemonCli.ts
+++ b/src/daemon/daemonCli.ts
@@ -7,6 +7,16 @@ import { existsSync } from 'node:fs';
 import { IpcClient, IpcRequestError } from '../ipc/client.js';
 import { daemonPaths } from './paths.js';
 import { RunStore, type PruneRunsResult } from '../runStore.js';
+import { buildObservabilitySnapshot } from '../observability.js';
+import { getBackendStatus } from '../diagnostics.js';
+import {
+  clampDashboardState,
+  formatSnapshot,
+  renderDashboard,
+  type DashboardState,
+  type SnapshotEnvelope,
+} from './observabilityFormat.js';
+import type { ObservabilitySnapshot } from '../contract.js';
 
 const paths = daemonPaths();
 const command = process.argv[2] ?? 'status';
@@ -22,11 +32,17 @@ async function main(): Promise<void> {
     case 'status':
       await status();
       break;
+    case 'runs':
+      await runs();
+      break;
+    case 'watch':
+      await watch();
+      break;
     case 'prune':
       await prune();
       break;
     default:
-      process.stderr.write('Usage: daemonCli.js start | stop [--force] | status | prune --older-than-days <days> [--dry-run]\n');
+      process.stderr.write('Usage: daemonCli.js start | stop [--force] | status [--verbose|--json] | runs [--json] [--prompts] | watch [--interval-ms <ms>] [--limit <n>] | prune --older-than-days <days> [--dry-run]\n');
       process.exit(1);
   }
 }
@@ -66,6 +82,16 @@ async function stop(force: boolean): Promise<void> {
 }
 
 async function status(): Promise<void> {
+  if (process.argv.includes('--verbose') || process.argv.includes('--json')) {
+    const envelope = await readSnapshotFromDaemonOrStore(snapshotOptionsFromArgs({ includePrompts: process.argv.includes('--prompts') }));
+    if (process.argv.includes('--json')) {
+      process.stdout.write(`${JSON.stringify(envelope, null, 2)}\n`);
+    } else {
+      process.stdout.write(formatSnapshot(envelope));
+    }
+    return;
+  }
+
   const client = new IpcClient(paths.socket);
   try {
     const pingResult = await client.request('ping', {}) as { ok: true; pong: true; daemon_pid: number };
@@ -77,6 +103,110 @@ async function status(): Promise<void> {
     process.stdout.write('stopped\n');
     process.exitCode = 1;
   }
+}
+
+async function runs(): Promise<void> {
+  const envelope = await readSnapshotFromDaemonOrStore(snapshotOptionsFromArgs({ includePrompts: process.argv.includes('--prompts') }));
+  if (process.argv.includes('--json')) {
+    process.stdout.write(`${JSON.stringify(envelope, null, 2)}\n`);
+  } else {
+    process.stdout.write(formatSnapshot(envelope));
+  }
+}
+
+async function watch(): Promise<void> {
+  const intervalMs = readPositiveIntOption('--interval-ms') ?? 1_000;
+  const options = snapshotOptionsFromArgs({ includePrompts: true });
+  if (!process.stdout.isTTY || !process.stdin.isTTY) {
+    process.stdout.write(formatSnapshot(await readSnapshotFromDaemonOrStore(options)));
+    return;
+  }
+
+  let envelope = await readSnapshotFromDaemonOrStore(options);
+  let state: DashboardState = { view: 'sessions', selectedSession: 0, selectedPrompt: 0 };
+  let stopped = false;
+  let refreshTimer: NodeJS.Timeout | null = null;
+  let resolveDone: (() => void) | null = null;
+
+  const finish = () => {
+    if (stopped) return;
+    stopped = true;
+    if (refreshTimer) clearTimeout(refreshTimer);
+    process.stdin.off('data', onKey);
+    if (process.stdin.isTTY) process.stdin.setRawMode(false);
+    process.stdin.pause();
+    process.stdout.write('\x1b[?25h\x1b[0m\n');
+    resolveDone?.();
+  };
+
+  const repaint = () => {
+    state = clampDashboardState(state, envelope.snapshot);
+    process.stdout.write('\x1b[?25l\x1b[H\x1b[2J');
+    process.stdout.write(renderDashboard(envelope, state, process.stdout.columns ?? 100, process.stdout.rows ?? 30));
+  };
+
+  const refresh = async () => {
+    if (stopped) return;
+    try {
+      envelope = await readSnapshotFromDaemonOrStore(options);
+    } catch (error) {
+      envelope = {
+        running: false,
+        snapshot: {
+          generated_at: new Date().toISOString(),
+          daemon_pid: null,
+          store_root: paths.home,
+          sessions: [],
+          runs: [],
+          backend_status: null,
+        },
+        error: error instanceof Error ? error.message : String(error),
+      };
+    }
+    if (stopped) return;
+    repaint();
+    refreshTimer = setTimeout(refresh, intervalMs);
+  };
+
+  const onKey = (chunk: Buffer) => {
+    const key = chunk.toString('utf8');
+    if (key === '\u0003' || key === 'q') {
+      finish();
+      return;
+    }
+    if (key === '\x1b[A') {
+      if (state.view === 'sessions') state.selectedSession -= 1;
+      if (state.view === 'prompts' || state.view === 'detail') state.selectedPrompt -= 1;
+      repaint();
+      return;
+    }
+    if (key === '\x1b[B') {
+      if (state.view === 'sessions') state.selectedSession += 1;
+      if (state.view === 'prompts' || state.view === 'detail') state.selectedPrompt += 1;
+      repaint();
+      return;
+    }
+    if (key === '\r' || key === '\n') {
+      if (state.view === 'sessions') state.view = 'prompts';
+      else if (state.view === 'prompts') state.view = 'detail';
+      repaint();
+      return;
+    }
+    if (key === '\x7f' || key === '\x1b') {
+      if (state.view === 'detail') state.view = 'prompts';
+      else if (state.view === 'prompts') state.view = 'sessions';
+      repaint();
+    }
+  };
+
+  process.stdin.setRawMode(true);
+  process.stdin.resume();
+  process.stdin.on('data', onKey);
+  process.once('SIGINT', finish);
+  process.once('SIGTERM', finish);
+  const done = new Promise<void>((resolve) => { resolveDone = resolve; });
+  await refresh();
+  await done;
 }
 
 async function prune(): Promise<void> {
@@ -104,6 +234,52 @@ async function prune(): Promise<void> {
   for (const run of result.matched) {
     process.stdout.write(`${run.run_id} ${run.status} ${run.finished_at ?? ''}\n`);
   }
+}
+
+interface SnapshotOptions {
+  limit: number;
+  includePrompts: boolean;
+  recentEventLimit: number;
+  diagnostics: boolean;
+}
+
+function snapshotOptionsFromArgs(defaults: Partial<SnapshotOptions> = {}): SnapshotOptions {
+  return {
+    limit: readPositiveIntOption('--limit') ?? defaults.limit ?? 50,
+    includePrompts: defaults.includePrompts ?? false,
+    recentEventLimit: readPositiveIntOption('--recent-events') ?? defaults.recentEventLimit ?? 5,
+    diagnostics: process.argv.includes('--diagnostics') || defaults.diagnostics === true,
+  };
+}
+
+async function readSnapshotFromDaemonOrStore(options: SnapshotOptions): Promise<SnapshotEnvelope> {
+  const params = {
+    limit: options.limit,
+    include_prompts: options.includePrompts,
+    recent_event_limit: options.recentEventLimit,
+    diagnostics: options.diagnostics,
+  };
+  if (await ping()) {
+    const client = new IpcClient(paths.socket);
+    const result = await client.request('get_observability_snapshot', params, 30_000) as {
+      ok: boolean;
+      snapshot?: ObservabilitySnapshot;
+      error?: { message?: string };
+    };
+    if (result.ok && result.snapshot) return { running: true, snapshot: result.snapshot };
+    throw new Error(result.error?.message ?? 'failed to read observability snapshot');
+  }
+
+  return {
+    running: false,
+    snapshot: await buildObservabilitySnapshot(new RunStore(paths.home), {
+      limit: options.limit,
+      includePrompts: options.includePrompts,
+      recentEventLimit: options.recentEventLimit,
+      daemonPid: null,
+      backendStatus: options.diagnostics ? await getBackendStatus() : null,
+    }),
+  };
 }
 
 async function ping(): Promise<boolean> {

--- a/src/daemon/daemonCli.ts
+++ b/src/daemon/daemonCli.ts
@@ -6,6 +6,7 @@ import { readFile } from 'node:fs/promises';
 import { existsSync } from 'node:fs';
 import { IpcClient, IpcRequestError } from '../ipc/client.js';
 import { daemonPaths } from './paths.js';
+import { checkDaemonVersion } from '../daemonVersion.js';
 import { getPackageVersion } from '../packageMetadata.js';
 import { RunStore, type PruneRunsResult } from '../runStore.js';
 import { buildObservabilitySnapshot } from '../observability.js';
@@ -17,7 +18,7 @@ import {
   type DashboardState,
   type SnapshotEnvelope,
 } from './observabilityFormat.js';
-import type { ObservabilitySnapshot } from '../contract.js';
+import type { ObservabilitySnapshot, OrchestratorError } from '../contract.js';
 
 const paths = daemonPaths();
 const command = process.argv[2] ?? 'status';
@@ -284,7 +285,18 @@ async function readSnapshotFromDaemonOrStore(options: SnapshotOptions): Promise<
     recent_event_limit: options.recentEventLimit,
     diagnostics: options.diagnostics,
   };
-  if (await ping()) {
+  const pingResult = await pingDaemon();
+  if (pingResult) {
+    const versionCheck = checkDaemonVersion(pingResult);
+    if (!versionCheck.ok) {
+      return readSnapshotFromStore(options, {
+        running: true,
+        daemonPid: errorDetailNumber(versionCheck.error, 'daemon_pid'),
+        daemonVersion: errorDetailString(versionCheck.error, 'daemon_version'),
+        error: versionCheck.error.message,
+      });
+    }
+
     const client = new IpcClient(paths.ipc.path);
     const result = await client.request('get_observability_snapshot', params, 30_000) as {
       ok: boolean;
@@ -295,30 +307,51 @@ async function readSnapshotFromDaemonOrStore(options: SnapshotOptions): Promise<
     throw new Error(result.error?.message ?? 'failed to read observability snapshot');
   }
 
+  return readSnapshotFromStore(options, { running: false });
+}
+
+async function readSnapshotFromStore(
+  options: SnapshotOptions,
+  state: { running: boolean; daemonPid?: number | null; daemonVersion?: string | null; error?: string },
+): Promise<SnapshotEnvelope> {
   return {
-    running: false,
+    running: state.running,
     snapshot: await buildObservabilitySnapshot(new RunStore(paths.home), {
       limit: options.limit,
       includePrompts: options.includePrompts,
       recentEventLimit: options.recentEventLimit,
-      daemonPid: null,
+      daemonPid: state.daemonPid ?? null,
       backendStatus: options.diagnostics ? await getBackendStatus({
         frontendVersion: getPackageVersion(),
-        daemonVersion: null,
-        daemonPid: null,
+        daemonVersion: state.daemonVersion ?? null,
+        daemonPid: state.daemonPid ?? null,
       }) : null,
     }),
+    error: state.error,
   };
 }
 
 async function ping(): Promise<boolean> {
+  return (await pingDaemon()) !== null;
+}
+
+async function pingDaemon(): Promise<unknown | null> {
   try {
     const client = new IpcClient(paths.ipc.path);
-    await client.request('ping', {}, 1000);
-    return true;
+    return await client.request('ping', {}, 1000);
   } catch {
-    return false;
+    return null;
   }
+}
+
+function errorDetailString(error: OrchestratorError, key: string): string | null {
+  const value = error.details?.[key];
+  return typeof value === 'string' ? value : null;
+}
+
+function errorDetailNumber(error: OrchestratorError, key: string): number | null {
+  const value = error.details?.[key];
+  return typeof value === 'number' ? value : null;
 }
 
 async function waitForDaemon(timeoutMs: number): Promise<void> {

--- a/src/daemon/observabilityFormat.ts
+++ b/src/daemon/observabilityFormat.ts
@@ -1,0 +1,433 @@
+import { basename, dirname } from 'node:path';
+import type { ObservabilityRun, ObservabilityRunSettings, ObservabilitySession, ObservabilitySnapshot } from '../contract.js';
+
+export interface SnapshotEnvelope {
+  running: boolean;
+  snapshot: ObservabilitySnapshot;
+  error?: string;
+}
+
+export interface DashboardState {
+  view: 'sessions' | 'prompts' | 'detail';
+  selectedSession: number;
+  selectedPrompt: number;
+}
+
+export function formatSnapshot(envelope: SnapshotEnvelope): string {
+  const { snapshot } = envelope;
+  const lines = [
+    `agent-orchestrator daemon: ${envelope.running ? `running pid=${snapshot.daemon_pid ?? 'unknown'}` : 'stopped'}`,
+    `store: ${snapshot.store_root}`,
+    `generated: ${snapshot.generated_at}`,
+  ];
+  if (envelope.error) lines.push(`error: ${envelope.error}`);
+
+  lines.push('', `sessions: ${snapshot.sessions.length} runs: ${snapshot.runs.length}`, '');
+  if (snapshot.sessions.length === 0) {
+    lines.push('No runs recorded.');
+    return `${lines.join('\n')}\n`;
+  }
+
+  lines.push('Sessions');
+  for (const session of snapshot.sessions) {
+    lines.push(`- ${session.title} [${session.status}] agent=${session.backend} model=${formatLatestModel(session)} effort=${formatLatestEffort(session)} tier=${formatLatestTier(session)} prompts=${session.run_count} workspace=${formatWorkspace(session)} updated=${session.updated_at}`);
+    if (session.summary) lines.push(`  ${session.summary}`);
+    if (session.session_id) lines.push(`  session=${session.session_id}`);
+    for (const prompt of session.prompts.slice(-5)) {
+      lines.push(`  - ${prompt.title} [${prompt.status}] model=${formatModel(prompt.model)} effort=${formatSetting(prompt.settings.reasoning_effort)} tier=${formatTier(prompt.settings)} last=${prompt.last_activity_at ?? 'none'}`);
+    }
+    for (const warning of session.warnings) lines.push(`  warning: ${warning}`);
+  }
+
+  lines.push('', 'Runs');
+  for (const run of snapshot.runs) {
+    lines.push(formatRunLine(run));
+  }
+
+  return `${lines.join('\n')}\n`;
+}
+
+export function renderDashboard(envelope: SnapshotEnvelope, state: DashboardState, width: number, height: number): string {
+  const snapshot = envelope.snapshot;
+  const lines = [
+    `${style.bold('agent-orchestrator')} ${style.dim(envelope.running ? `running pid=${snapshot.daemon_pid ?? 'unknown'}` : 'stopped')} | ${snapshot.sessions.length} sessions | ${snapshot.runs.length} runs | ${snapshot.generated_at}`,
+    renderViewState(snapshot, state),
+    style.dim(renderKeyHint(snapshot, state)),
+    '',
+  ];
+  if (envelope.error) lines.push(`error: ${envelope.error}`, '');
+
+  if (state.view === 'sessions') {
+    lines.push(...renderSessionList(snapshot.sessions, state.selectedSession));
+  } else if (state.view === 'prompts') {
+    lines.push(...renderPromptList(currentSession(snapshot, state), state.selectedPrompt));
+  } else {
+    lines.push(...renderRunDetail(currentRun(snapshot, state), width));
+  }
+
+  return `${lines.slice(0, Math.max(1, height - 1)).map((line) => fit(line, width)).join('\n')}\n`;
+}
+
+export function clampDashboardState(state: DashboardState, snapshot: ObservabilitySnapshot): DashboardState {
+  const next = { ...state };
+  next.selectedSession = clamp(next.selectedSession, 0, Math.max(0, snapshot.sessions.length - 1));
+  const session = snapshot.sessions[next.selectedSession] ?? null;
+  next.selectedPrompt = clamp(next.selectedPrompt, 0, Math.max(0, (session?.prompts.length ?? 1) - 1));
+  if (!session && next.view !== 'sessions') next.view = 'sessions';
+  return next;
+}
+
+function renderSessionList(sessions: ObservabilitySession[], selected: number): string[] {
+  if (sessions.length === 0) return ['No runs recorded.'];
+  const lines = [
+    sectionTitle('Sessions'),
+    style.dim(`  ${pad('AGENT', 7)} ${pad('STATUS', 10)} ${pad('PROMPTS', 7)} ${pad('MODEL', 22)} ${pad('EFFORT', 8)} ${pad('TIER', 8)} ${pad('WORKSPACE', 32)} CHAT`),
+    style.dim(`  ${'-'.repeat(7)} ${'-'.repeat(10)} ${'-'.repeat(7)} ${'-'.repeat(22)} ${'-'.repeat(8)} ${'-'.repeat(8)} ${'-'.repeat(32)} ${'-'.repeat(20)}`),
+  ];
+  sessions.forEach((session, index) => {
+    lines.push(selectLine(index === selected, formatSessionRow(session)));
+  });
+  return lines;
+}
+
+function renderPromptList(session: ObservabilitySession | null, selected: number): string[] {
+  if (!session) return ['No session selected.'];
+  const shownText = session.prompts.length === session.run_count ? '' : ` shown=${session.prompts.length}`;
+  const lines = [
+    `Session: ${session.title} [${session.status}] prompts=${session.run_count}${shownText} workspace=${formatWorkspace(session)} updated=${session.updated_at}`,
+  ];
+  if (session.summary) lines.push(`Summary: ${session.summary}`);
+  if (session.session_id) lines.push(`Session ID: ${session.session_id}`);
+  for (const warning of session.warnings) lines.push(`Warning: ${warning}`);
+  lines.push(
+    '',
+    sectionTitle('Prompts'),
+    style.dim(`  ${pad('STATUS', 10)} ${pad('MODEL', 26)} ${pad('EFFORT', 8)} ${pad('TIER', 8)} ${pad('LAST', 19)} PROMPT`),
+    style.dim(`  ${'-'.repeat(10)} ${'-'.repeat(26)} ${'-'.repeat(8)} ${'-'.repeat(8)} ${'-'.repeat(19)} ${'-'.repeat(20)}`),
+  );
+  session.prompts.forEach((prompt, index) => {
+    lines.push(selectLine(index === selected, `${statusCell(prompt.status, 10)} ${modelCell(formatModelCompact(prompt.model), 26)} ${settingsCell(formatSetting(prompt.settings.reasoning_effort), 8)} ${settingsCell(formatTier(prompt.settings), 8)} ${pad(formatTimestamp(prompt.last_activity_at), 19)} ${prompt.title}`));
+  });
+  return lines;
+}
+
+function formatSessionRow(session: ObservabilitySession): string {
+  const warningText = session.warnings.length > 0 ? ` warnings=${session.warnings.length}` : '';
+  return `${agentCell(session.backend, 7)} ${statusCell(session.status, 10)} ${pad(String(session.run_count), 7)} ${modelCell(formatLatestModel(session), 22)} ${settingsCell(formatLatestEffort(session), 8)} ${settingsCell(formatLatestTier(session), 8)} ${workspaceCell(formatWorkspace(session), 32)} ${session.title}${warningText}`;
+}
+
+function renderRunDetail(run: ObservabilityRun | null, width: number): string[] {
+  if (!run) return ['No run selected.'];
+  const lines = [
+    sectionTitle('Prompt Detail'),
+    detailLine('Run', run.run.run_id),
+    detailLine('Title', run.prompt.title),
+    `${style.bold('Status')}: ${colorStatus(run.run.status)}`,
+    detailLine('Agent', run.run.backend),
+    detailLine('Model', formatModel(run.model)),
+    detailLine('Reasoning', formatSetting(run.settings.reasoning_effort)),
+    detailLine('Service Tier', formatTier(run.settings)),
+    detailLine('Invocation', formatInvocation(run)),
+    detailLine('Cwd', run.run.cwd),
+    detailLine('Git', formatRunGit(run)),
+    detailLine('Session', `requested=${run.session.requested_session_id ?? 'none'} observed=${run.session.observed_session_id ?? 'none'} effective=${run.session.effective_session_id ?? 'none'} audit=${run.session.status}`),
+    detailLine('Duration', `${run.duration_seconds === null ? 'unknown' : `${run.duration_seconds}s`} events=${run.activity.event_count}`),
+  ];
+  for (const warning of run.session.warnings) lines.push(`Warning: ${warning}`);
+  if (run.prompt.summary) lines.push(`Summary: ${run.prompt.summary}`);
+  lines.push('', sectionTitle('User Prompt'));
+  lines.push(...wrap((run.prompt.text ?? run.prompt.preview) || '(prompt not included)', Math.max(40, width - 2)).map((line) => `  ${line}`));
+  lines.push('', `${sectionTitle('Final Response')} ${colorResponseStatus(run.response.status ?? responseStateLabel(run))}`);
+  lines.push(...wrap(run.response.summary ?? responsePlaceholder(run), Math.max(40, width - 2)).map((line) => `  ${line}`));
+  lines.push('', sectionTitle('Recent Activity'));
+  if (run.activity.recent_events.length === 0) lines.push('  none');
+  for (const event of run.activity.recent_events) {
+    lines.push(`  ${style.dim(`#${event.seq}`)} ${formatTimestamp(event.ts)} ${event.type}`);
+  }
+  if (run.activity.recent_errors.length > 0) {
+    lines.push('', sectionTitle('Recent Errors'));
+    for (const error of run.activity.recent_errors) lines.push(`  ${error}`);
+  }
+  lines.push('', sectionTitle('Artifacts'));
+  for (const artifact of run.artifacts) {
+    lines.push(`  ${artifact.name} ${artifact.exists ? formatBytes(artifact.bytes ?? 0) : 'missing'} ${artifact.path}`);
+  }
+  return lines;
+}
+
+function responseStateLabel(run: ObservabilityRun): string {
+  return run.run.status === 'running' ? 'pending' : 'missing';
+}
+
+function responsePlaceholder(run: ObservabilityRun): string {
+  return run.run.status === 'running' ? '(response pending)' : '(no final response recorded)';
+}
+
+function currentSession(snapshot: ObservabilitySnapshot, state: DashboardState): ObservabilitySession | null {
+  return snapshot.sessions[state.selectedSession] ?? null;
+}
+
+function currentRun(snapshot: ObservabilitySnapshot, state: DashboardState): ObservabilityRun | null {
+  const session = currentSession(snapshot, state);
+  const prompt = session?.prompts[state.selectedPrompt];
+  if (!prompt) return null;
+  return snapshot.runs.find((run) => run.run.run_id === prompt.run_id) ?? null;
+}
+
+function renderViewState(snapshot: ObservabilitySnapshot, state: DashboardState): string {
+  const session = currentSession(snapshot, state);
+  const prompt = session?.prompts[state.selectedPrompt] ?? null;
+  if (state.view === 'sessions') {
+    return `${style.bold('View')}: Sessions ${position(state.selectedSession, snapshot.sessions.length)}`;
+  }
+  if (state.view === 'prompts') {
+    return `${style.bold('View')}: Sessions > ${session?.title ?? 'none'} | Prompt ${position(state.selectedPrompt, session?.prompts.length ?? 0)}`;
+  }
+  return `${style.bold('View')}: Detail > ${session?.title ?? 'none'} > ${prompt?.title ?? 'none'} | Prompt ${position(state.selectedPrompt, session?.prompts.length ?? 0)}`;
+}
+
+function renderKeyHint(snapshot: ObservabilitySnapshot, state: DashboardState): string {
+  const session = currentSession(snapshot, state);
+  if (state.view === 'sessions') return 'Keys: Up/Down choose chat, Enter opens prompts, q exits | PROMPTS=history length';
+  if (state.view === 'prompts') return 'Keys: Up/Down choose prompt, Enter opens detail, Esc/Backspace returns to chats, q exits';
+  return `Keys: Up/Down switches prompt in ${session?.title ?? 'this chat'}, Esc/Backspace returns to prompts, q exits`;
+}
+
+function position(index: number, count: number): string {
+  return count > 0 ? `${clamp(index, 0, count - 1) + 1}/${count}` : '0/0';
+}
+
+function formatRunLine(run: ObservabilityRun): string {
+  return `- ${run.prompt.title} [${run.run.status}] ${run.run.run_id} model=${formatModel(run.model)} effort=${formatSetting(run.settings.reasoning_effort)} tier=${formatTier(run.settings)} invocation=${formatInvocation(run)} session=${run.session.effective_session_id ?? 'none'} events=${run.activity.event_count} size=${formatBytes(run.artifacts.reduce((sum, artifact) => sum + (artifact.bytes ?? 0), 0))}`;
+}
+
+function formatModel(model: { name: string | null; source: string; requested_name?: string | null; observed_name?: string | null }): string {
+  const name = model.name ?? 'default';
+  if (model.requested_name && model.observed_name && model.requested_name !== model.observed_name) {
+    return `${name} (${model.source}, requested ${model.requested_name})`;
+  }
+  return `${name} (${model.source})`;
+}
+
+function formatModelCompact(model: { name: string | null; source: string }): string {
+  return model.name ?? `default/${model.source}`;
+}
+
+function formatSessionModels(session: ObservabilitySession): string {
+  if (session.models.length === 0) return 'unknown';
+  const labels = session.models.map(formatModelCompact);
+  const [first, ...rest] = labels;
+  return rest.length === 0 ? first ?? 'unknown' : `${first ?? 'unknown'} +${rest.length}`;
+}
+
+function formatSessionEfforts(session: ObservabilitySession): string {
+  return formatUniqueSettings(session.settings.map((settings) => formatSetting(settings.reasoning_effort)));
+}
+
+function formatSessionTiers(session: ObservabilitySession): string {
+  return formatUniqueSettings(session.settings.map(formatTier));
+}
+
+function formatLatestModel(session: ObservabilitySession): string {
+  const prompt = latestPrompt(session);
+  return prompt ? formatModelCompact(prompt.model) : formatSessionModels(session);
+}
+
+function formatLatestEffort(session: ObservabilitySession): string {
+  const prompt = latestPrompt(session);
+  return prompt ? formatSetting(prompt.settings.reasoning_effort) : formatSessionEfforts(session);
+}
+
+function formatLatestTier(session: ObservabilitySession): string {
+  const prompt = latestPrompt(session);
+  return prompt ? formatTier(prompt.settings) : formatSessionTiers(session);
+}
+
+function latestPrompt(session: ObservabilitySession) {
+  return session.prompts[session.prompts.length - 1] ?? null;
+}
+
+function formatWorkspace(session: ObservabilitySession): string {
+  const workspace = session.workspace;
+  if (!workspace) return compactFolder(session.cwd);
+  const dirty = workspace.dirty_count !== null && workspace.dirty_count > 0 ? '*' : '';
+  if (workspace.repository_name && workspace.branch) {
+    const repo = compactRepositoryName(workspace.repository_name);
+    return `${repo}:${compactBranchName(workspace.branch, Math.max(8, 31 - repo.length - dirty.length))}${dirty}`;
+  }
+  if (workspace.repository_name) {
+    return workspace.label.replace(workspace.repository_name, compactRepositoryName(workspace.repository_name));
+  }
+  return compactFolder(workspace.cwd);
+}
+
+function formatRunGit(run: ObservabilityRun): string {
+  const snapshot = run.run.git_snapshot;
+  if (!snapshot) return run.run.git_snapshot_status;
+  const repo = snapshot.root ? basename(snapshot.root) : null;
+  const target = repo && snapshot.branch
+    ? `${repo}:${snapshot.branch}`
+    : repo
+      ? `${repo}@${snapshot.sha.slice(0, 7)}`
+      : snapshot.sha.slice(0, 7);
+  const dirty = snapshot.dirty_count > 0 ? `dirty=${snapshot.dirty_count}` : 'clean';
+  return `${target} ${dirty}`;
+}
+
+function compactFolder(cwd: string): string {
+  const leaf = basename(cwd);
+  const rawParent = basename(dirname(cwd));
+  const parent = rawParent.startsWith('worktrees-') ? rawParent.slice('worktrees-'.length) : rawParent;
+  const compactParent = compactRepositoryName(parent);
+  if (parent && leaf && parent !== leaf && `${parent}/${leaf}`.length <= 32) return `${parent}/${leaf}`;
+  if (compactParent && leaf && compactParent !== leaf) return `${compactParent}/${leaf}`;
+  return leaf || cwd;
+}
+
+function compactRepositoryName(name: string): string {
+  if (name.length <= 14) return name;
+  const parts = name.split('-').filter(Boolean);
+  if (parts.length <= 1) return name.slice(0, 14);
+  const head = parts.slice(0, -1).map((part) => part[0]).join('');
+  return `${head}-${parts[parts.length - 1] ?? ''}`;
+}
+
+function compactBranchName(name: string, maxLength: number): string {
+  if (name.length <= maxLength) return name;
+  const parts = name.split('/').filter(Boolean);
+  const last = parts[parts.length - 1];
+  if (last && last.length <= maxLength) return last;
+  if (maxLength <= 1) return name.slice(0, maxLength);
+  return `${name.slice(0, maxLength - 1)}.`;
+}
+
+function formatUniqueSettings(values: string[]): string {
+  const unique = Array.from(new Set(values));
+  const [first, ...rest] = unique;
+  return rest.length === 0 ? first ?? 'default' : `${first ?? 'default'} +${rest.length}`;
+}
+
+function formatSetting(value: string | null): string {
+  return value ?? 'default';
+}
+
+function formatTier(settings: ObservabilityRunSettings): string {
+  return settings.service_tier ?? settings.mode ?? 'default';
+}
+
+function formatInvocation(run: ObservabilityRun): string {
+  const invocation = run.run.worker_invocation;
+  if (!invocation) return 'not recorded';
+  return [invocation.command, ...invocation.args.map(shellQuote)].join(' ');
+}
+
+function shellQuote(value: string): string {
+  return /^[A-Za-z0-9_./:=@+-]+$/.test(value) ? value : `'${value.replace(/'/g, `'\\''`)}'`;
+}
+
+function formatTimestamp(value: string | null): string {
+  return value ? value.replace('T', ' ').slice(0, 19) : 'none';
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes}B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)}KiB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)}MiB`;
+}
+
+function detailLine(label: string, value: string): string {
+  return `${style.bold(label)}: ${value}`;
+}
+
+function sectionTitle(value: string): string {
+  return `\x1b[1;36m${value}\x1b[0m`;
+}
+
+function agentCell(value: string, width: number): string {
+  return style.magenta(pad(value, width));
+}
+
+function statusCell(value: string, width: number): string {
+  return colorStatus(pad(value, width), value);
+}
+
+function modelCell(value: string, width: number): string {
+  return style.cyan(pad(value, width));
+}
+
+function workspaceCell(value: string, width: number): string {
+  return style.dim(pad(value, width));
+}
+
+function settingsCell(value: string, width: number): string {
+  return value === 'default' ? style.dim(pad(value, width)) : style.yellow(pad(value, width));
+}
+
+function colorStatus(value: string, status = value): string {
+  if (status === 'running') return style.yellow(value);
+  if (status === 'completed') return style.green(value);
+  if (status === 'cancelled' || status === 'timed_out' || status === 'failed' || status === 'orphaned') return style.red(value);
+  return value;
+}
+
+function colorResponseStatus(status: string): string {
+  if (status === 'completed') return style.green(`[${status}]`);
+  if (status === 'pending' || status === 'needs_input') return style.yellow(`[${status}]`);
+  if (status === 'failed' || status === 'blocked' || status === 'missing') return style.red(`[${status}]`);
+  return `[${status}]`;
+}
+
+function pad(value: string, width: number): string {
+  if (value.length === width) return value;
+  if (value.length > width) return `${value.slice(0, Math.max(0, width - 1))}.`;
+  return `${value}${' '.repeat(width - value.length)}`;
+}
+
+function selectLine(selected: boolean, text: string): string {
+  return selected ? `\x1b[7m> ${text}\x1b[0m` : `  ${text}`;
+}
+
+function fit(line: string, width: number): string {
+  if (visibleLength(line) <= width) return line;
+  return `${stripAnsi(line).slice(0, Math.max(0, width - 3))}...`;
+}
+
+function wrap(text: string, width: number): string[] {
+  const words = text.split(/\s+/).filter(Boolean);
+  const lines: string[] = [];
+  let current = '';
+  for (const word of words) {
+    if (!current) {
+      current = word;
+    } else if (`${current} ${word}`.length <= width) {
+      current = `${current} ${word}`;
+    } else {
+      lines.push(current);
+      current = word;
+    }
+  }
+  if (current) lines.push(current);
+  return lines.length > 0 ? lines : [''];
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(Math.max(value, min), max);
+}
+
+function visibleLength(value: string): number {
+  return stripAnsi(value).length;
+}
+
+function stripAnsi(value: string): string {
+  return value.replace(/\x1b\[[0-9;]*m/g, '');
+}
+
+const style = {
+  bold: (value: string) => `\x1b[1m${value}\x1b[0m`,
+  dim: (value: string) => `\x1b[2m${value}\x1b[0m`,
+  cyan: (value: string) => `\x1b[36m${value}\x1b[0m`,
+  green: (value: string) => `\x1b[32m${value}\x1b[0m`,
+  yellow: (value: string) => `\x1b[33m${value}\x1b[0m`,
+  red: (value: string) => `\x1b[31m${value}\x1b[0m`,
+  magenta: (value: string) => `\x1b[35m${value}\x1b[0m`,
+};

--- a/src/gitSnapshot.ts
+++ b/src/gitSnapshot.ts
@@ -30,8 +30,9 @@ export async function captureGitSnapshot(cwd: string): Promise<GitSnapshotCaptur
 }
 
 async function doCaptureGitSnapshot(cwd: string): Promise<GitSnapshotCapture> {
+  let root: string;
   try {
-    await git(cwd, ['rev-parse', '--show-toplevel']);
+    root = (await git(cwd, ['rev-parse', '--show-toplevel'])).trim();
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
       return { status: 'git_unavailable', snapshot: null };
@@ -39,6 +40,7 @@ async function doCaptureGitSnapshot(cwd: string): Promise<GitSnapshotCapture> {
     return { status: 'not_a_repo', snapshot: null };
   }
 
+  const branch = await currentBranch(cwd);
   let sha: string;
   try {
     sha = (await git(cwd, ['rev-parse', 'HEAD'])).trim();
@@ -63,6 +65,8 @@ async function doCaptureGitSnapshot(cwd: string): Promise<GitSnapshotCapture> {
     status: 'captured',
     snapshot: {
       sha,
+      root,
+      branch,
       dirty_count: dirty.length,
       dirty,
       dirty_fingerprints: await fingerprintPaths(cwd, dirty),
@@ -122,6 +126,22 @@ async function git(cwd: string, args: string[]): Promise<string> {
     env: { ...process.env, NO_COLOR: '1', TERM: 'dumb' },
   });
   return stdout;
+}
+
+async function currentBranch(cwd: string): Promise<string | null> {
+  try {
+    const branch = (await git(cwd, ['branch', '--show-current'])).trim();
+    if (branch) return branch;
+  } catch {
+    // Detached HEADs and older Git versions can fail here; fall back below.
+  }
+
+  try {
+    const branch = (await git(cwd, ['rev-parse', '--abbrev-ref', 'HEAD'])).trim();
+    return branch && branch !== 'HEAD' ? branch : null;
+  } catch {
+    return null;
+  }
 }
 
 function parseNameOnly(output: string): string[] {

--- a/src/mcpTools.ts
+++ b/src/mcpTools.ts
@@ -1,0 +1,134 @@
+export const tools = [
+  {
+    name: 'start_run',
+    description: 'Start a Codex or Claude worker run.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        backend: { type: 'string', enum: ['codex', 'claude'] },
+        prompt: { type: 'string' },
+        cwd: { type: 'string' },
+        model: {
+          type: 'string',
+          description: 'Worker model id. For Claude, pass a direct model id such as claude-opus-4-7 or claude-opus-4-7[1m], not aliases like opus or sonnet.',
+        },
+        reasoning_effort: {
+          type: 'string',
+          enum: ['none', 'minimal', 'low', 'medium', 'high', 'xhigh', 'max'],
+          description: 'Backend-applied reasoning effort. Codex supports none/minimal/low/medium/high/xhigh. Claude supports low/medium/high/xhigh/max on supported direct model ids; xhigh requires Opus 4.7.',
+        },
+        service_tier: {
+          type: 'string',
+          enum: ['fast', 'flex', 'normal'],
+          description: 'Backend-applied speed tier for Codex. Claude does not support this field.',
+        },
+        metadata: { type: 'object', additionalProperties: true },
+        execution_timeout_seconds: { type: 'number' },
+      },
+      required: ['backend', 'prompt', 'cwd'],
+    },
+  },
+  {
+    name: 'list_runs',
+    description: 'List known worker runs in descending creation order.',
+    inputSchema: { type: 'object', properties: {} },
+  },
+  {
+    name: 'get_run_status',
+    description: 'Get the current lifecycle status for a run.',
+    inputSchema: {
+      type: 'object',
+      properties: { run_id: { type: 'string' } },
+      required: ['run_id'],
+    },
+  },
+  {
+    name: 'get_run_events',
+    description: 'Read worker events with cursor pagination.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        run_id: { type: 'string' },
+        after_sequence: { type: 'number' },
+        limit: { type: 'number' },
+      },
+      required: ['run_id'],
+    },
+  },
+  {
+    name: 'wait_for_run',
+    description: 'Wait for a run to reach a terminal status, bounded by wait_seconds.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        run_id: { type: 'string' },
+        wait_seconds: { type: 'number' },
+      },
+      required: ['run_id', 'wait_seconds'],
+    },
+  },
+  {
+    name: 'get_run_result',
+    description: 'Get the normalized worker result for a run, or null while it is running.',
+    inputSchema: {
+      type: 'object',
+      properties: { run_id: { type: 'string' } },
+      required: ['run_id'],
+    },
+  },
+  {
+    name: 'send_followup',
+    description: 'Start a follow-up run by resuming the parent run backend session.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        run_id: { type: 'string' },
+        prompt: { type: 'string' },
+        model: {
+          type: 'string',
+          description: 'Worker model id. For Claude, pass a direct model id such as claude-opus-4-7 or claude-opus-4-7[1m], not aliases like opus or sonnet.',
+        },
+        reasoning_effort: {
+          type: 'string',
+          enum: ['none', 'minimal', 'low', 'medium', 'high', 'xhigh', 'max'],
+          description: 'Backend-applied reasoning effort. Omit to inherit the parent run setting. Claude xhigh requires Opus 4.7.',
+        },
+        service_tier: {
+          type: 'string',
+          enum: ['fast', 'flex', 'normal'],
+          description: 'Backend-applied speed tier for Codex. Omit to inherit the parent run setting.',
+        },
+        metadata: { type: 'object', additionalProperties: true },
+        execution_timeout_seconds: { type: 'number' },
+      },
+      required: ['run_id', 'prompt'],
+    },
+  },
+  {
+    name: 'cancel_run',
+    description: 'Cancel a running worker process group.',
+    inputSchema: {
+      type: 'object',
+      properties: { run_id: { type: 'string' } },
+      required: ['run_id'],
+    },
+  },
+  {
+    name: 'get_backend_status',
+    description: 'Diagnose local Codex and Claude worker CLI availability without making model calls.',
+    inputSchema: { type: 'object', properties: {} },
+  },
+  {
+    name: 'get_observability_snapshot',
+    description: 'Get a dashboard-ready snapshot of daemon, session, run, prompt, model, and recent activity state.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        limit: { type: 'number' },
+        include_prompts: { type: 'boolean' },
+        recent_event_limit: { type: 'number' },
+        diagnostics: { type: 'boolean' },
+      },
+    },
+  },
+] as const;

--- a/src/observability.ts
+++ b/src/observability.ts
@@ -1,0 +1,490 @@
+import { stat } from 'node:fs/promises';
+import { basename, dirname } from 'node:path';
+import {
+  isTerminalStatus,
+  ObservabilitySnapshotSchema,
+  type BackendStatusReport,
+  type ObservabilityActivity,
+  type ObservabilityArtifact,
+  type ObservabilityModel,
+  type ObservabilityPrompt,
+  type ObservabilityResponse,
+  type ObservabilityRun,
+  type ObservabilityRunSettings,
+  type ObservabilitySession,
+  type ObservabilitySessionAudit,
+  type ObservabilitySessionPrompt,
+  type ObservabilityWorkspace,
+  type RunMeta,
+  type RunStatus,
+} from './contract.js';
+import type { RunStore } from './runStore.js';
+
+interface EventSummary {
+  event_count: number;
+  last_event: ObservabilityActivity['recent_events'][number] | null;
+  recent_events: ObservabilityActivity['recent_events'];
+}
+
+export interface BuildObservabilitySnapshotOptions {
+  limit: number;
+  includePrompts: boolean;
+  recentEventLimit: number;
+  daemonPid?: number | null;
+  backendStatus?: BackendStatusReport | null;
+}
+
+export async function buildObservabilitySnapshot(
+  store: RunStore,
+  options: BuildObservabilitySnapshotOptions,
+) {
+  const allMetas = await store.listRuns();
+  const metas = allMetas.slice(0, options.limit);
+  const runs: ObservabilityRun[] = [];
+  for (const meta of metas) {
+    const eventSummary = await store.readEventSummary(meta.run_id, Math.max(options.recentEventLimit, 20));
+    const promptText = await store.readPrompt(meta.run_id);
+    runs.push({
+      run: meta,
+      prompt: await buildPrompt(store, meta, promptText, options.includePrompts),
+      response: await buildResponse(store, meta.run_id, eventSummary),
+      model: buildModel(meta),
+      settings: buildSettings(meta),
+      session: buildSessionAudit(meta),
+      activity: buildActivity(eventSummary, options.recentEventLimit),
+      artifacts: await buildArtifacts(store, meta.run_id),
+      duration_seconds: durationSeconds(meta),
+    });
+  }
+
+  const sessions = buildSessions(runs, allMetas);
+  return ObservabilitySnapshotSchema.parse({
+    generated_at: new Date().toISOString(),
+    daemon_pid: options.daemonPid ?? null,
+    store_root: store.root,
+    sessions,
+    runs,
+    backend_status: options.backendStatus ?? null,
+  });
+}
+
+async function buildPrompt(
+  store: RunStore,
+  meta: RunMeta,
+  promptText: string | null,
+  includePrompt: boolean,
+): Promise<ObservabilityPrompt> {
+  const path = store.promptPath(meta.run_id);
+  const promptInfo = await fileInfo(path);
+  const preview = promptPreview(promptText);
+  const title = meta.display.prompt_title ?? previewOrRunId(preview, meta.run_id);
+  return {
+    title,
+    summary: meta.display.prompt_summary,
+    preview,
+    text: includePrompt ? promptText : null,
+    path: promptInfo.exists ? path : null,
+    bytes: promptInfo.bytes,
+  };
+}
+
+async function buildResponse(store: RunStore, runId: string, events: EventSummary): Promise<ObservabilityResponse> {
+  const result = await store.loadResult(runId);
+  const path = store.resultPath(runId);
+  const info = await fileInfo(path);
+  const resultSummary = result?.summary.trim() ? result.summary : null;
+  return {
+    status: result?.status ?? null,
+    summary: resultSummary ?? lastAssistantMessage(events.recent_events),
+    path: info.exists ? path : null,
+    bytes: info.bytes,
+  };
+}
+
+function buildModel(meta: RunMeta): ObservabilityModel {
+  const requestedName = meta.model;
+  const observedName = meta.observed_model;
+  return {
+    name: observedName ?? requestedName,
+    source: meta.model_source,
+    requested_name: requestedName,
+    observed_name: observedName,
+  };
+}
+
+function buildSettings(meta: RunMeta): ObservabilityRunSettings {
+  return meta.model_settings;
+}
+
+function buildSessionAudit(meta: RunMeta): ObservabilitySessionAudit {
+  const requested = meta.requested_session_id;
+  const observed = meta.observed_session_id;
+  const effective = observed ?? meta.session_id;
+  const warnings: string[] = [];
+  let status: ObservabilitySessionAudit['status'];
+
+  if (requested && observed && requested !== observed) {
+    status = 'mismatch';
+    warnings.push(`requested session ${requested} but backend reported ${observed}`);
+  } else if (requested && observed === requested) {
+    status = 'resumed';
+  } else if (requested && !observed) {
+    status = 'pending';
+    if (isTerminalStatus(meta.status)) {
+      warnings.push(`backend did not report resumed session ${requested}`);
+    }
+  } else if (observed || meta.session_id) {
+    status = 'new_session';
+  } else {
+    status = 'pending';
+  }
+
+  if (meta.model && meta.observed_model && meta.model !== meta.observed_model) {
+    warnings.push(`requested model ${meta.model} but backend reported ${meta.observed_model}`);
+  }
+
+  return {
+    requested_session_id: requested,
+    observed_session_id: observed,
+    effective_session_id: effective,
+    status,
+    warnings,
+  };
+}
+
+function buildActivity(summary: EventSummary, recentEventLimit: number): ObservabilityActivity {
+  const recentEvents = recentEventLimit === 0 ? [] : summary.recent_events.slice(-recentEventLimit);
+  return {
+    last_event_sequence: summary.last_event?.seq ?? summary.event_count,
+    last_event_at: summary.last_event?.ts ?? null,
+    last_event_type: summary.last_event?.type ?? null,
+    last_interaction_preview: lastInteractionPreview(summary.recent_events),
+    event_count: summary.event_count,
+    recent_errors: recentErrors(summary.recent_events),
+    recent_events: recentEvents,
+  };
+}
+
+async function buildArtifacts(store: RunStore, runId: string): Promise<ObservabilityArtifact[]> {
+  return Promise.all(store.defaultArtifacts(runId).map(async (artifact) => {
+    const info = await fileInfo(artifact.path);
+    return {
+      name: artifact.name,
+      path: artifact.path,
+      exists: info.exists,
+      bytes: info.bytes,
+    };
+  }));
+}
+
+interface SessionStats {
+  session_id: string | null;
+  run_count: number;
+  running_count: number;
+}
+
+function buildSessions(runs: ObservabilityRun[], allMetas: RunMeta[]): ObservabilitySession[] {
+  const byRunId = new Map(runs.map((run) => [run.run.run_id, run]));
+  const metaByRunId = new Map(allMetas.map((meta) => [meta.run_id, meta]));
+  const stats = buildSessionStats(allMetas, metaByRunId);
+  const groups = new Map<string, ObservabilityRun[]>();
+  for (const run of runs) {
+    const key = sessionKey(run.run, metaByRunId);
+    const group = groups.get(key) ?? [];
+    group.push(run);
+    groups.set(key, group);
+  }
+
+  const sessions = Array.from(groups.entries()).map(([sessionKeyValue, group]) => {
+    const chronological = group.slice().sort((a, b) => a.run.created_at.localeCompare(b.run.created_at));
+    const root = rootRun(chronological[0]!, byRunId);
+    const sessionStats = stats.get(sessionKeyValue);
+    const updatedAt = maxIso(group.map((run) => run.activity.last_event_at ?? run.run.finished_at ?? run.run.started_at ?? run.run.created_at));
+    const runningCount = sessionStats?.running_count ?? group.filter((run) => run.run.status === 'running').length;
+    const status = sessionStatus(group);
+    const latestSessionSummary = lastNonNull(chronological.map((run) => run.run.display.session_summary));
+    const title = root.run.display.session_title ?? root.prompt.title;
+    const prompts = chronological.map(sessionPrompt);
+    return {
+      session_key: sessionKeyValue,
+      session_id: sessionStats?.session_id ?? firstNonNull(group.map((run) => run.session.effective_session_id)),
+      root_run_id: root.run.run_id,
+      backend: root.run.backend,
+      cwd: root.run.cwd,
+      workspace: buildWorkspace(root),
+      title,
+      summary: latestSessionSummary,
+      status,
+      created_at: chronological[0]!.run.created_at,
+      updated_at: updatedAt,
+      run_count: sessionStats?.run_count ?? group.length,
+      running_count: runningCount,
+      models: uniqueModels(group.map((run) => run.model)),
+      settings: uniqueSettings(group.map((run) => run.settings)),
+      warnings: Array.from(new Set(group.flatMap((run) => run.session.warnings))),
+      prompts,
+    };
+  });
+
+  return sessions.sort((a, b) => b.updated_at.localeCompare(a.updated_at));
+}
+
+function buildSessionStats(allMetas: RunMeta[], metaByRunId: Map<string, RunMeta>): Map<string, SessionStats> {
+  const groups = new Map<string, RunMeta[]>();
+  for (const meta of allMetas) {
+    const key = sessionKey(meta, metaByRunId);
+    const group = groups.get(key) ?? [];
+    group.push(meta);
+    groups.set(key, group);
+  }
+
+  const stats = new Map<string, SessionStats>();
+  for (const [key, group] of groups) {
+    stats.set(key, {
+      session_id: firstNonNull(group.map((meta) => buildSessionAudit(meta).effective_session_id)),
+      run_count: group.length,
+      running_count: group.filter((meta) => meta.status === 'running').length,
+    });
+  }
+  return stats;
+}
+
+function buildWorkspace(root: ObservabilityRun): ObservabilityWorkspace {
+  const snapshot = root.run.git_snapshot;
+  const repositoryRoot = snapshot?.root ?? null;
+  const branch = snapshot?.branch ?? null;
+  const repositoryName = repositoryRoot ? repositoryNameFromRoot(repositoryRoot, branch) : null;
+  const dirtyCount = snapshot?.dirty_count ?? null;
+  const dirtySuffix = dirtyCount !== null && dirtyCount > 0 ? '*' : '';
+  let label: string;
+
+  if (repositoryName && branch) {
+    label = `${repositoryName}:${branch}${dirtySuffix}`;
+  } else if (repositoryName && snapshot?.sha) {
+    label = `${repositoryName}@${snapshot.sha.slice(0, 7)}${dirtySuffix}`;
+  } else if (repositoryName) {
+    label = `${repositoryName}${dirtySuffix}`;
+  } else {
+    label = compactFolder(root.run.cwd);
+  }
+
+  return {
+    cwd: root.run.cwd,
+    repository_root: repositoryRoot,
+    repository_name: repositoryName,
+    branch,
+    dirty_count: dirtyCount,
+    label,
+  };
+}
+
+function compactFolder(cwd: string): string {
+  const leaf = basename(cwd);
+  const parent = basename(dirname(cwd));
+  if (parent && leaf && parent !== leaf) return `${parent}/${leaf}`;
+  return leaf || cwd;
+}
+
+function repositoryNameFromRoot(root: string, branch: string | null): string {
+  const rootName = basename(root);
+  const parent = basename(dirname(root));
+  if (branch && rootName === branch && parent.startsWith('worktrees-')) {
+    return parent.slice('worktrees-'.length);
+  }
+  return rootName;
+}
+
+function sessionPrompt(run: ObservabilityRun): ObservabilitySessionPrompt {
+  return {
+    run_id: run.run.run_id,
+    status: run.run.status,
+    title: run.prompt.title,
+    summary: run.prompt.summary,
+    preview: run.prompt.preview,
+    model: run.model,
+    settings: run.settings,
+    created_at: run.run.created_at,
+    last_activity_at: run.activity.last_event_at,
+  };
+}
+
+function sessionKey(meta: RunMeta, byRunId: Map<string, RunMeta>): string {
+  const session = buildSessionAudit(meta);
+  if (session.effective_session_id) return `${meta.backend}:${session.effective_session_id}`;
+  return `${meta.backend}:root:${rootMeta(meta, byRunId).run_id}`;
+}
+
+function rootRun(run: ObservabilityRun, byRunId: Map<string, ObservabilityRun>): ObservabilityRun {
+  let current = run;
+  const seen = new Set<string>();
+  while (current.run.parent_run_id && !seen.has(current.run.run_id)) {
+    seen.add(current.run.run_id);
+    const parent = byRunId.get(current.run.parent_run_id);
+    if (!parent) break;
+    current = parent;
+  }
+  return current;
+}
+
+function rootMeta(meta: RunMeta, byRunId: Map<string, RunMeta>): RunMeta {
+  let current = meta;
+  const seen = new Set<string>();
+  while (current.parent_run_id && !seen.has(current.run_id)) {
+    seen.add(current.run_id);
+    const parent = byRunId.get(current.parent_run_id);
+    if (!parent) break;
+    current = parent;
+  }
+  return current;
+}
+
+function sessionStatus(group: ObservabilityRun[]): RunStatus {
+  if (group.some((run) => run.run.status === 'running')) return 'running';
+  const latest = group.slice().sort((a, b) =>
+    (b.run.finished_at ?? b.run.started_at ?? b.run.created_at).localeCompare(a.run.finished_at ?? a.run.started_at ?? a.run.created_at))[0];
+  return latest?.run.status ?? 'completed';
+}
+
+function uniqueModels(models: ObservabilityModel[]): ObservabilityModel[] {
+  const seen = new Set<string>();
+  const result: ObservabilityModel[] = [];
+  for (const model of models) {
+    const key = `${model.name ?? ''}:${model.source}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    result.push(model);
+  }
+  return result;
+}
+
+function uniqueSettings(settings: ObservabilityRunSettings[]): ObservabilityRunSettings[] {
+  const seen = new Set<string>();
+  const result: ObservabilityRunSettings[] = [];
+  for (const item of settings) {
+    const key = `${item.reasoning_effort ?? ''}:${item.service_tier ?? ''}:${item.mode ?? ''}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    result.push(item);
+  }
+  return result;
+}
+
+function durationSeconds(meta: RunMeta): number | null {
+  const start = Date.parse(meta.started_at ?? meta.created_at);
+  if (!Number.isFinite(start)) return null;
+  const end = meta.finished_at ? Date.parse(meta.finished_at) : Date.now();
+  if (!Number.isFinite(end) || end < start) return null;
+  return Math.round((end - start) / 1000);
+}
+
+async function fileInfo(path: string): Promise<{ exists: boolean; bytes: number | null }> {
+  try {
+    const info = await stat(path);
+    return { exists: true, bytes: info.size };
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+      return { exists: false, bytes: null };
+    }
+    throw error;
+  }
+}
+
+function promptPreview(promptText: string | null): string {
+  if (!promptText) return '';
+  return compactText(promptText, 160);
+}
+
+function previewOrRunId(preview: string, runId: string): string {
+  return preview || runId;
+}
+
+function lastInteractionPreview(events: ObservabilityActivity['recent_events']): string | null {
+  for (let index = events.length - 1; index >= 0; index -= 1) {
+    const preview = eventPreview(events[index]!);
+    if (preview) return preview;
+  }
+  return null;
+}
+
+function lastAssistantMessage(events: ObservabilityActivity['recent_events']): string | null {
+  for (let index = events.length - 1; index >= 0; index -= 1) {
+    const event = events[index]!;
+    if (event.type !== 'assistant_message') continue;
+    const text = compactText(stringFromRecord(event.payload, 'text') ?? stringFromRecord(event.payload, 'message') ?? '', 4000);
+    if (text) return text;
+  }
+  return null;
+}
+
+function recentErrors(events: ObservabilityActivity['recent_events']): string[] {
+  const errors: string[] = [];
+  for (let index = events.length - 1; index >= 0 && errors.length < 5; index -= 1) {
+    const event = events[index]!;
+    if (event.type === 'error') {
+      errors.push(eventPreview(event) ?? 'worker error');
+      continue;
+    }
+    const payloadErrors = Array.isArray(event.payload.errors) ? event.payload.errors : [];
+    for (const item of payloadErrors) {
+      const message = stringFromRecord(item, 'message');
+      if (message) errors.push(message);
+      if (errors.length >= 5) break;
+    }
+  }
+  return errors.reverse();
+}
+
+function eventPreview(event: ObservabilityActivity['recent_events'][number]): string | null {
+  if (event.type === 'assistant_message') {
+    return compactText(stringFromRecord(event.payload, 'text') ?? stringFromRecord(event.payload, 'message') ?? '', 160) || null;
+  }
+  if (event.type === 'tool_use') {
+    const name = stringFromRecord(event.payload, 'name') ?? stringFromRecord(event.payload, 'tool_name') ?? stringFromRecord(event.payload, 'type') ?? 'tool';
+    const command = stringFromRecord(event.payload, 'command') ?? commandFromInput(event.payload.input);
+    return command ? `${name}: ${compactText(command, 120)}` : name;
+  }
+  if (event.type === 'error') {
+    return compactText(stringFromRecord(event.payload, 'text') ?? stringFromRecord(event.payload, 'message') ?? JSON.stringify(event.payload), 160);
+  }
+  if (event.type === 'lifecycle') {
+    const status = stringFromRecord(event.payload, 'status') ?? stringFromRecord(event.payload, 'state') ?? stringFromRecord(event.payload, 'subtype');
+    return status ? `lifecycle: ${status}` : null;
+  }
+  return null;
+}
+
+function commandFromInput(input: unknown): string | null {
+  if (!input || typeof input !== 'object') return null;
+  return stringFromRecord(input as Record<string, unknown>, 'command');
+}
+
+function stringFromRecord(value: unknown, key: string): string | null {
+  if (!value || typeof value !== 'object') return null;
+  const rec = value as Record<string, unknown>;
+  const raw = rec[key];
+  return typeof raw === 'string' && raw.trim() ? raw.trim() : null;
+}
+
+function compactText(value: string, maxLength: number): string {
+  const compact = value.replace(/\s+/g, ' ').trim();
+  return compact.length > maxLength ? `${compact.slice(0, maxLength - 3)}...` : compact;
+}
+
+function firstNonNull<T>(values: (T | null | undefined)[]): T | null {
+  for (const value of values) {
+    if (value !== null && value !== undefined) return value;
+  }
+  return null;
+}
+
+function lastNonNull<T>(values: (T | null | undefined)[]): T | null {
+  for (let index = values.length - 1; index >= 0; index -= 1) {
+    const value = values[index];
+    if (value !== null && value !== undefined) return value;
+  }
+  return null;
+}
+
+function maxIso(values: string[]): string {
+  return values.reduce((current, value) => value.localeCompare(current) > 0 ? value : current, values[0] ?? new Date(0).toISOString());
+}

--- a/src/orchestratorService.ts
+++ b/src/orchestratorService.ts
@@ -3,10 +3,12 @@ import { constants } from 'node:fs';
 import {
   BackendSchema,
   CancelRunInputSchema,
+  GetObservabilitySnapshotInputSchema,
   GetRunEventsInputSchema,
   isTerminalStatus,
   orchestratorError,
   PruneRunsInputSchema,
+  ReasoningEffortSchema,
   RunIdInputSchema,
   SendFollowupInputSchema,
   ShutdownInputSchema,
@@ -15,8 +17,13 @@ import {
   wrapErr,
   wrapOk,
   type Backend,
+  type RunDisplayMetadata,
+  type ReasoningEffort,
+  type ModelSource,
   type OrchestratorError,
   type RunStatus,
+  type RunModelSettings,
+  type ServiceTier,
   type ToolResponse,
   type WorkerResult,
 } from './contract.js';
@@ -24,6 +31,7 @@ import type { WorkerBackend } from './backend/WorkerBackend.js';
 import { resolveBinary } from './backend/common.js';
 import { getBackendStatus } from './diagnostics.js';
 import { captureGitSnapshot } from './gitSnapshot.js';
+import { buildObservabilitySnapshot } from './observability.js';
 import { ProcessManager, type ManagedRun } from './processManager.js';
 import { RunStore } from './runStore.js';
 
@@ -87,6 +95,8 @@ export class OrchestratorService {
         return this.cancelRun(params);
       case 'get_backend_status':
         return wrapOk({ status: await getBackendStatus() });
+      case 'get_observability_snapshot':
+        return this.getObservabilitySnapshot(params);
       default:
         return wrapErr(orchestratorError('INVALID_INPUT', `Unknown method: ${method}`));
     }
@@ -100,17 +110,23 @@ export class OrchestratorService {
     if (!backend) return wrapErr(orchestratorError('BACKEND_NOT_FOUND', `Backend not found: ${input.backend}`));
     const timeout = this.resolveExecutionTimeout(input.execution_timeout_seconds);
     if (!timeout.ok) return wrapErr(timeout.error);
+    const settings = modelSettingsForBackend(input.backend, input.model ?? null, input.reasoning_effort, input.service_tier);
+    if (!settings.ok) return wrapErr(settings.error);
 
     const meta = await this.store.createRun({
       backend: input.backend,
       cwd: input.cwd,
+      prompt: input.prompt,
       model: input.model ?? null,
+      model_source: input.model ? 'explicit' : 'backend_default',
+      model_settings: settings.value,
+      display: displayMetadata(input.metadata, input.prompt),
       metadata: input.metadata,
       execution_timeout_seconds: timeout.value,
     });
     await this.captureAndPersistGitSnapshot(meta.run_id, input.cwd);
 
-    await this.startManagedRun(meta.run_id, backend, input.prompt, input.cwd, timeout.value, undefined, input.model);
+    await this.startManagedRun(meta.run_id, backend, input.prompt, input.cwd, timeout.value, settings.value, undefined, input.model);
     return wrapOk({ run_id: meta.run_id });
   }
 
@@ -122,7 +138,8 @@ export class OrchestratorService {
     if (!isTerminalStatus(parent.meta.status)) {
       return wrapErr(orchestratorError('INVALID_STATE', 'Cannot send follow-up while parent run is still running'));
     }
-    if (!parent.meta.session_id) {
+    const resumeSessionId = parent.meta.observed_session_id ?? parent.meta.session_id;
+    if (!resumeSessionId) {
       return wrapErr(orchestratorError('INVALID_STATE', 'Cannot send follow-up because parent run has no backend session id'));
     }
 
@@ -132,19 +149,32 @@ export class OrchestratorService {
     const timeout = this.resolveExecutionTimeout(parsed.data.execution_timeout_seconds);
     if (!timeout.ok) return wrapErr(timeout.error);
     const model = parsed.data.model ?? parent.meta.model;
+    const metadata = { ...parent.meta.metadata, ...parsed.data.metadata };
+    const modelSource: ModelSource = parsed.data.model ? 'explicit' : parent.meta.model ? 'inherited' : 'backend_default';
+    const settings = hasModelSettingsInput(parsed.data)
+      ? modelSettingsForBackend(backendName, model, parsed.data.reasoning_effort, parsed.data.service_tier)
+      : parsed.data.model
+        ? validateInheritedModelSettingsForBackend(backendName, model, parent.meta.model_settings)
+        : { ok: true as const, value: parent.meta.model_settings };
+    if (!settings.ok) return wrapErr(settings.error);
 
     const meta = await this.store.createRun({
       backend: backendName,
       cwd: parent.meta.cwd,
+      prompt: parsed.data.prompt,
       parent_run_id: parent.meta.run_id,
-      session_id: parent.meta.session_id,
+      session_id: resumeSessionId,
+      requested_session_id: resumeSessionId,
       model,
-      metadata: parent.meta.metadata,
+      model_source: modelSource,
+      model_settings: settings.value,
+      display: displayMetadata(parsed.data.metadata, parsed.data.prompt, parent.meta.display),
+      metadata,
       execution_timeout_seconds: timeout.value,
     });
     await this.captureAndPersistGitSnapshot(meta.run_id, parent.meta.cwd);
 
-    await this.startManagedRun(meta.run_id, backend, parsed.data.prompt, parent.meta.cwd, timeout.value, parent.meta.session_id, model);
+    await this.startManagedRun(meta.run_id, backend, parsed.data.prompt, parent.meta.cwd, timeout.value, settings.value, resumeSessionId, model);
     return wrapOk({ run_id: meta.run_id });
   }
 
@@ -231,12 +261,27 @@ export class OrchestratorService {
     return wrapOk(await this.store.pruneTerminalRuns(parsed.data.older_than_days, parsed.data.dry_run));
   }
 
+  async getObservabilitySnapshot(params: unknown): Promise<ToolResult> {
+    const parsed = GetObservabilitySnapshotInputSchema.safeParse(params);
+    if (!parsed.success) return invalidInput(parsed.error.message);
+    return wrapOk({
+      snapshot: await buildObservabilitySnapshot(this.store, {
+        limit: parsed.data.limit,
+        includePrompts: parsed.data.include_prompts,
+        recentEventLimit: parsed.data.recent_event_limit,
+        daemonPid: process.pid,
+        backendStatus: parsed.data.diagnostics ? await getBackendStatus() : null,
+      }),
+    });
+  }
+
   private async startManagedRun(
     runId: string,
     backend: WorkerBackend,
     prompt: string,
     cwd: string,
     timeoutSeconds: number,
+    modelSettings: RunModelSettings,
     sessionId?: string,
     model?: string | null,
   ): Promise<void> {
@@ -255,8 +300,8 @@ export class OrchestratorService {
 
     try {
       const invocation = sessionId
-        ? await backend.resume(sessionId, { prompt, cwd, model })
-        : await backend.start({ prompt, cwd, model });
+        ? await backend.resume(sessionId, { prompt, cwd, model, modelSettings })
+        : await backend.start({ prompt, cwd, model, modelSettings });
       invocation.command = binary;
       const managed = await this.processManager.start(runId, backend, invocation);
       this.activeRuns.set(runId, managed);
@@ -368,8 +413,138 @@ function unknownRun(runId: string): ToolResult {
   return wrapErr(orchestratorError('UNKNOWN_RUN', `Unknown run: ${runId}`));
 }
 
+function hasModelSettingsInput(input: { reasoning_effort?: ReasoningEffort; service_tier?: ServiceTier }): boolean {
+  return input.reasoning_effort !== undefined || input.service_tier !== undefined;
+}
+
+function modelSettingsForBackend(
+  backend: Backend,
+  model: string | null | undefined,
+  reasoningEffort: ReasoningEffort | undefined,
+  serviceTier: ServiceTier | undefined,
+): { ok: true; value: RunModelSettings } | { ok: false; error: OrchestratorError } {
+  if (backend === 'codex') {
+    if (reasoningEffort === 'max') {
+      return { ok: false, error: orchestratorError('INVALID_INPUT', 'Codex reasoning_effort must be one of none, minimal, low, medium, high, or xhigh') };
+    }
+    return {
+      ok: true,
+      value: {
+        reasoning_effort: reasoningEffort ?? null,
+        service_tier: serviceTier && serviceTier !== 'normal' ? serviceTier : null,
+        mode: serviceTier === 'normal' ? 'normal' : null,
+      },
+    };
+  }
+
+  if (reasoningEffort === 'none' || reasoningEffort === 'minimal') {
+    return { ok: false, error: orchestratorError('INVALID_INPUT', 'Claude reasoning_effort must be one of low, medium, high, xhigh, or max') };
+  }
+  if (serviceTier !== undefined) {
+    return { ok: false, error: orchestratorError('INVALID_INPUT', 'Claude does not support service_tier; set reasoning_effort and model only') };
+  }
+  const claudeModelError = validateClaudeModelAndEffort(model, reasoningEffort);
+  if (claudeModelError) return { ok: false, error: claudeModelError };
+  return {
+    ok: true,
+    value: {
+      reasoning_effort: reasoningEffort ?? null,
+      service_tier: null,
+      mode: null,
+    },
+  };
+}
+
+function validateClaudeModelAndEffort(model: string | null | undefined, reasoningEffort: ReasoningEffort | undefined): OrchestratorError | null {
+  const normalized = normalizeClaudeModel(model);
+  if (normalized && isClaudeAlias(normalized)) {
+    return orchestratorError('INVALID_INPUT', 'Claude model must be a direct model id such as claude-opus-4-7 or claude-opus-4-7[1m]; aliases like opus and sonnet can drift');
+  }
+  if (reasoningEffort && !normalized) {
+    return orchestratorError('INVALID_INPUT', 'Claude reasoning_effort requires an explicit direct model id such as claude-opus-4-7 so fallback behavior is visible');
+  }
+  if (reasoningEffort === 'xhigh' && normalized && !isClaudeOpus47(normalized)) {
+    return orchestratorError('INVALID_INPUT', 'Claude xhigh effort requires claude-opus-4-7 or claude-opus-4-7[1m]; other Claude models can fall back to high');
+  }
+  if (reasoningEffort && normalized && isAnthropicClaudeModelId(normalized) && !isKnownClaudeEffortModel(normalized)) {
+    return orchestratorError('INVALID_INPUT', 'Claude effort levels are documented for Opus 4.7, Opus 4.6, and Sonnet 4.6; use one of those direct model ids');
+  }
+  return null;
+}
+
+function validateInheritedModelSettingsForBackend(
+  backend: Backend,
+  model: string | null | undefined,
+  settings: RunModelSettings,
+): { ok: true; value: RunModelSettings } | { ok: false; error: OrchestratorError } {
+  if (backend !== 'claude') return { ok: true, value: settings };
+  const reasoningEffort = parseReasoningEffort(settings.reasoning_effort);
+  const error = validateClaudeModelAndEffort(model, reasoningEffort);
+  return error ? { ok: false, error } : { ok: true, value: settings };
+}
+
+function parseReasoningEffort(value: string | null | undefined): ReasoningEffort | undefined {
+  const parsed = value ? ReasoningEffortSchema.safeParse(value) : null;
+  return parsed?.success ? parsed.data : undefined;
+}
+
+function normalizeClaudeModel(model: string | null | undefined): string | null {
+  const value = model?.trim().toLowerCase();
+  return value ? value.replace(/\[1m\]$/, '') : null;
+}
+
+function isClaudeAlias(model: string): boolean {
+  return model === 'default'
+    || model === 'best'
+    || model === 'opus'
+    || model === 'sonnet'
+    || model === 'haiku'
+    || model === 'opusplan';
+}
+
+function isClaudeOpus47(model: string): boolean {
+  return model.includes('claude-opus-4-7');
+}
+
+function isKnownClaudeEffortModel(model: string): boolean {
+  return model.includes('claude-opus-4-7')
+    || model.includes('claude-opus-4-6')
+    || model.includes('claude-sonnet-4-6');
+}
+
+function isAnthropicClaudeModelId(model: string): boolean {
+  return model.startsWith('claude-') || model.includes('.claude-');
+}
+
 function positiveInt(value: unknown): number | null {
   return typeof value === 'number' && Number.isInteger(value) && value > 0 ? value : null;
+}
+
+function displayMetadata(
+  metadata: Record<string, unknown>,
+  prompt: string,
+  parent?: RunDisplayMetadata,
+): RunDisplayMetadata {
+  const promptFallback = promptTitleFromPrompt(prompt);
+  return {
+    session_title: metadataString(metadata, 'session_title') ?? parent?.session_title ?? metadataString(metadata, 'title') ?? promptFallback,
+    session_summary: metadataString(metadata, 'session_summary') ?? parent?.session_summary ?? metadataString(metadata, 'summary'),
+    prompt_title: metadataString(metadata, 'prompt_title') ?? metadataString(metadata, 'title') ?? promptFallback,
+    prompt_summary: metadataString(metadata, 'prompt_summary') ?? metadataString(metadata, 'summary'),
+  };
+}
+
+function metadataString(metadata: Record<string, unknown>, key: string): string | null {
+  const value = metadata[key];
+  if (typeof value !== 'string') return null;
+  const trimmed = value.trim();
+  return trimmed || null;
+}
+
+function promptTitleFromPrompt(prompt: string): string {
+  const firstLine = prompt.split(/\r?\n/, 1)[0]?.trim() ?? '';
+  if (!firstLine) return 'Untitled prompt';
+  return firstLine.length > 80 ? `${firstLine.slice(0, 77)}...` : firstLine;
 }
 
 function scheduleProcessExit(): void {

--- a/src/processManager.ts
+++ b/src/processManager.ts
@@ -42,6 +42,10 @@ export class ProcessManager {
       worker_pid: workerPid,
       worker_pgid: workerPgid,
       daemon_pid_at_spawn: process.pid,
+      worker_invocation: {
+        command: invocation.command,
+        args: invocation.args,
+      },
     }));
     await this.store.appendEvent(runId, {
       type: 'lifecycle',
@@ -154,9 +158,17 @@ export class ProcessManager {
     }
 
     const parsed = backend.parseEvent(raw);
-    if (parsed.sessionId) {
-      sinks.setSessionId(parsed.sessionId);
-      await this.store.updateMeta(runId, (meta) => ({ ...meta, session_id: meta.session_id ?? parsed.sessionId! }));
+    const observedModel = extractObservedModel(raw);
+    if (parsed.sessionId || observedModel) {
+      if (parsed.sessionId) sinks.setSessionId(parsed.sessionId);
+      await this.store.updateMeta(runId, (meta) => ({
+        ...meta,
+        session_id: parsed.sessionId ? meta.session_id ?? parsed.sessionId : meta.session_id,
+        observed_session_id: parsed.sessionId ?? meta.observed_session_id,
+        observed_model: observedModel ?? meta.observed_model,
+        model: meta.model ?? observedModel,
+        model_source: !meta.model && observedModel && meta.model_source === 'legacy_unknown' ? 'backend_default' : meta.model_source,
+      }));
     }
     if (parsed.resultEvent) sinks.setResultEvent(parsed.resultEvent);
     for (const file of parsed.filesChanged) sinks.addFile(file);
@@ -273,4 +285,27 @@ function relativeInside(cwd: string, file: string): string | null {
   const relativePath = relative(cwd, file);
   if (!relativePath || relativePath === '..' || relativePath.startsWith(`..${sep}`) || isAbsolute(relativePath)) return null;
   return relativePath;
+}
+
+function extractObservedModel(raw: unknown): string | null {
+  const rec = record(raw);
+  if (!rec) return null;
+
+  return stringValue(rec.model)
+    ?? stringValue(record(rec.message)?.model)
+    ?? stringValue(record(rec.response)?.model)
+    ?? firstModelUsageKey(record(rec.modelUsage));
+}
+
+function firstModelUsageKey(modelUsage: Record<string, unknown> | null): string | null {
+  if (!modelUsage) return null;
+  return Object.keys(modelUsage)[0] ?? null;
+}
+
+function record(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === 'object' && !Array.isArray(value) ? value as Record<string, unknown> : null;
+}
+
+function stringValue(value: unknown): string | null {
+  return typeof value === 'string' && value.trim() ? value.trim() : null;
 }

--- a/src/runStore.ts
+++ b/src/runStore.ts
@@ -9,7 +9,10 @@ import {
   type GitSnapshot,
   type GitSnapshotStatus,
   isTerminalStatus,
+  type ModelSource,
+  type RunDisplayMetadata,
   type RunMeta,
+  type RunModelSettings,
   RunMetaSchema,
   type RunStatus,
   type TerminalRunStatus,
@@ -31,9 +34,16 @@ interface LockMetadata {
 export interface CreateRunInput {
   backend: Backend;
   cwd: string;
+  prompt?: string;
   model?: string | null;
+  model_source?: ModelSource;
+  model_settings?: RunModelSettings;
   parent_run_id?: string | null;
   session_id?: string | null;
+  requested_session_id?: string | null;
+  observed_session_id?: string | null;
+  observed_model?: string | null;
+  display?: RunDisplayMetadata;
   metadata?: Record<string, unknown>;
   execution_timeout_seconds?: number | null;
   git_snapshot_status?: GitSnapshotStatus;
@@ -98,6 +108,21 @@ export class RunStore {
       parent_run_id: input.parent_run_id ?? null,
       session_id: input.session_id ?? null,
       model: input.model ?? null,
+      model_source: input.model_source ?? 'legacy_unknown',
+      model_settings: input.model_settings ?? {
+        reasoning_effort: null,
+        service_tier: null,
+        mode: null,
+      },
+      requested_session_id: input.requested_session_id ?? null,
+      observed_session_id: input.observed_session_id ?? null,
+      observed_model: input.observed_model ?? null,
+      display: input.display ?? {
+        session_title: null,
+        session_summary: null,
+        prompt_title: null,
+        prompt_summary: null,
+      },
       cwd: input.cwd,
       created_at: now,
       started_at: null,
@@ -105,6 +130,7 @@ export class RunStore {
       worker_pid: null,
       worker_pgid: null,
       daemon_pid_at_spawn: null,
+      worker_invocation: null,
       git_snapshot_status: input.git_snapshot_status ?? 'not_a_repo',
       git_snapshot: input.git_snapshot ?? null,
       git_snapshot_at_start: input.git_snapshot ?? null,
@@ -114,11 +140,12 @@ export class RunStore {
 
     const dir = this.runDir(runId);
     await mkdir(dir, { recursive: false, mode: rootMode });
-    await writeAtomicJson(this.metaPath(runId), meta);
     await writeFile(this.eventsPath(runId), '', { mode: fileMode });
     await writeFile(this.eventSeqPath(runId), '0\n', { mode: fileMode });
+    await writeFile(this.promptPath(runId), input.prompt ?? '', { mode: fileMode });
     await writeFile(this.stdoutPath(runId), '', { mode: fileMode });
     await writeFile(this.stderrPath(runId), '', { mode: fileMode });
+    await writeAtomicJson(this.metaPath(runId), meta);
     return meta;
   }
 
@@ -147,6 +174,15 @@ export class RunStore {
 
   async writeResult(runId: string, result: WorkerResult): Promise<void> {
     await writeAtomicJson(this.resultPath(runId), WorkerResultSchema.parse(result));
+  }
+
+  async readPrompt(runId: string): Promise<string | null> {
+    try {
+      return await readFile(this.promptPath(runId), 'utf8');
+    } catch (error) {
+      if (isNotFound(error)) return null;
+      throw error;
+    }
   }
 
   async loadRun(runId: string): Promise<RunRecord | null> {
@@ -200,6 +236,20 @@ export class RunStore {
     return this.readEventsPage(runId, afterSequence, limit);
   }
 
+  async readEventSummary(runId: string, recentLimit = 5): Promise<{
+    event_count: number;
+    last_event: WorkerEvent | null;
+    recent_events: WorkerEvent[];
+  }> {
+    const event_count = await this.getLastSequence(runId, true);
+    const recent_events = await this.readRecentEventsFromLog(runId, recentLimit);
+    return {
+      event_count,
+      last_event: recent_events.at(-1) ?? null,
+      recent_events,
+    };
+  }
+
   async markTerminal(
     runId: string,
     status: TerminalRunStatus,
@@ -234,6 +284,7 @@ export class RunStore {
         payload: { status, errors },
       });
       await appendFile(this.eventsPath(runId), `${JSON.stringify(event)}\n`, { mode: fileMode });
+      await writeFile(this.eventSeqPath(runId), `${event.seq}\n`, { mode: fileMode });
       return next;
     });
   }
@@ -241,6 +292,7 @@ export class RunStore {
   defaultArtifacts(runId: string): { name: string; path: string }[] {
     return [
       { name: 'result.json', path: this.resultPath(runId) },
+      { name: 'prompt.txt', path: this.promptPath(runId) },
       { name: 'stdout.log', path: this.stdoutPath(runId) },
       { name: 'stderr.log', path: this.stderrPath(runId) },
       { name: 'events.jsonl', path: this.eventsPath(runId) },
@@ -253,6 +305,10 @@ export class RunStore {
 
   resultPath(runId: string): string {
     return join(this.runDir(runId), 'result.json');
+  }
+
+  promptPath(runId: string): string {
+    return join(this.runDir(runId), 'prompt.txt');
   }
 
   eventsPath(runId: string): string {
@@ -283,10 +339,18 @@ export class RunStore {
       .map((line) => WorkerEventSchema.parse(JSON.parse(line)));
   }
 
-  private async getLastSequence(runId: string): Promise<number> {
+  private async getLastSequence(runId: string, reconcileLog = false): Promise<number> {
     try {
       const seq = Number.parseInt((await readFile(this.eventSeqPath(runId), 'utf8')).trim(), 10);
-      if (Number.isInteger(seq) && seq >= 0) return seq;
+      if (Number.isInteger(seq) && seq >= 0) {
+        if (!reconcileLog) return seq;
+        const logSeq = await this.readLastEventSequenceFromLog(runId);
+        if (logSeq > seq) {
+          await writeFile(this.eventSeqPath(runId), `${logSeq}\n`, { mode: fileMode });
+          return logSeq;
+        }
+        return seq;
+      }
     } catch (error) {
       if (!isNotFound(error)) throw error;
     }
@@ -373,6 +437,37 @@ export class RunStore {
       return events.at(-1)?.seq ?? 0;
     } finally {
       await handle.close();
+    }
+  }
+
+  private async readRecentEventsFromLog(runId: string, limit: number): Promise<WorkerEvent[]> {
+    if (limit <= 0) return [];
+    const path = this.eventsPath(runId);
+    const info = await stat(path);
+    if (info.size === 0) return [];
+
+    let bytesToRead = Math.min(info.size, 64 * 1024);
+    while (true) {
+      const handle = await open(path, 'r');
+      try {
+        const buffer = Buffer.alloc(bytesToRead);
+        await handle.read(buffer, 0, bytesToRead, info.size - bytesToRead);
+        const text = buffer.toString('utf8');
+        const lines = text.split('\n').filter(Boolean);
+        const hasFileStart = bytesToRead === info.size;
+        if (hasFileStart || lines.length > limit) {
+          const completeLines = hasFileStart ? lines : lines.slice(1);
+          return completeLines
+            .slice(-limit)
+            .map((line) => WorkerEventSchema.parse(JSON.parse(line)));
+        }
+      } finally {
+        await handle.close();
+      }
+
+      const nextBytes = Math.min(info.size, bytesToRead * 2);
+      if (nextBytes === bytesToRead) return this.readAllEvents(runId).then((events) => events.slice(-limit));
+      bytesToRead = nextBytes;
     }
   }
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -12,104 +12,10 @@ import { IpcClient, IpcRequestError } from './ipc/client.js';
 import { daemonPaths } from './daemon/paths.js';
 import { orchestratorError, wrapErr } from './contract.js';
 import { ipcTimeoutForTool } from './toolTimeout.js';
+import { tools } from './mcpTools.js';
 
 const paths = daemonPaths();
 const client = new IpcClient(paths.socket);
-
-const tools = [
-  {
-    name: 'start_run',
-    description: 'Start a Codex or Claude worker run.',
-    inputSchema: {
-      type: 'object',
-      properties: {
-        backend: { type: 'string', enum: ['codex', 'claude'] },
-        prompt: { type: 'string' },
-        cwd: { type: 'string' },
-        model: { type: 'string' },
-        metadata: { type: 'object', additionalProperties: true },
-        execution_timeout_seconds: { type: 'number' },
-      },
-      required: ['backend', 'prompt', 'cwd'],
-    },
-  },
-  {
-    name: 'list_runs',
-    description: 'List known worker runs in descending creation order.',
-    inputSchema: { type: 'object', properties: {} },
-  },
-  {
-    name: 'get_run_status',
-    description: 'Get the current lifecycle status for a run.',
-    inputSchema: {
-      type: 'object',
-      properties: { run_id: { type: 'string' } },
-      required: ['run_id'],
-    },
-  },
-  {
-    name: 'get_run_events',
-    description: 'Read worker events with cursor pagination.',
-    inputSchema: {
-      type: 'object',
-      properties: {
-        run_id: { type: 'string' },
-        after_sequence: { type: 'number' },
-        limit: { type: 'number' },
-      },
-      required: ['run_id'],
-    },
-  },
-  {
-    name: 'wait_for_run',
-    description: 'Wait for a run to reach a terminal status, bounded by wait_seconds.',
-    inputSchema: {
-      type: 'object',
-      properties: {
-        run_id: { type: 'string' },
-        wait_seconds: { type: 'number' },
-      },
-      required: ['run_id', 'wait_seconds'],
-    },
-  },
-  {
-    name: 'get_run_result',
-    description: 'Get the normalized worker result for a run, or null while it is running.',
-    inputSchema: {
-      type: 'object',
-      properties: { run_id: { type: 'string' } },
-      required: ['run_id'],
-    },
-  },
-  {
-    name: 'send_followup',
-    description: 'Start a follow-up run by resuming the parent run backend session.',
-    inputSchema: {
-      type: 'object',
-      properties: {
-        run_id: { type: 'string' },
-        prompt: { type: 'string' },
-        model: { type: 'string' },
-        execution_timeout_seconds: { type: 'number' },
-      },
-      required: ['run_id', 'prompt'],
-    },
-  },
-  {
-    name: 'cancel_run',
-    description: 'Cancel a running worker process group.',
-    inputSchema: {
-      type: 'object',
-      properties: { run_id: { type: 'string' } },
-      required: ['run_id'],
-    },
-  },
-  {
-    name: 'get_backend_status',
-    description: 'Diagnose local Codex and Claude worker CLI availability without making model calls.',
-    inputSchema: { type: 'object', properties: {} },
-  },
-] as const;
 
 const server = new Server(
   { name: 'agent-orchestrator-mcp', version: '0.1.0' },


### PR DESCRIPTION
## Summary

- Add a shared observability snapshot contract plus the `get_observability_snapshot` MCP tool.
- Add daemon CLI observability views: `status --verbose`, `runs`, JSON output, and the interactive `watch` dashboard.
- Persist raw prompts, display metadata, model/source/settings, requested vs observed sessions, observed models, workspace/git labels, activity summaries, and artifact sizes.
- Preserve merged Windows IPC/version-skew behavior, including stale-daemon handling in dashboard CLI commands.

## Issue

Closes #4

## Review

- Self-review findings were recorded in `plans/4-add-observability/reviews/` and fixed.
- Merge review after pulling `main` found one stale-daemon dashboard gap; fixed in `72ba6c2`.

## Verification

- [x] `pnpm build`
- [x] `node --test dist/__tests__/daemonCli.test.js`
- [x] `pnpm test` (69 passed, 1 skipped)
- [x] `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Interactive observability dashboard (`watch`) plus `runs` and `status --verbose/--json` for detailed snapshots
  * New observability API/tool for fetching snapshots (`get_observability_snapshot`)
  * start_run/send_followup accept optional reasoning_effort, service_tier, metadata, execution_timeout_seconds
  * Run storage now persists prompt.txt and richer run/session metadata

* **Bug Fixes**
  * wait_for_run “still running” response uses wait_exceeded: true

* **Documentation**
  * Expanded Observability guide and CLI docs covering dashboard, run/session grouping, prompts, and metadata fields
<!-- end of auto-generated comment: release notes by coderabbit.ai -->