### PR TITLE
feat(cli): print help on TTY for bare agent-orchestrator (#33)

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,13 @@ For local development from a checkout:
 pnpm install --frozen-lockfile
 pnpm build
 node dist/cli.js doctor
-node dist/cli.js
+node dist/cli.js server
 ```
+
+Bare `agent-orchestrator` (no subcommand) prints this help when run from a
+terminal and starts the stdio MCP server when stdin is piped (the way every MCP
+client launches it). Use `agent-orchestrator server` to start the MCP server
+explicitly from a terminal.
 
 To test a checkout without colliding with an npm-installed stable daemon, use
 the short local `just` passthrough:

--- a/docs/development/mcp-tooling.md
+++ b/docs/development/mcp-tooling.md
@@ -302,8 +302,13 @@ The `agent-orchestrator` server starts this repository's own MCP package from
 the local build output:
 
 ```text
-node dist/cli.js
+node dist/cli.js server
 ```
+
+The bare `node dist/cli.js` form prints help when run from a terminal and
+starts the stdio MCP server when stdin is piped (the path real MCP clients
+take). Use the explicit `server` subcommand above to start the MCP server from
+a terminal.
 
 This lets agents use the orchestrator while developing the orchestrator. Run
 `pnpm build` after changing source before restarting the MCP client. If the

--- a/plans/33-root-command-should-give-you-the-help/plan.md
+++ b/plans/33-root-command-should-give-you-the-help/plan.md
@@ -1,0 +1,10 @@
+## Plan Index
+
+Branch: `33-root-command-should-give-you-the-help`
+Updated: 2026-05-06
+
+## Sub-Plans
+
+| Plan | Scope | Status | File |
+|---|---|---|---|
+| Root Command Prints Help On A TTY | Make `agent-orchestrator` (no args) print help when stdin is a TTY; keep MCP-stdio behavior for piped invocations. | planning | [plans/33-root-command-help.md](plans/33-root-command-help.md) |

--- a/plans/33-root-command-should-give-you-the-help/plans/33-root-command-help.md
+++ b/plans/33-root-command-should-give-you-the-help/plans/33-root-command-help.md
@@ -1,0 +1,153 @@
+## Root Command Prints Help On A TTY
+
+Branch: `33-root-command-should-give-you-the-help`
+Plan Slug: `33-root-command-help`
+Parent Issue: #33
+Created: 2026-05-06
+Status: planning
+
+## Context
+
+Issue #33: when a user runs `agent-orchestrator` interactively, they see "a stream of json messages" because the no-args branch of `src/cli.ts` immediately starts the stdio MCP server (which begins accepting JSON-RPC over stdin/stdout). The user wants `agent-orchestrator` with no args to behave like `agent-orchestrator --help`.
+
+Plan #14 explicitly preserved no-args server startup (Decision 2 of `plans/14-clean-up-the-cli-surface/plans/14-clean-cli-surface.md`) because every MCP client config in the README invokes `npx -y @ralphkrauss/agent-orchestrator@latest` with no command arguments. A naive flip to "always show help" would break those configs in the wild. The chosen reconciliation is to switch on whether stdin is a TTY: humans get help, piped stdio (MCP clients) get the server. This keeps every existing MCP client config working unchanged.
+
+Sources read:
+
+- `AGENTS.md`: keep public package behavior stable unless the task is explicitly an API/contract change; verify both human-readable and JSON CLI output where applicable; record concrete verification evidence; do not commit/push without instruction.
+- `.agents/rules/node-typescript.md` (source of truth; `.claude/rules/node-typescript.md` is a generated mirror): pnpm-only, Node 22+, keep `tsconfig.json` strict, prefer Node built-ins, no new deps without asking, verify CLI human + JSON output where applicable.
+- GitHub issue #33: "now when I run agent-orchestrator I see some stream of json messages, not very useful. it should just work like help and give you assistance on how to use the tool".
+- `src/cli.ts`: dispatch table; current branches are `doctor`, no-arg/`server`, `opencode`, `claude`, `monitor`, `auth`, `supervisor`, daemon commands via `isDaemonCliCommand`, and `--help`/`-h`/`help`. The help text and the no-args dispatch live inline in this file today.
+- `src/server.ts`: imports start the MCP wiring, call `await ensureDaemon({ allowVersionMismatch: true })` (which spawns `daemonMain.js` with `detached: true`/`stdio: 'ignore'` if no daemon is running) and `await server.connect(transport)` at module top level. So *any* import of `./server.js` — including from a unit test — will auto-start the daemon and connect MCP stdio. Helper code intended for unit tests must live in a separate, side-effect-free module.
+- `src/__tests__/daemonCli.test.ts`: spawns `dist/cli.js --help` with `execFile` to assert help output (provides the help-text test pattern); and isolates daemon state in tests by `mkdtemp(...)`-ing a temp root, setting `env.AGENT_ORCHESTRATOR_HOME = <home>` for the spawn, and cleaning up with `cliPath stop --force` plus a `waitForStopped(env)` helper (see lines 56–104 and 166–177). The new spawn test copies this isolation + cleanup pattern into its own file so it cannot leak a daemon onto the developer's `~/.agent-orchestrator/`. (We do not `import` from `daemonCli.test.ts`; importing another test file would execute its top-level `describe`/`it` definitions.)
+- `node_modules/@modelcontextprotocol/sdk/dist/esm/shared/stdio.js` (SDK 1.29.0, the version pinned in this repo): MCP stdio transport uses **newline-delimited JSON**, not `Content-Length` framing. `serializeMessage(message) = JSON.stringify(message) + '\n'` (lines 28–30). `ReadBuffer.readMessage` splits on the first `\n`, strips a trailing `\r`, and `JSON.parse`s the result (lines 13–19). The new spawn test in T3 must write and read using this exact framing.
+- `node_modules/@modelcontextprotocol/sdk/dist/esm/server/stdio.js`: `StdioServerTransport.send` calls `serializeMessage` and writes to `process.stdout`; `start()` listens for `data` on `process.stdin` and feeds it through `ReadBuffer` (lines 26–47, 63–73). Confirms the server reads the same NDJSON framing the test will write.
+- `package.json`: `bin.agent-orchestrator -> dist/cli.js`; Node 22+; no new deps required.
+- `README.md`: every MCP client config example invokes the package with no args (`npx -y @ralphkrauss/agent-orchestrator@latest`); MCP clients always pipe stdio. Line ~15 ("For local development from a checkout") shows a bare `node dist/cli.js` invocation that is intended as an MCP-style smoke test and will, after this change, print help when the developer's terminal is a TTY.
+- `docs/development/mcp-tooling.md` ~line 301 ("Agent Orchestrator Server"): instructs running `node dist/cli.js` to start the local-checkout MCP server. This is the local-dogfood entry point and must keep working — either via piped stdin from the MCP client (which is what really happens) or via an explicit `server` subcommand.
+- `plans/14-clean-up-the-cli-surface/plans/14-clean-cli-surface.md` Decision 2: prior choice to keep no-args server startup, which this plan revises to TTY-based dispatch.
+
+Verification commands:
+
+- `pnpm build`
+- `node --test dist/__tests__/daemonCli.test.js` (existing `--help` coverage)
+- `node --test dist/__tests__/cliRoot.test.js` (new file, see T3)
+- `pnpm test`
+- `pnpm verify`
+
+## Decisions
+
+| # | Decision | Choice | Rationale | Rejected Alternatives |
+|---|---|---|---|---|
+| 1 | No-args dispatch | When `process.stdin.isTTY` is truthy, print the shared help text and exit 0. Otherwise import `./server.js` exactly as today. | Issue #33 wants help on a terminal; existing MCP client configs (every README example) use no args and pipe stdio, so a TTY check splits the cases without breaking any deployed config. | (a) Hard switch to help and require `agent-orchestrator server` for MCP — breaks every MCP config in the README and in user installations. (b) Deprecation period (warn on stderr, still start server) — drags out the bad UX the issue is about and adds noise to MCP stderr streams that some clients surface to users. |
+| 2 | Detection signal | Use `process.stdin.isTTY`. | MCP stdio clients always pipe stdin (and stdout). Humans launching the CLI have a TTY on stdin. `stdin` is more reliable than `stdout` because users sometimes redirect stdout (e.g., piping help to `less`) without intending an MCP client invocation. | (a) `process.stdout.isTTY` — false-negatives when humans pipe help into a pager. (b) Both stdin and stdout TTY — too restrictive. (c) Env-var opt-in (`AGENT_ORCHESTRATOR_HELP_ON_TTY=1`) — users would never set it; defeats the purpose. |
+| 3 | Escape hatch | None beyond the existing explicit `agent-orchestrator server` subcommand. | `server` already starts the MCP server explicitly and is documented; that is the documented way to override TTY detection if it ever misfires. | Adding `AGENT_ORCHESTRATOR_FORCE_SERVER=1` — premature; we have no reported case of misdetection. Can be added later if needed. |
+| 4 | Help content | Reuse one shared help string for all help paths (`agent-orchestrator` no-args TTY branch, `--help`, `-h`, and `help`). The string lives in the new side-effect-free module (see Decision 6) and `cli.ts` writes it to stdout in every help path. The body of the help is unchanged from today except for the wording change in Decision 5. | Smallest diff; one source of truth for help text; no test churn for the help body. The existing block already groups commands and is good enough. | Reformatting the help with sections/examples — out of scope for this issue; can be a follow-up. |
+| 5 | Help text wording for the no-args line | Change the "agent-orchestrator              Start the stdio MCP server" line to "agent-orchestrator              Show this help in a terminal; start the MCP server for piped stdio". Keep the explicit "agent-orchestrator server       Start the stdio MCP server" line unchanged. | Honestly describes the new behavior so a user reading help understands why the same command may have done something different in an MCP client context. | Removing the no-args line — confusing. Leaving the line unchanged — misleading after the behavior change. |
+| 6 | Refactor shape | Create a new side-effect-free module `src/cliRoot.ts` that exports (a) `HELP_TEXT` (the shared help string used by all help paths) and (b) a pure helper `decideRootMode(stdinIsTty: boolean \| undefined): 'help' \| 'server'`. `src/cli.ts` imports both and uses them in the no-args and explicit-help branches. The dispatch caller still does `await import('./server.js')` for the `'server'` branch, so the import-time `await server.connect(transport)` behavior of `src/server.ts` is unchanged. The unit test imports `src/cliRoot.ts` only, never `src/cli.ts` or `src/server.ts`, so it cannot trigger the daemon-spawn / MCP-connect side effects. | A pure function in a side-effect-free module is unit-testable without a pty *and* without spawning a daemon. Keeping `await import('./server.js')` in `cli.ts` preserves the current import-time `server.connect(transport)` behavior. Importing `src/cli.ts` from a unit test would execute the top-level dispatch (and may import `./server.js`, which auto-starts the daemon), so the helper must not live in `cli.ts`. | (a) Put the helper in `src/cli.ts` — importing `src/cli.ts` runs CLI top-level code and may transitively start the daemon. (b) Wrap server startup in a function inside `src/server.ts` — invasive change to a hot path; risks regressing the stdio handshake. (c) Use a pty-based test — would need a new dev dependency (`node-pty`) we have no other reason to add. |
+| 7 | Exit code on help | `process.exit(0)` (or fall through to natural exit) for the help-on-TTY path. | `--help` today exits 0 (no explicit exit; falls through after writing); matching that keeps shells, pipelines, and CI consistent. | Non-zero exit for "no command" — would break any script that relies on TTY-less invocation; we rely on TTY presence as the discriminator instead. |
+
+## Scope
+
+### In Scope
+
+- New file `src/cliRoot.ts`: exports `HELP_TEXT` and `decideRootMode(stdinIsTty)`. No imports of `./server.js`, `./daemon/*`, or anything with import-time side effects. Pure module.
+- `src/cli.ts`: imports `HELP_TEXT` and `decideRootMode` from `./cliRoot.js`. The no-args branch consults `decideRootMode(process.stdin.isTTY)` and either writes `HELP_TEXT` or `await import('./server.js')`. The existing `--help`/`-h`/`help` branch writes the same `HELP_TEXT`.
+- `src/cliRoot.ts`: help-text wording for the no-args line (Decision 5) baked into the shared `HELP_TEXT`.
+- One small focused test file `src/__tests__/cliRoot.test.ts` that:
+  - Imports `src/cliRoot.ts` directly (no `cli.ts`, no `server.ts`) and asserts the pure dispatch helper returns `'help'` for `stdinIsTty: true` and `'server'` for `stdinIsTty: false` and `stdinIsTty: undefined`.
+  - Asserts `HELP_TEXT` contains the new no-args wording line and the unchanged explicit-`server` line.
+  - Spawn test (defense-in-depth): isolates state with `mkdtemp` + `AGENT_ORCHESTRATOR_HOME`, spawns `dist/cli.js` with default piped stdin, sends a real MCP `initialize` JSON-RPC request over stdin, asserts a framed JSON-RPC response on stdout, then cleans up with `dist/cli.js stop --force` and `waitForStopped(env)`. Reuses the isolation pattern from `src/__tests__/daemonCli.test.ts` lines 56–104 and 166–177.
+- README clarification (line ~15 region and the MCP client config block): one-line note that the bare `node dist/cli.js` example is for piped MCP-client use, and that the same command from a terminal now prints help.
+- `docs/development/mcp-tooling.md` ~line 301: clarify that `node dist/cli.js` starts the MCP server when invoked over piped stdio (e.g., from an MCP client) and prints help on a TTY; explicitly point at `node dist/cli.js server` as the always-server form.
+
+### Out Of Scope
+
+- Reformatting or expanding the help text body (Decision 4).
+- Changing `agent-orchestrator server`, `doctor`, `opencode`, `claude`, `monitor`, `auth`, `supervisor`, or any daemon subcommand.
+- Changing MCP tool names, schemas, server transport, or daemon IPC.
+- Changing `src/server.ts` startup ordering (`ensureDaemon` then `server.connect(transport)`).
+- Adding a `node-pty` or any other new dependency.
+- Adding env-var overrides for TTY detection (Decision 3).
+- Bumping the package version, publishing, or pushing.
+- Editing `.agents/` rule files unless a new repeatable rule emerges (see Rule Candidates).
+
+## Risks And Edge Cases
+
+| # | Scenario | Mitigation | Covered By |
+|---|---|---|---|
+| 1 | An MCP client launches `agent-orchestrator` in a way where stdin is unexpectedly a TTY (none known today). | Document `agent-orchestrator server` as the explicit MCP-server entry point and keep it always working. The help text we print on a TTY tells the user how to start the server. | Decision 3, T1, T4 |
+| 2 | A CI script runs `agent-orchestrator` with no stdin attached and expects the server to start. | `process.stdin.isTTY` is `undefined`/`false` when stdin is a pipe or `/dev/null`, so the server still starts. This matches the current behavior for non-TTY invocation. | T1, T3 |
+| 3 | The README and `docs/development/mcp-tooling.md` show bare `node dist/cli.js` examples that humans may run on a TTY. After this change those will print help, not start the server. | T4 adds a one-line clarification next to each example explaining the TTY-vs-piped-stdio split, and points at `agent-orchestrator server` (or `node dist/cli.js server`) as the always-server form. The MCP-client configs themselves are unchanged because they always pipe stdio. | T4 |
+| 4 | A test that spawns `dist/cli.js` with piped stdin auto-starts the daemon (`ensureDaemon` in `src/server.ts`) and writes to the user's `~/.agent-orchestrator/` if `AGENT_ORCHESTRATOR_HOME` is unset. This would pollute the developer's machine and could fight a real daemon. | The spawn test sets `AGENT_ORCHESTRATOR_HOME=<mkdtemp>` for the child process and ends the test by calling `dist/cli.js stop --force` against the same env, then `waitForStopped(env)`, then `rm -rf` the temp root. This is the pattern already used by `daemonCli.test.ts` (`controls the daemon through the top-level CLI`). | T3 |
+| 5 | A spawn smoke test that just checks "child did not exit within N ms" can pass for a hung child and does not prove MCP stdio still works. | The spawn test sends a real MCP `initialize` JSON-RPC request and asserts a successful framed JSON-RPC response on stdout (matching `id=1`, `result` set, `result.serverInfo.name === "agent-orchestrator"`). The framing matches what `StdioServerTransport` actually uses today — newline-delimited JSON, `JSON.stringify(message) + '\n'` — verified at `node_modules/@modelcontextprotocol/sdk/dist/esm/shared/stdio.js` line 28–30 and line 13–19. That proves the stdio MCP transport is still wired up after the dispatch refactor. | T3 |
+| 6 | The help-on-TTY path on Windows (Node 22) where `process.stdin.isTTY` semantics in PowerShell vs. Git Bash vs. cmd.exe could differ. | Node's `tty.ReadStream.isTTY` is documented and consistent across platforms when stdin is attached to a console; the spawn test (piped stdin) covers the non-TTY direction on all platforms. Manual smoke on a TTY is sufficient for the positive direction. | T3, T6 |
+| 7 | The existing `--help` test in `src/__tests__/daemonCli.test.ts` greps the help text. | The help text content does not change except for one line wording (Decision 5). Update the assertion only if it pins that exact line; today's test asserts on subcommand lines that are unaffected. | T1, T2 |
+
+## Implementation Tasks
+
+| Task ID | Title | Depends On | Status | Acceptance Criteria |
+|---|---|---|---|---|
+| T1 | Add `src/cliRoot.ts` with `HELP_TEXT` + `decideRootMode` | None | pending | New file `src/cliRoot.ts` exists and is side-effect-free (no top-level `await`; no import of `./server.js`, `./daemon/*`, `./diagnostics.js`, or any module with import-time side effects). It exports `export const HELP_TEXT: string` (the same body as today's `--help` block, with the no-args wording change from Decision 5 baked in) and `export function decideRootMode(stdinIsTty: boolean \| undefined): 'help' \| 'server'` returning `'help'` iff `stdinIsTty === true`. `pnpm build` succeeds. |
+| T2 | Wire `src/cli.ts` to use the new module | T1 | pending | `src/cli.ts` imports `HELP_TEXT` and `decideRootMode` from `./cliRoot.js`. The no-args branch (`!command`) calls `decideRootMode(process.stdin.isTTY)` and writes `HELP_TEXT` to stdout (and falls through / `process.exit(0)`) for `'help'`, or `await import('./server.js')` for `'server'`. The explicit `command === 'server'` branch is unchanged: it always imports `./server.js`. The `--help`/`-h`/`help` branch writes the same `HELP_TEXT`. The inline help block in `src/cli.ts` is removed (no duplication). `pnpm build` succeeds and the existing `daemonCli.test.ts --help` assertions still pass (the subcommand lines are unchanged; only one wording line moves). |
+| T3 | Add focused tests in `src/__tests__/cliRoot.test.ts` | T1, T2 | pending | New `src/__tests__/cliRoot.test.ts` covers: (a) unit: import `../cliRoot.js` and assert `decideRootMode(true) === 'help'`, `decideRootMode(false) === 'server'`, `decideRootMode(undefined) === 'server'`; (b) unit: assert `HELP_TEXT` contains both `agent-orchestrator              Show this help in a terminal; start the MCP server for piped stdio` and `agent-orchestrator server       Start the stdio MCP server`; (c) spawn test: `mkdtemp(join(tmpdir(), 'agent-cli-root-'))` for an isolated home; spawn `dist/cli.js` with `env = { ...process.env, AGENT_ORCHESTRATOR_HOME: home }` and default (piped) stdio; write the JSON-RPC `initialize` request to the child's stdin using the framing `StdioServerTransport` actually expects — `JSON.stringify(message) + '\n'` (newline-delimited JSON), per `node_modules/@modelcontextprotocol/sdk/dist/esm/shared/stdio.js` line 28–30 (`serializeMessage`) and line 13–19 (`ReadBuffer.readMessage` splits on `\n` and strips a trailing `\r`). The exact bytes written: `{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"cliRoot.test","version":"0.0.0"}}}\n`. Parse the child's stdout the same way: accumulate chunks into a buffer, split on `\n`, strip trailing `\r`, JSON.parse each non-empty line, take the first message with `id === 1`. Assert the parsed message has `jsonrpc === "2.0"`, `id === 1`, a `result` (not an `error`), `result.protocolVersion` is a string, and `result.serverInfo?.name === "agent-orchestrator"` (matches `src/server.ts` `new Server({ name: 'agent-orchestrator', ... })`). Then kill the child; cleanup in `finally`: `execFileAsync(process.execPath, [cliPath, 'stop', '--force'], { env, timeout: 10_000 }).catch(() => undefined)`, then a locally-defined `waitForStopped(env)` helper (copy the function body from `src/__tests__/daemonCli.test.ts` lines 166–177 into this test file — do NOT `import` from the other test file, since that would execute its top-level `describe`/`it` definitions), then `rm(root, { recursive: true, force: true })`. The test must not run without `AGENT_ORCHESTRATOR_HOME` isolation. (d) spawn test: `dist/cli.js --help` still prints the help text (regression check; may be redundant with the existing `daemonCli.test.ts --help` test — keep it there if so). |
+| T4 | Update README and human-facing docs | T2 | pending | `README.md` ~line 15 ("For local development from a checkout"): leave the `node dist/cli.js doctor` line alone; for the bare `node dist/cli.js` line, change it to `node dist/cli.js server` (explicit MCP-server entry — the intended behavior of the example). Add one short sentence near the MCP client config block clarifying that no-args invocation starts the stdio MCP server because clients pipe stdin/stdout, and that running `agent-orchestrator` from a terminal now prints help. `docs/development/mcp-tooling.md` ~line 301: change the example from `node dist/cli.js` to `node dist/cli.js server` (explicit MCP-server entry) and add a one-line note that the bare form prints help on a TTY. No other docs reword. |
+| T5 | Sync AI workspace if any rule/skill changed | T4 | pending | If T4 or any earlier task edits `.agents/`, run `node scripts/sync-ai-workspace.mjs`. Otherwise this task is a documented no-op. |
+| T6 | Verify and record evidence | T1, T2, T3, T4, T5 | pending | `pnpm build` passes. `node --test dist/__tests__/daemonCli.test.js dist/__tests__/cliRoot.test.js` passes. `pnpm test` passes. `pnpm verify` passes (or any failure is documented with concrete output and next step). Manual smoke (recorded in execution log): in this terminal, `node dist/cli.js` prints help and exits 0; then run the piped-stdin smoke as: <br>`TEMP_HOME=$(mktemp -d)` <br>`printf '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"smoke","version":"0.0.0"}}}\n' \| AGENT_ORCHESTRATOR_HOME=$TEMP_HOME node dist/cli.js` <br>and confirm a JSON-RPC response with `id=1` and `result.serverInfo.name === "agent-orchestrator"`; then <br>`AGENT_ORCHESTRATOR_HOME=$TEMP_HOME node dist/cli.js stop --force` <br>`rm -rf "$TEMP_HOME"` <br>The same `$TEMP_HOME` is used for the smoke and the cleanup so the spawned daemon is shut down deterministically. |
+
+## Rule Candidates
+
+| # | Candidate | Scope | Create After |
+|---|---|---|---|
+| 1 | When a CLI is also an MCP stdio entry point, gate human-friendly behavior (help, banners, prompts) on `process.stdin.isTTY` so MCP clients that pipe stdio are never affected. | All CLI work that adds interactive output to a binary that doubles as an MCP server. | After T6, if this comes up again on `opencode`/`claude` launchers. |
+| 2 | Helpers intended for unit tests must live in side-effect-free modules; never put them in `cli.ts` or any file with top-level `await` / import-time side effects (e.g., `server.connect`). | All CLI source files. | After T6 if this distinction needs explicit guidance. |
+
+## Quality Gates
+
+- [ ] `pnpm build` passes.
+- [ ] `node --test dist/__tests__/daemonCli.test.js dist/__tests__/cliRoot.test.js` passes.
+- [ ] `pnpm test` passes.
+- [ ] `pnpm verify` passes (or documented failure).
+- [ ] `.agents/rules/node-typescript.md` (source of truth): no new deps; pnpm only; TS strictness intact; CLI human + JSON output verified where touched.
+- [ ] Manual smoke: `node dist/cli.js` from this terminal prints help; piped-stdin invocation with isolated `AGENT_ORCHESTRATOR_HOME` answers an MCP `initialize` request, then `stop --force` shuts the test daemon down.
+- [ ] No commit, push, or version bump performed.
+
+## Reviewer Questions
+
+none
+
+## Open Human Decisions
+
+none
+
+## Execution Log
+
+### T1: Add `src/cliRoot.ts` with `HELP_TEXT` + `decideRootMode`
+- **Status:** pending
+- **Evidence:** pending
+- **Notes:** pending
+
+### T2: Wire `src/cli.ts` to use the new module
+- **Status:** pending
+- **Evidence:** pending
+- **Notes:** pending
+
+### T3: Add focused tests in `src/__tests__/cliRoot.test.ts`
+- **Status:** pending
+- **Evidence:** pending
+- **Notes:** pending
+
+### T4: Update README and human-facing docs
+- **Status:** pending
+- **Evidence:** pending
+- **Notes:** pending
+
+### T5: Sync AI workspace if any rule/skill changed
+- **Status:** pending
+- **Evidence:** pending
+- **Notes:** pending
+
+### T6: Verify and record evidence
+- **Status:** pending
+- **Evidence:** pending
+- **Notes:** pending

--- a/plans/33-root-command-should-give-you-the-help/plans/33-root-command-help.md
+++ b/plans/33-root-command-should-give-you-the-help/plans/33-root-command-help.md
@@ -4,7 +4,7 @@ Branch: `33-root-command-should-give-you-the-help`
 Plan Slug: `33-root-command-help`
 Parent Issue: #33
 Created: 2026-05-06
-Status: planning
+Status: implemented (awaiting review)
 
 ## Context
 
@@ -123,31 +123,37 @@ none
 ## Execution Log
 
 ### T1: Add `src/cliRoot.ts` with `HELP_TEXT` + `decideRootMode`
-- **Status:** pending
-- **Evidence:** pending
-- **Notes:** pending
+- **Status:** done
+- **Evidence:** New `src/cliRoot.ts` created. No top-level `await`; imports nothing (no `./server.js`, no `./daemon/*`, no `./diagnostics.js`). Exports `HELP_TEXT` (with the Decision 5 wording change baked into the no-args line) and `decideRootMode(stdinIsTty)` returning `'help'` iff `stdinIsTty === true`.
+- **Notes:** Module is pure; safe to import from unit tests without daemon side effects.
 
 ### T2: Wire `src/cli.ts` to use the new module
-- **Status:** pending
-- **Evidence:** pending
-- **Notes:** pending
+- **Status:** done
+- **Evidence:** `src/cli.ts` now imports `HELP_TEXT` and `decideRootMode` from `./cliRoot.js`. Inline help block removed (single source of truth). No-args branch consults `decideRootMode(process.stdin.isTTY)` — writes `HELP_TEXT` for `'help'`, falls through to `await import('./server.js')` for `'server'`. Explicit `command === 'server'` is its own branch and unchanged. `--help`/`-h`/`help` writes the same `HELP_TEXT`.
+- **Notes:** Existing `daemonCli.test.ts --help` assertions continue to pass because subcommand lines are unchanged.
 
 ### T3: Add focused tests in `src/__tests__/cliRoot.test.ts`
-- **Status:** pending
-- **Evidence:** pending
-- **Notes:** pending
+- **Status:** done
+- **Evidence:** New `src/__tests__/cliRoot.test.ts` covers (a) `decideRootMode` truth table; (b) `HELP_TEXT` contains both the bare-invocation wording and the explicit-server line; (c) regression: `dist/cli.js --help` prints help; (d) spawn test that isolates `AGENT_ORCHESTRATOR_HOME` via `mkdtemp`, sends NDJSON `initialize` to a piped stdin, parses the framed response, asserts `result.serverInfo.name === "agent-orchestrator"`. Cleanup uses `dist/cli.js stop --force` + a locally-defined `waitForStopped` helper + `rm -rf` of the temp home (no import from `daemonCli.test.ts`). All four cliRoot tests pass.
+- **Notes:** Run: `node --test dist/__tests__/daemonCli.test.js dist/__tests__/cliRoot.test.js` → 11/11 passing.
 
 ### T4: Update README and human-facing docs
-- **Status:** pending
-- **Evidence:** pending
-- **Notes:** pending
+- **Status:** done
+- **Evidence:** `README.md` local-checkout block changed `node dist/cli.js` → `node dist/cli.js server` and added a one-paragraph note clarifying that bare invocation prints help on a TTY and starts the MCP server when stdin is piped. `docs/development/mcp-tooling.md` ~line 301 changed the example to `node dist/cli.js server` and added a one-line note that the bare form prints help on a TTY. MCP client config blocks left unchanged because they always pipe stdio.
+- **Notes:** No changes elsewhere; line ~330 statement that `dist/cli.js` "starts the stdio MCP server" still holds in MCP-client (piped-stdin) context.
 
 ### T5: Sync AI workspace if any rule/skill changed
-- **Status:** pending
-- **Evidence:** pending
-- **Notes:** pending
+- **Status:** done (no-op)
+- **Evidence:** No edits under `.agents/` — `sync-ai-workspace.mjs` not run.
+- **Notes:** Per plan, T5 is a documented no-op when no rule/skill changed.
 
 ### T6: Verify and record evidence
-- **Status:** pending
-- **Evidence:** pending
-- **Notes:** pending
+- **Status:** done
+- **Evidence:**
+  - `pnpm build` → exit 0.
+  - `node --test dist/__tests__/daemonCli.test.js dist/__tests__/cliRoot.test.js` → 11 pass / 0 fail (4 cliRoot, 7 daemon CLI).
+  - `pnpm test` → 534 pass / 0 fail / 2 skipped (536 total, 108 suites).
+  - `pnpm verify` → exit 0 (build + test + check-publish-ready + resolve-publish-tag + audit + npm pack --dry-run all green).
+  - Manual smoke: `TEMP_HOME=$(mktemp -d); printf '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"smoke","version":"0.0.0"}}}\n' | AGENT_ORCHESTRATOR_HOME=$TEMP_HOME node dist/cli.js` returned `{"result":{"protocolVersion":"2024-11-05","capabilities":{"tools":{}},"serverInfo":{"name":"agent-orchestrator","version":"0.2.1"}},"jsonrpc":"2.0","id":1}`. `AGENT_ORCHESTRATOR_HOME=$TEMP_HOME node dist/cli.js stop --force` printed `agent-orchestrator daemon stopping store=$TEMP_HOME`. Temp home removed.
+  - Manual TTY smoke: `script -qfc "node dist/cli.js" /dev/null < /dev/null` (PTY-allocated stdin) printed the new help text starting with `agent-orchestrator` and the line `agent-orchestrator              Show this help in a terminal; start the MCP server for piped stdio`.
+- **Notes:** No commit, push, or version bump performed.

--- a/plans/33-root-command-should-give-you-the-help/resolution-map.md
+++ b/plans/33-root-command-should-give-you-the-help/resolution-map.md
@@ -1,0 +1,151 @@
+---
+pr: 50
+url: https://github.com/ralphkrauss/agent-orchestrator/pull/50
+branch: 33-root-command-should-give-you-the-help
+created: 2026-05-07
+generated_by: Claude resolve-pr-comments triage (resolution-map-only, batched)
+ai_reply_prefix: "**[AI Agent]:**"
+correlation_marker_pattern: "<!-- agent-orchestrator:pr50:<tag> -->"
+scope: "Resolution map only. No implementation, no commits, no pushes, no GitHub replies, no thread resolution."
+---
+
+# PR #50 Resolution Map
+
+Branch: `33-root-command-should-give-you-the-help`
+Base: `main`
+Head commit: `76563b9 feat(cli)(33): print help on TTY for bare agent-orchestrator`
+Merge state: `CLEAN` / `MERGEABLE`. CI: green (Node 22, Node 24, CodeRabbit).
+Approved plan: `plans/33-root-command-should-give-you-the-help/plans/33-root-command-help.md`.
+
+## Fetch Results
+
+- `gh pr view 50` reviews: **0**
+- `gh api repos/.../pulls/50/comments` (inline review comments): **0**
+- `gh api repos/.../issues/50/comments` (conversation comments): **1**
+- GraphQL `reviewThreads`: **0** (no threads to filter as resolved)
+
+## Counts
+
+- Total comments fetched: 1
+- Filtered as bot noise (no actionable content): 1
+- Actionable comments triaged: 1 (an embedded pre-merge check warning surfaced from the same auto-summary comment)
+- To fix: 0 | To decline: 1 | To defer: 0 | To escalate: 0 | Human Approval Required: 0
+
+## Filter Notes
+
+The single fetched comment is CodeRabbit's auto-generated walkthrough/summary
+comment (id `4394526803`). Its top line explicitly states:
+
+> No actionable comments were generated in the recent review. 🎉
+
+The body's `Additional comments (10)` section is praise-only ("looks
+consistent and correctly scoped", "is clean, side-effect-free", "Great
+end-to-end coverage", etc.) and is not actionable feedback. The walkthrough
+itself is therefore filtered as informational bot noise per the
+`resolve-pr-comments` filter rules.
+
+The same comment embeds a "Pre-merge checks" block with one warning:
+**Docstring Coverage**. That is the only item inside the comment that could
+plausibly be construed as feedback, so it is surfaced as `C1` below and
+triaged on its merits rather than silently dropped.
+
+No prior AI replies with `<!-- agent-orchestrator:pr50:* -->` correlation
+markers exist on this PR (no replies have been posted to this PR by any AI
+agent yet).
+
+## Comment C1 | Decline | Low
+
+- **Comment Type:** conversation (embedded pre-merge check warning inside the CodeRabbit auto-summary)
+- **File:** N/A (repo-wide bot threshold, not tied to a specific path/line)
+- **Comment ID:** `4394526803` (parent CodeRabbit summary)
+- **Review ID:** N/A
+- **Thread Node ID:** N/A (not posted as a review thread)
+- **Author:** `coderabbitai[bot]`
+- **Comment (excerpt):**
+
+  > Docstring Coverage — ⚠️ Warning — Docstring coverage is 0.00% which is
+  > insufficient. The required threshold is 80.00%. Resolution: Write
+  > docstrings for the functions missing them to satisfy the coverage
+  > threshold.
+
+- **Cited code on this branch:**
+  - `src/cliRoot.ts` (new) — exports `HELP_TEXT` (constant) and
+    `decideRootMode(stdinIsTty)` (one-line pure function). Currently no
+    JSDoc.
+  - `src/cli.ts` — minor edits: imports `HELP_TEXT` and calls
+    `decideRootMode(process.stdin.isTTY)` from the no-args branch. No JSDoc
+    added or removed.
+  - `src/__tests__/cliRoot.test.ts` (new) — test file; not a docstring
+    target.
+- **Independent Assessment:**
+  - The warning is a generic CodeRabbit threshold check ("0.00% < 80.00%")
+    applied uniformly, not a verified review of this PR's content.
+  - The CodeRabbit comment that contains this warning explicitly declares
+    "No actionable comments were generated in the recent review. 🎉",
+    confirming the bot itself does not classify this as actionable feedback.
+  - Repository convention does not use JSDoc tag-based docstrings: across
+    `src/`, `/**` block-comment opens occur **193** times across **33**
+    files, but `@param` / `@returns` / `@throws` tags occur **zero** times.
+    Existing `/**` blocks are plain prose intros, not formal docstrings.
+    Forcing 80%+ JSDoc tag coverage on a two-export module would diverge
+    from the repo's established TypeScript style.
+  - Neither `AGENTS.md`, `.cursor/rules/node-typescript.mdc`, nor the
+    approved plan (`plans/33-root-command-should-give-you-the-help/plans/33-root-command-help.md`)
+    require docstrings.
+  - The two new symbols are self-documenting:
+    - `HELP_TEXT` is a string literal whose content *is* the documentation.
+    - `decideRootMode(stdinIsTty: boolean | undefined): 'help' | 'server'`
+      has a self-explanatory name, typed signature, and a one-line body —
+      `return stdinIsTty === true ? 'help' : 'server';`.
+  - The plan-approved test (`src/__tests__/cliRoot.test.ts`) covers the
+    truth table for `decideRootMode` and the content/format of `HELP_TEXT`,
+    so behavior is documented through tests.
+  - PR-level CI on this branch is `CLEAN`; no required check is failing.
+    The Docstring Coverage check is reported as a CodeRabbit pre-merge
+    warning, not a blocking status.
+- **Decision:** Decline.
+- **Rationale:** Generic bot threshold not aligned with repo TypeScript
+  conventions, not requested by the approved plan, not blocking CI, and the
+  affected symbols are already self-documenting + test-covered. Adding
+  JSDoc here purely to satisfy a global CodeRabbit threshold would be scope
+  creep on a focused PR and could invite unrelated stylistic churn.
+- **Approach:** No code change. Reply on the conversation comment to
+  acknowledge the warning, explain the convention mismatch, and link to the
+  approved plan and the existing tests as the documentation surface.
+- **Files To Change:** none.
+- **Reply Draft:**
+
+  > **[AI Agent]:** Acknowledged, but declining this pre-merge warning.
+  > It's a generic CodeRabbit threshold (0.00% vs. 80.00%) not tied to a
+  > specific correctness issue in this PR — the same review explicitly
+  > notes "No actionable comments were generated". The repo's TypeScript
+  > convention
+  > does not use JSDoc tag-based docstrings (193 `/**` blocks across `src/`
+  > but zero `@param`/`@returns`/`@throws`), and neither `AGENTS.md` nor
+  > the approved plan
+  > (`plans/33-root-command-should-give-you-the-help/plans/33-root-command-help.md`)
+  > requires them. The two new symbols are self-documenting:
+  > `HELP_TEXT` is a string literal whose content is the help message, and
+  > `decideRootMode(stdinIsTty)` is a typed one-line pure function whose
+  > truth table is asserted in `src/__tests__/cliRoot.test.ts`. Happy to
+  > revisit if we ever adopt a repo-wide JSDoc policy.
+  > <!-- agent-orchestrator:pr50:c1 -->
+
+## Reviewer Questions
+
+none.
+
+The single fetched comment is bot noise per the resolve-pr-comments filter
+rules, and its only embedded warning has a clear rationale to decline based
+on existing repo convention, the approved plan, and current tests. No
+ambiguity required reviewer adjudication.
+
+## Open Human Decisions
+
+none.
+
+The lone triage item (`C1`) is a `decline` against a generic CodeRabbit
+threshold warning. It does not propose any behavior change, public-contract
+change, workflow change, permission/tool-surface change, security-boundary
+change, release/publish change, dependency-policy change, or capability
+removal — so no human approval gate is triggered.

--- a/src/__tests__/cliRoot.test.ts
+++ b/src/__tests__/cliRoot.test.ts
@@ -1,0 +1,164 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { execFile, spawn } from 'node:child_process';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { promisify } from 'node:util';
+import { HELP_TEXT, decideRootMode } from '../cliRoot.js';
+
+const execFileAsync = promisify(execFile);
+const testDir = dirname(fileURLToPath(import.meta.url));
+const cliPath = join(testDir, '..', 'cli.js');
+const daemonCliPath = join(testDir, '..', 'daemonCli.js');
+
+describe('cliRoot', () => {
+  it('decideRootMode returns help only for an interactive TTY stdin', () => {
+    assert.equal(decideRootMode(true), 'help');
+    assert.equal(decideRootMode(false), 'server');
+    assert.equal(decideRootMode(undefined), 'server');
+  });
+
+  it('HELP_TEXT documents both the bare and explicit-server invocations', () => {
+    assert.match(
+      HELP_TEXT,
+      /agent-orchestrator {14}Show this help in a terminal; start the MCP server for piped stdio/,
+    );
+    assert.match(HELP_TEXT, /agent-orchestrator server {7}Start the stdio MCP server/);
+  });
+
+  it('dist/cli.js --help still prints the help text', async () => {
+    const result = await execFileAsync(process.execPath, [cliPath, '--help'], { timeout: 5_000 });
+    assert.match(result.stdout, /agent-orchestrator server {7}Start the stdio MCP server/);
+    assert.match(
+      result.stdout,
+      /agent-orchestrator {14}Show this help in a terminal; start the MCP server for piped stdio/,
+    );
+  });
+
+  it('answers an MCP initialize request when stdin is piped', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'agent-cli-root-'));
+    const home = join(root, 'home');
+    const env = { ...process.env, AGENT_ORCHESTRATOR_HOME: home };
+
+    const child = spawn(process.execPath, [cliPath], {
+      env,
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+
+    let resolveResponse!: (message: Record<string, unknown>) => void;
+    let rejectResponse!: (reason: unknown) => void;
+    const responsePromise = new Promise<Record<string, unknown>>((resolve, reject) => {
+      resolveResponse = resolve;
+      rejectResponse = reject;
+    });
+
+    let stdoutBuffer = '';
+    let stderrBuffer = '';
+    let resolved = false;
+
+    child.stdout.setEncoding('utf8');
+    child.stdout.on('data', (chunk: string) => {
+      stdoutBuffer += chunk;
+      let newlineIdx = stdoutBuffer.indexOf('\n');
+      while (newlineIdx >= 0) {
+        const rawLine = stdoutBuffer.slice(0, newlineIdx);
+        stdoutBuffer = stdoutBuffer.slice(newlineIdx + 1);
+        const line = rawLine.endsWith('\r') ? rawLine.slice(0, -1) : rawLine;
+        if (line.length > 0 && !resolved) {
+          try {
+            const parsed = JSON.parse(line) as Record<string, unknown>;
+            if (parsed.id === 1) {
+              resolved = true;
+              resolveResponse(parsed);
+              return;
+            }
+          } catch (error) {
+            resolved = true;
+            rejectResponse(new Error(`failed to parse stdout line as JSON: ${line} (${(error as Error).message})`));
+            return;
+          }
+        }
+        newlineIdx = stdoutBuffer.indexOf('\n');
+      }
+    });
+
+    child.stderr.setEncoding('utf8');
+    child.stderr.on('data', (chunk: string) => {
+      stderrBuffer += chunk;
+    });
+
+    child.on('error', (error) => {
+      if (!resolved) {
+        resolved = true;
+        rejectResponse(error);
+      }
+    });
+    child.on('exit', (code, signal) => {
+      if (!resolved) {
+        resolved = true;
+        rejectResponse(new Error(`child exited before responding: code=${code} signal=${signal} stderr=${stderrBuffer}`));
+      }
+    });
+
+    const initRequest = {
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'initialize',
+      params: {
+        protocolVersion: '2024-11-05',
+        capabilities: {},
+        clientInfo: { name: 'cliRoot.test', version: '0.0.0' },
+      },
+    };
+    child.stdin.write(`${JSON.stringify(initRequest)}\n`);
+
+    const timeoutHandle = setTimeout(() => {
+      if (!resolved) {
+        resolved = true;
+        rejectResponse(new Error(`timed out waiting for MCP initialize response. stderr=${stderrBuffer}`));
+      }
+    }, 20_000);
+
+    try {
+      const response = await responsePromise;
+      assert.equal(response.jsonrpc, '2.0');
+      assert.equal(response.id, 1);
+      assert.equal(response.error, undefined, `expected no error, got ${JSON.stringify(response.error)}`);
+      const result = response.result as
+        | { protocolVersion?: unknown; serverInfo?: { name?: unknown } }
+        | undefined;
+      assert.ok(result, 'expected result on initialize response');
+      assert.equal(typeof result.protocolVersion, 'string');
+      assert.equal(result.serverInfo?.name, 'agent-orchestrator');
+    } finally {
+      clearTimeout(timeoutHandle);
+      child.stdin.end();
+      try {
+        child.kill('SIGTERM');
+      } catch {
+        // best effort
+      }
+      await execFileAsync(process.execPath, [cliPath, 'stop', '--force'], {
+        env,
+        timeout: 10_000,
+      }).catch(() => undefined);
+      await waitForStopped(env);
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+});
+
+async function waitForStopped(env: NodeJS.ProcessEnv): Promise<void> {
+  const deadline = Date.now() + 5_000;
+  while (Date.now() < deadline) {
+    try {
+      await execFileAsync(process.execPath, [daemonCliPath, 'status'], { env, timeout: 2_000 });
+      await new Promise((resolve) => setTimeout(resolve, 100));
+    } catch {
+      return;
+    }
+  }
+  throw new Error('daemon did not stop before timeout');
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 import { getBackendStatus, formatBackendStatus } from './diagnostics.js';
 import { isDaemonCliCommand, runDaemonCli } from './daemon/daemonCli.js';
+import { HELP_TEXT, decideRootMode } from './cliRoot.js';
 
 const command = process.argv[2];
 
@@ -11,7 +12,13 @@ if (command === 'doctor') {
   } else {
     process.stdout.write(formatBackendStatus(status));
   }
-} else if (!command || command === 'server') {
+} else if (!command) {
+  if (decideRootMode(process.stdin.isTTY) === 'help') {
+    process.stdout.write(HELP_TEXT);
+  } else {
+    await import('./server.js');
+  }
+} else if (command === 'server') {
   await import('./server.js');
 } else if (command === 'opencode') {
   const { runOpenCodeLauncher } = await import('./opencode/launcher.js');
@@ -36,49 +43,7 @@ if (command === 'doctor') {
     process.exit(1);
   }
 } else if (command === '--help' || command === '-h' || command === 'help') {
-  process.stdout.write(`agent-orchestrator
-
-Usage:
-  agent-orchestrator              Start the stdio MCP server
-  agent-orchestrator server       Start the stdio MCP server
-  agent-orchestrator doctor       Check local worker CLI availability
-  agent-orchestrator doctor --json
-  agent-orchestrator opencode     Start OpenCode in orchestration mode
-  agent-orchestrator claude       Start Claude Code in orchestration mode (recommended rich-feature harness)
-  agent-orchestrator monitor <run_id> [--json-line] [--since <id>]
-  agent-orchestrator auth status [--json]
-  agent-orchestrator auth <provider> [--from-env [VAR] | --from-stdin]
-  agent-orchestrator auth unset <provider>
-  agent-orchestrator supervisor register --label <name> --cwd <path>
-  agent-orchestrator supervisor signal <event>
-  agent-orchestrator supervisor unregister --orchestrator-id <id>
-  agent-orchestrator supervisor status [--orchestrator-id <id>]
-  agent-orchestrator status       Show daemon status
-  agent-orchestrator status --json
-  agent-orchestrator runs [--json] [--prompts]
-  agent-orchestrator watch [--interval-ms <ms>] [--limit <n>]
-  agent-orchestrator start
-  agent-orchestrator stop [--force]
-  agent-orchestrator restart [--force]
-  agent-orchestrator prune --older-than-days <days> [--dry-run]
-
-Standalone daemon alias:
-  agent-orchestrator-daemon status
-  agent-orchestrator-daemon status --verbose
-  agent-orchestrator-daemon status --json
-  agent-orchestrator-daemon runs [--json] [--prompts]
-  agent-orchestrator-daemon watch [--interval-ms <ms>] [--limit <n>]
-  agent-orchestrator-daemon start
-  agent-orchestrator-daemon stop [--force]
-  agent-orchestrator-daemon restart [--force]
-  agent-orchestrator-daemon prune --older-than-days <days> [--dry-run]
-  agent-orchestrator-daemon auth status [--json]
-  agent-orchestrator-daemon auth <provider> [--from-env [VAR] | --from-stdin]
-  agent-orchestrator-daemon auth unset <provider>
-
-OpenCode orchestration:
-  agent-orchestrator-opencode [options]
-`);
+  process.stdout.write(HELP_TEXT);
 } else {
   process.stderr.write(`Unknown command: ${command}\nRun agent-orchestrator --help for usage.\n`);
   process.exit(1);

--- a/src/cliRoot.ts
+++ b/src/cliRoot.ts
@@ -1,0 +1,47 @@
+export const HELP_TEXT = `agent-orchestrator
+
+Usage:
+  agent-orchestrator              Show this help in a terminal; start the MCP server for piped stdio
+  agent-orchestrator server       Start the stdio MCP server
+  agent-orchestrator doctor       Check local worker CLI availability
+  agent-orchestrator doctor --json
+  agent-orchestrator opencode     Start OpenCode in orchestration mode
+  agent-orchestrator claude       Start Claude Code in orchestration mode (recommended rich-feature harness)
+  agent-orchestrator monitor <run_id> [--json-line] [--since <id>]
+  agent-orchestrator auth status [--json]
+  agent-orchestrator auth <provider> [--from-env [VAR] | --from-stdin]
+  agent-orchestrator auth unset <provider>
+  agent-orchestrator supervisor register --label <name> --cwd <path>
+  agent-orchestrator supervisor signal <event>
+  agent-orchestrator supervisor unregister --orchestrator-id <id>
+  agent-orchestrator supervisor status [--orchestrator-id <id>]
+  agent-orchestrator status       Show daemon status
+  agent-orchestrator status --json
+  agent-orchestrator runs [--json] [--prompts]
+  agent-orchestrator watch [--interval-ms <ms>] [--limit <n>]
+  agent-orchestrator start
+  agent-orchestrator stop [--force]
+  agent-orchestrator restart [--force]
+  agent-orchestrator prune --older-than-days <days> [--dry-run]
+
+Standalone daemon alias:
+  agent-orchestrator-daemon status
+  agent-orchestrator-daemon status --verbose
+  agent-orchestrator-daemon status --json
+  agent-orchestrator-daemon runs [--json] [--prompts]
+  agent-orchestrator-daemon watch [--interval-ms <ms>] [--limit <n>]
+  agent-orchestrator-daemon start
+  agent-orchestrator-daemon stop [--force]
+  agent-orchestrator-daemon restart [--force]
+  agent-orchestrator-daemon prune --older-than-days <days> [--dry-run]
+  agent-orchestrator-daemon auth status [--json]
+  agent-orchestrator-daemon auth <provider> [--from-env [VAR] | --from-stdin]
+  agent-orchestrator-daemon auth unset <provider>
+
+OpenCode orchestration:
+  agent-orchestrator-opencode [options]
+`;
+
+export function decideRootMode(stdinIsTty: boolean | undefined): 'help' | 'server' {
+  return stdinIsTty === true ? 'help' : 'server';
+}


### PR DESCRIPTION
## Summary

Bare `agent-orchestrator` (no subcommand) now branches on `process.stdin.isTTY`:

- **TTY (humans)** → prints the same help text as `--help` and exits 0.
- **Piped stdin (MCP clients)** → imports `./server.js` and runs the stdio MCP server exactly as before.

Every existing MCP client config in the README pipes stdio, so all deployed configs continue to work unchanged. The explicit `agent-orchestrator server` subcommand remains the documented always-server entry point.

## Issue

Fixes #33

## Key Decisions

- **TTY signal:** `process.stdin.isTTY` — MCP clients always pipe stdin; humans don't.
- **Side-effect-free `src/cliRoot.ts`:** new module exporting `HELP_TEXT` and `decideRootMode(stdinIsTty)` so unit tests can import the helper without triggering `./server.js` import-time side effects (daemon spawn, `server.connect`).
- **Real MCP `initialize` test:** the spawn test sends a framed JSON-RPC `initialize` over piped stdin and asserts a framed response with `result.serverInfo.name === "agent-orchestrator"` — proves stdio MCP transport is still wired up after the dispatch refactor (a "did not exit" check would pass for a hung child).
- **Isolated `AGENT_ORCHESTRATOR_HOME`:** spawn test uses `mkdtemp` + `stop --force` + `waitForStopped` so it cannot leak a daemon onto the developer's `~/.agent-orchestrator/`.

## Changes

- `src/cliRoot.ts` (new) — pure module exporting `HELP_TEXT` and `decideRootMode`.
- `src/cli.ts` — no-args branch consults `decideRootMode(process.stdin.isTTY)`; inline help block removed (single source of truth); explicit `server` subcommand unchanged.
- `src/__tests__/cliRoot.test.ts` (new) — `decideRootMode` truth table, `HELP_TEXT` content, `--help` regression, and a real `initialize` JSON-RPC spawn test with isolated home.
- `README.md` — local-checkout example uses `node dist/cli.js server`; one-line note explaining the TTY-vs-piped-stdio split.
- `docs/development/mcp-tooling.md` — local-checkout example uses `node dist/cli.js server`; same TTY note.

## Test plan

Verifications already run on this branch:

- [x] `pnpm build` — exit 0
- [x] `node --test dist/__tests__/daemonCli.test.js dist/__tests__/cliRoot.test.js` — 11 pass / 0 fail
- [x] `pnpm test` — 534 pass / 0 fail / 2 skipped (108 suites)
- [x] `pnpm verify` — exit 0 (build + test + check-publish-ready + resolve-publish-tag + audit + npm pack --dry-run)
- [x] Manual MCP smoke: piped `initialize` over isolated `AGENT_ORCHESTRATOR_HOME` returned `result.serverInfo.name === "agent-orchestrator"`; `stop --force` shut the test daemon down cleanly.
- [x] Manual TTY smoke: `script -qfc "node dist/cli.js" /dev/null < /dev/null` printed the new help text including the updated no-args wording line.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CLI now shows root help when run without arguments in a terminal; explicit server start remains available.

* **Documentation**
  * Updated README and developer docs to recommend the explicit server command and clarify TTY vs piped-stdio behavior.

* **Tests**
  * Added unit and end-to-end tests for root-command decision logic and help/output behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->