### PR TITLE
Prepare repository for open source launch

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,93 @@
+name: Bug report
+description: Report a reproducible problem with Agent Orchestrator.
+title: "[Bug]: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Do not paste secrets, API keys, private tokens, or full prompt logs. Use SECURITY.md for vulnerabilities.
+  - type: input
+    id: package_version
+    attributes:
+      label: Package version
+      description: Run `agent-orchestrator --version` or check `npm ls @ralphkrauss/agent-orchestrator`.
+      placeholder: "0.2.2"
+    validations:
+      required: true
+  - type: input
+    id: os
+    attributes:
+      label: OS
+      placeholder: "macOS 15.4, Ubuntu 24.04, Windows 11"
+    validations:
+      required: true
+  - type: input
+    id: node
+    attributes:
+      label: Node.js version
+      placeholder: "v22.15.0"
+    validations:
+      required: true
+  - type: dropdown
+    id: backend
+    attributes:
+      label: Backend
+      multiple: true
+      options:
+        - Codex
+        - Claude
+        - Cursor
+        - OpenCode
+        - Daemon / MCP server
+        - Packaging / CI
+        - Documentation
+    validations:
+      required: true
+  - type: input
+    id: mcp_client
+    attributes:
+      label: MCP client
+      placeholder: "Claude Code, Codex, Cursor, OpenCode, other"
+  - type: textarea
+    id: command
+    attributes:
+      label: Command or MCP tool call
+      description: Include the exact command or tool input, with secrets removed.
+      render: text
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+    validations:
+      required: true
+  - type: textarea
+    id: diagnostics
+    attributes:
+      label: Diagnostics
+      description: Paste relevant `doctor --json`, `get_backend_status`, or run summary output with secrets removed.
+      render: json
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant logs
+      description: Keep excerpts minimal and remove secrets, private tokens, and unrelated prompt content.
+      render: text
+  - type: textarea
+    id: repro
+    attributes:
+      label: Reproduction steps
+      placeholder: |
+        1. ...
+        2. ...
+        3. ...
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,57 @@
+name: Feature request
+description: Suggest an improvement or new capability.
+title: "[Feature]: "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Please describe the workflow and constraints. Do not include secrets or private customer data.
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What are you trying to accomplish, and what is hard today?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: Describe the behavior, command, MCP tool shape, or docs change you want.
+    validations:
+      required: true
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      multiple: true
+      options:
+        - Codex backend
+        - Claude backend
+        - Cursor backend
+        - OpenCode harness
+        - Daemon lifecycle
+        - MCP contracts
+        - CLI
+        - Documentation
+        - Packaging / CI
+  - type: input
+    id: os
+    attributes:
+      label: Relevant OS
+      placeholder: "Linux, macOS, Windows, all"
+  - type: input
+    id: mcp_client
+    attributes:
+      label: Relevant MCP client
+      placeholder: "Claude Code, Codex, Cursor, OpenCode, other"
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+  - type: textarea
+    id: compatibility
+    attributes:
+      label: Compatibility notes
+      description: Mention expected migration, security, or backward-compatibility concerns.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,17 @@
+## Summary
+
+-
+
+## Verification
+
+- [ ] `pnpm build`
+- [ ] Targeted tests:
+- [ ] `pnpm verify`
+
+## Checklist
+
+- [ ] The change is scoped to the described behavior or setup work.
+- [ ] Public behavior, MCP contracts, and CLI output are documented when changed.
+- [ ] Tests cover daemon lifecycle, run-store persistence, backend invocation, MCP contracts, or release behavior when those areas are touched.
+- [ ] No secrets, local credentials, private tokens, or `.env` contents are included.
+- [ ] Package, publishing, or external-service behavior is unchanged unless explicitly intended.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,12 +13,13 @@ permissions:
   contents: read
 
 jobs:
-  test:
-    name: Build, Test, and Pack on Node ${{ matrix.node-version }}
-    runs-on: ubuntu-latest
+  verify:
+    name: Verify on ${{ matrix.os }} / Node ${{ matrix.node-version }}
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
+        os: [ubuntu-latest, macos-latest]
         node-version: ['22', '24']
 
     steps:
@@ -56,3 +57,52 @@ jobs:
           ./node_modules/.bin/agent-orchestrator-opencode --help
           ./node_modules/.bin/agent-orchestrator-opencode --print-config >/dev/null
           ./node_modules/.bin/agent-orchestrator opencode --print-config >/dev/null
+
+  windows-smoke:
+    name: Windows Smoke on Node ${{ matrix.node-version }}
+    runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: ['22', '24']
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.30.3
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build
+        run: pnpm build
+
+      - name: Windows-focused tests
+        run: node --test dist/__tests__/backendInvocation.test.js dist/__tests__/daemonPaths.test.js dist/__tests__/monitorPin.test.js dist/__tests__/cliVersion.test.js
+
+      - name: Install packed tarball smoke test
+        shell: pwsh
+        run: |
+          $packageFile = npm pack --silent | Select-Object -Last 1
+          $tempDir = Join-Path $env:RUNNER_TEMP ([guid]::NewGuid().ToString())
+          New-Item -ItemType Directory -Path $tempDir | Out-Null
+          Push-Location $tempDir
+          npm init -y | Out-Null
+          npm install (Join-Path $env:GITHUB_WORKSPACE $packageFile) | Out-Null
+          .\node_modules\.bin\agent-orchestrator.cmd --help
+          .\node_modules\.bin\agent-orchestrator.cmd doctor --json
+          .\node_modules\.bin\agent-orchestrator-daemon.cmd --help
+          .\node_modules\.bin\agent-orchestrator-opencode.cmd --help
+          .\node_modules\.bin\agent-orchestrator-opencode.cmd --print-config | Out-Null
+          .\node_modules\.bin\agent-orchestrator.cmd opencode --print-config | Out-Null
+          Pop-Location

--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,7 @@ coverage/
 *.log
 *.tgz
 .env
+*.env
+secrets.env
+mcp-secrets.env
 .DS_Store

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,138 +1,100 @@
 # Changelog
 
-## Unreleased — BREAKING: codex profiles now default to closed network egress
+This project uses npm dist-tags as documented in `PUBLISHING.md`: prereleases publish to `next`, and stable releases publish to `latest`.
 
-> Issue #31. Decisions OD1 = B and OD2 = B locked on 2026-05-05.
+## Unreleased
 
-### BREAKING (codex)
+### Repository Setup
 
-The codex backend's network egress posture is now controlled by an explicit
-`codex_network` profile field (`isolated`, `workspace`, `user-config`) rather
-than as a side effect of `service_tier`. **Every codex profile that does not
-set `codex_network` resolves to `'isolated'` on upgrade**, regardless of
-`service_tier`. Profiles that previously honored `~/.codex/config.toml` for
-network access via `service_tier ∈ {'fast','flex',unset}` will lose that
-access until they migrate.
+- Added public contributor, security, support, code-of-conduct, issue-template, PR-template, roadmap, and repository-map files.
+- Reworked the README into a newcomer-focused landing page and moved reference material into `docs/`.
+- Added cross-platform CI coverage: full verification on Linux/macOS and focused Windows build/smoke coverage.
 
-#### Behavior change summary
+### Fixed
 
-| Existing codex profile shape                        | Today's argv                      | Argv after upgrade with no manifest change       | Required action                                                                        |
-|-----------------------------------------------------|-----------------------------------|--------------------------------------------------|----------------------------------------------------------------------------------------|
-| `service_tier: 'normal'`                            | includes `--ignore-user-config`   | includes `--ignore-user-config`                  | None — same posture.                                                                   |
-| `service_tier: 'fast'`                              | no `--ignore-user-config`         | **includes `--ignore-user-config`**              | Set `codex_network` explicitly (see migration options).                                |
-| `service_tier: 'flex'`                              | no `--ignore-user-config`         | **includes `--ignore-user-config`**              | Same as above.                                                                         |
-| `service_tier` unset                                | no `--ignore-user-config`         | **includes `--ignore-user-config`**              | Same as above.                                                                         |
-| `codex_network` set explicitly                      | per docs/development/codex-backend.md | per docs/development/codex-backend.md         | None — explicit value wins.                                                            |
+- Fixed Claude config-dir rotation session-copy lookup on macOS paths where worker processes observe `/private/var/...` while callers pass `/var/...`.
+- Normalized macOS temporary-path expectations in git snapshot and OpenCode harness tests.
+- Updated the lockfile to patched transitive `fast-uri` and `hono` versions so `pnpm audit --prod` remains green.
 
-#### Three migration options
+## 0.2.2 - 2026-05-07
 
-In increasing security cost:
+### BREAKING: Codex Network Posture Defaults To Isolated
 
-1. **Restore today's behavior verbatim** (closest to a no-op):
+Codex backend network egress is now controlled by the explicit `codex_network` field:
 
-   ```jsonc
-   {
-     "version": 1,
-     "profiles": {
-       "<your-profile>": {
-         "backend": "codex",
-         "model": "gpt-5.5",
-         "codex_network": "user-config"
-       }
-     }
-   }
-   ```
+- `isolated`
+- `workspace`
+- `user-config`
 
-2. **Use codex's own network override** (network on, deterministic across
-   machines):
+Every Codex profile that omits `codex_network` resolves to `isolated`, regardless of `service_tier`. Profiles that previously relied on `~/.codex/config.toml` for network access via `service_tier: "fast"`, `service_tier: "flex"`, or an unset `service_tier` must set `codex_network` explicitly.
 
-   ```jsonc
-   {
-     "version": 1,
-     "profiles": {
-       "<your-profile>": {
-         "backend": "codex",
-         "model": "gpt-5.5",
-         "codex_network": "workspace"
-       }
-     }
-   }
-   ```
+Migration options:
 
-3. **Adopt the new closed-by-default posture** (recommended for
-   review-only and implementation profiles that do not need outbound HTTP):
+| Desired behavior | Set |
+|---|---|
+| Restore prior user-config behavior | `codex_network: "user-config"` |
+| Enable Codex workspace network explicitly | `codex_network: "workspace"` |
+| Keep the new closed-by-default posture | `codex_network: "isolated"` |
 
-   ```jsonc
-   {
-     "version": 1,
-     "profiles": {
-       "<your-profile>": {
-         "backend": "codex",
-         "model": "gpt-5.5",
-         "codex_network": "isolated"
-       }
-     }
-   }
-   ```
+Read the full migration table in `docs/development/codex-backend.md`.
 
-For workflows that need PR or external data, prefer the supervisor pre-fetch
-pattern documented in `orchestrate-resolve-pr-comments`: the supervisor calls
-`gh api ...` itself and writes the JSON to a temp file the worker reads from
-disk, so the worker never needs outbound HTTP.
+### Added
 
-#### Per-run warning copy
+- `codex_network` on Codex worker profiles and direct-mode Codex `start_run` / `send_followup`.
+- Capability metadata advertising Codex network modes.
+- Per-run lifecycle warning when Codex network posture defaults to `isolated`.
+- Observability aggregation that distinguishes runs by `codex_network`.
 
-When a codex worker run starts and `codex_network` was not set explicitly on
-the profile or on the direct-mode `start_run` argument, the daemon emits a
-single non-blocking lifecycle event into the run's event log:
+### Changed
 
-```text
-agent-orchestrator codex_network not set on <profile or direct-mode run>; defaulting to 'isolated' (no network access). Set codex_network explicitly to silence this warning. See docs/development/codex-backend.md for migration.
-```
+- `service_tier` no longer implicitly controls whether Codex reads user config.
+- Profile-mode follow-ups reject direct `codex_network` overrides; edit the profile or start a direct-mode run instead.
 
-The warning is a `lifecycle` event with payload
-`state: 'codex_network_defaulted'`. Use `get_run_events` to read the full
-warning text on the event payload (`get_run_progress` only surfaces the
-compact lifecycle marker, not the full message).
+## 0.2.1 - 2026-05-06
 
-#### Where to read more
+### Changed
 
-- `docs/development/codex-backend.md` — full migration table, argv mapping,
-  per-run warning, recommended patterns, and the manual smoke procedure
-  (T6).
-- README MCP tool tables — `start_run`, `send_followup`, and
-  `upsert_worker_profile` advertise the new optional `codex_network`
-  argument.
+- Stable release following the `0.2.1-beta.0` prerelease.
+- Continued hardening of worker orchestration, package metadata, and release checks.
 
-#### Manual smoke evidence
+## 0.2.1-beta.0 - 2026-05-06
 
-Manual smoke procedure for `codex_network: 'workspace'` is documented in
-`docs/development/codex-backend.md` ("Manual Smoke Procedure (T6)"). The
-smoke runs a real `codex exec` against `gh api /zen` and confirms the
-returned zen sentence and the literal
-`-c sandbox_workspace_write.network_access=true` argv. It is intentionally
-**not** part of `pnpm verify` or CI: codex CLI is not available in CI and
-the `gh api /zen` smoke needs the human's `gh auth` state.
+### Added
 
-### Internal changes
+- Prerelease validation of the `0.2.1` release line on the npm `next` dist-tag.
 
-- `RunModelSettings` gains an optional `codex_network` field. Legacy run
-  records load with `codex_network: null` (schema default).
-- `WorkerProfileSchema` accepts `codex_network` only on codex profiles;
-  claude / cursor profiles that set it are rejected with a clear validation
-  error.
-- The codex `WorkerBackendCapability` advertises
-  `network_modes: ['isolated','workspace','user-config']` so MCP clients can
-  render selectors. Other backends advertise an empty `network_modes` list
-  (no schema break for clients that already iterate `settings`).
-- Supervisor system-prompt formatters in both the OpenCode and Claude
-  harnesses now render `codex_network=<value>` for codex profiles (and
-  `codex_network=isolated (default)` for codex profiles that do not set it),
-  plus `network_modes=...` in the catalog for the codex backend.
-- Observability: `uniqueSettings` aggregation key includes `codex_network`,
-  so two runs differing only by `codex_network` no longer collide into a
-  single dedup row.
-- `start_run` / `send_followup`: `codex_network` is direct-mode-only
-  (OD2 = B). The schema-side `superRefine` rejects `profile + codex_network`
-  with `INVALID_INPUT`, mirroring the existing carve-out for `model` /
-  `reasoning_effort` / `service_tier`.
+## 0.2.0 - 2026-05-04
+
+### Added
+
+- Minor release line for expanded local worker orchestration capabilities and daemon hardening.
+
+## 0.1.5 - 2026-05-04
+
+### Changed
+
+- Patch release in the initial public package series.
+
+## 0.1.4 - 2026-05-04
+
+### Changed
+
+- Patch release in the initial public package series.
+
+## 0.1.3 - 2026-05-03
+
+### Changed
+
+- Patch release in the initial public package series.
+
+## 0.1.2 - 2026-05-02
+
+### Changed
+
+- Patch release in the initial public package series.
+
+## 0.1.1 - 2026-05-02
+
+### Added
+
+- Initial public npm release of `@ralphkrauss/agent-orchestrator`.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,17 @@
+# Code Of Conduct
+
+This project expects respectful, technical collaboration.
+
+## Expected Behavior
+
+- Keep discussion focused on the work and its impact.
+- Assume good intent while being precise about risks and tradeoffs.
+- Be patient with first-time contributors.
+- Avoid harassment, personal attacks, threats, and discriminatory language.
+- Do not pressure contributors to reveal private credentials, repositories, employer details, or personal information.
+
+## Reporting
+
+For ordinary conduct concerns, open a GitHub issue with minimal public detail and ask for maintainer follow-up. For security-sensitive or privacy-sensitive concerns, use the private vulnerability reporting path in `SECURITY.md` and state that the report is conduct-related.
+
+Maintainers may edit or remove comments, close issues, block users, or restrict participation when behavior makes the project unsafe or unproductive.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,93 @@
+# Contributing
+
+Thanks for helping improve Agent Orchestrator. This project is a local MCP server and daemon, so small changes can affect process supervision, credentials, and persisted run state. Keep changes focused and verify them with repository scripts.
+
+## Requirements
+
+- Node.js 22 or newer.
+- pnpm 10.30.3.
+- Git.
+- Optional local CLIs for backend smoke testing: Codex, Claude Code, OpenCode.
+
+## Setup
+
+```bash
+pnpm install --frozen-lockfile
+pnpm build
+pnpm test
+```
+
+Use a local isolated daemon store while dogfooding a checkout:
+
+```bash
+just local doctor
+just local status
+just local stop --force
+just local-clean
+```
+
+## Verification
+
+Release-quality verification:
+
+```bash
+pnpm verify
+```
+
+`pnpm verify` builds, runs tests, checks publish readiness, resolves the npm dist-tag, audits production dependencies, and runs `npm pack --dry-run`.
+
+Focused checks:
+
+```bash
+pnpm build
+node --test dist/__tests__/contract.test.js
+node --test dist/__tests__/processManager.test.js
+node --test dist/__tests__/integration/orchestrator.test.js
+```
+
+Packed-output smoke test:
+
+```bash
+package_file="$(npm pack --silent | tail -n 1)"
+temp_dir="$(mktemp -d)"
+cd "$temp_dir"
+npm init -y >/dev/null
+npm install "/path/to/agent-orchestrator/$package_file" >/dev/null
+./node_modules/.bin/agent-orchestrator doctor --json
+```
+
+## Tests With External CLIs
+
+Most tests use mock CLIs. Do not require a real Codex, Claude, Cursor, or OpenCode account for the default test suite.
+
+Manual backend smokes may use host auth state. Keep them out of `pnpm verify` unless they are hermetic and do not make model calls. Document any manual smoke in the relevant `docs/development/` page.
+
+## Coding Style
+
+- Prefer plain TypeScript and Node built-ins.
+- Keep runtime compatibility with Node.js 22 and newer.
+- Use existing package scripts instead of ad hoc tool invocations.
+- Keep public package behavior stable unless the change is explicitly about a contract.
+- For MCP contract changes, update schemas, docs, and tests together.
+- For CLI behavior changes, verify human-readable and JSON output where applicable.
+
+## Security And Secrets
+
+Never commit real tokens, API keys, `.env` contents, local credential files, or command arguments that contain secrets.
+
+Do not ask users to paste secrets into prompts or MCP tool calls. Provider credentials should come from the backend CLI's normal auth state, environment managed by the daemon owner, or the daemon-managed user secrets file documented in `docs/development/auth-setup.md`.
+
+## Pull Requests
+
+Before opening a PR:
+
+- Run the narrowest useful tests for the touched area.
+- Run `pnpm verify` when the change affects release behavior, daemon lifecycle, run-store persistence, backend invocation, MCP contracts, package metadata, or docs linked from the README.
+- Update docs when behavior or setup changes.
+- Include concrete command evidence in the PR description.
+
+Contributors should not publish packages, push release tags, activate hooks, or change external service configuration from a PR branch.
+
+## Release Behavior
+
+Maintainers publish from matching `v*.*.*` tags through GitHub Actions and npm Trusted Publishing. Prereleases go to the npm `next` dist-tag; stable releases go to `latest`. See `PUBLISHING.md`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,6 +7,7 @@ Thanks for helping improve Agent Orchestrator. This project is a local MCP serve
 - Node.js 22 or newer.
 - pnpm 10.30.3.
 - Git.
+- Just 1.44 or newer for repository-local dogfooding helpers.
 - Optional local CLIs for backend smoke testing: Codex, Claude Code, OpenCode.
 
 ## Setup

--- a/OPEN_SOURCE_READINESS.md
+++ b/OPEN_SOURCE_READINESS.md
@@ -368,19 +368,18 @@ Before broadly sharing the project:
 
 - [x] `pnpm install --frozen-lockfile` succeeds from a clean clone.
 - [x] `pnpm verify` passes locally.
-- [ ] CI is green on the supported platform matrix.
-  - CI matrix is configured for Ubuntu/macOS full verification and Windows
-    smoke coverage, but the current tree must be committed and pushed before
-    GitHub Actions can prove this exact change set.
+- [x] CI is green on the supported platform matrix.
+  - PR #54 passed Ubuntu/macOS full verification and Windows smoke coverage on
+    Node 22 and Node 24.
 - [x] `npm pack --dry-run` contains only intended package files.
 - [x] README gives a clear five-minute path to success.
 - [x] Security model is documented.
 - [x] CONTRIBUTING flow is documented.
 - [x] Issue and PR templates exist.
 - [x] CHANGELOG has versioned released entries.
-- [ ] GitHub repo metadata is filled in.
-  - The exact description, homepage, topics, and authenticated `gh api`
-    commands are documented in `docs/repository-map.md`.
+- [x] GitHub repo metadata is filled in.
+  - The live repository description, homepage, and topics match
+    `docs/repository-map.md`.
 - [x] Public roadmap or project-status statement exists.
 
 ## Current Audit Status
@@ -407,8 +406,14 @@ Evidence from the latest clean-copy run:
 - The temporary clean-copy directory was removed.
 - No `.tgz` artifact remained in the worktree after verification.
 
-Remaining external blockers:
+Additional remote evidence:
 
-- The current tree is not committed or pushed, so GitHub Actions has not run on
-  this exact change set.
-- Live GitHub repository metadata still needs an authenticated maintainer update.
+- PR #54 ran the supported CI matrix successfully:
+  - `Verify on ubuntu-latest / Node 22`
+  - `Verify on ubuntu-latest / Node 24`
+  - `Verify on macos-latest / Node 22`
+  - `Verify on macos-latest / Node 24`
+  - `Windows Smoke on Node 22`
+  - `Windows Smoke on Node 24`
+- Live GitHub repository metadata was verified with the configured description,
+  npm homepage, and topics.

--- a/OPEN_SOURCE_READINESS.md
+++ b/OPEN_SOURCE_READINESS.md
@@ -1,0 +1,414 @@
+# Open Source Readiness Direction
+
+Date: 2026-05-10
+
+This document is a handoff plan for polishing `@ralphkrauss/agent-orchestrator`
+into a project that feels ready to share with outside users and contributors.
+
+The repository is already well beyond a prototype: it has npm metadata, an MIT
+license, TypeScript strictness, CI, release workflows, published npm versions,
+and a large test suite. The remaining work is mostly about trust, first-run
+clarity, public maintenance signals, and cross-platform confidence.
+
+## Current Baseline
+
+- GitHub repo: `https://github.com/ralphkrauss/agent-orchestrator`
+- npm package: `@ralphkrauss/agent-orchestrator`
+- Current local commit inspected: `4d1de7d4526cb1990edbd3604f6c9ca5903ef4fe`
+- Current npm latest inspected: `0.2.2`
+- Node engine: `>=22`
+- Package manager: `pnpm@10.30.3`
+- License: MIT
+
+Important: before any public push, make `pnpm verify` pass on a clean checkout.
+At the time this plan was written, a clean local verification run failed:
+
+```text
+tests 553
+pass 541
+fail 10
+skipped 2
+```
+
+The failures were concentrated in:
+
+- `claudeRotation.test.js`: rotation/session JSONL copy behavior
+- `diagnostics.test.js`: Windows cmd shim version checks
+- `gitSnapshot.test.js`: macOS `/private/var` vs `/var` path normalization
+- `opencodeHarness.test.js`: macOS `/private/var` vs `/var` path normalization
+- `processManager.test.js`: terminal finalization failure settling
+
+Treat those as release blockers unless later CI proves they are local-only and
+the reason is documented.
+
+## Target Outcome
+
+The repo should give a new visitor these signals within the first few minutes:
+
+1. They understand what the project does and whether it is for them.
+2. They can install it and run one safe diagnostic command.
+3. They can configure one MCP client and see one successful flow.
+4. They understand the security model and local-credential boundaries.
+5. They can report issues or contribute without guessing the workflow.
+6. CI and local verification agree across supported platforms.
+
+## Work Plan
+
+### 1. Make The Verification Baseline Green
+
+Goal: `pnpm verify` must pass locally and in CI from a clean clone.
+
+Tasks:
+
+- Reproduce the current failures with `pnpm install --frozen-lockfile` and
+  `pnpm verify`.
+- Fix or explicitly quarantine the failing tests.
+- Normalize temporary paths on macOS where tests compare `/var/...` and
+  `/private/var/...`.
+- Investigate the Claude rotation/session-copy failures as product behavior,
+  not just test failures.
+- Investigate `ProcessManager` completion settling when terminal finalization
+  throws.
+- Add narrower regression tests for any fixed behavior.
+
+Acceptance criteria:
+
+- `pnpm verify` passes locally on macOS.
+- Existing Ubuntu CI remains green.
+- No test is skipped without a short comment explaining why and what issue
+  tracks re-enabling it.
+
+### 2. Add Real Cross-Platform CI
+
+Goal: CI should match the platform support claimed in the README.
+
+Current state:
+
+- `.github/workflows/ci.yml` runs on Ubuntu only.
+- README documents Linux, macOS, and Windows behavior.
+
+Tasks:
+
+- Add a CI matrix for `ubuntu-latest`, `macos-latest`, and `windows-latest`.
+- Keep Node versions `22` and `24` if runtime coverage remains valuable.
+- If Windows cannot run the full suite immediately, split CI into:
+  - Full suite on Ubuntu/macOS.
+  - Build plus Windows-specific smoke tests on Windows.
+- Add a packed-tarball smoke test on each supported OS where practical.
+
+Acceptance criteria:
+
+- Pull requests show platform-specific status checks.
+- The README support claims match the CI matrix.
+- Any platform caveats are documented in the README and `CONTRIBUTING.md`.
+
+### 3. Rewrite The README Around First-Time Success
+
+Goal: the README should be a landing page, not the full reference manual.
+
+Current state:
+
+- `README.md` is about 830 lines.
+- It contains valuable details, but too much operational and reference content
+  appears before a newcomer gets a simple success path.
+
+Suggested README structure:
+
+1. Project name and one-sentence value proposition.
+2. Short "What it does" section.
+3. "Who this is for" and "What this does not do".
+4. Install.
+5. Five-minute quickstart.
+6. Supported backends: Codex, Claude, Cursor.
+7. MCP client configuration examples.
+8. Security model summary.
+9. Development and contribution links.
+10. Links to reference docs.
+
+Tasks:
+
+- Move long reference sections into `docs/`.
+- Keep the top-level README focused on install, quickstart, concepts, and links.
+- Add expected output snippets for `doctor` and one successful run.
+- Make the first backend path explicit. For example, choose Codex or simulated
+  diagnostics as the easiest starting point.
+
+Acceptance criteria:
+
+- A new user can read the first 150 lines and understand how to try the project.
+- Detailed tables and long backend-specific notes live in `docs/`.
+- README links are checked manually after restructuring.
+
+### 4. Add A "First Successful Run" Guide
+
+Goal: remove ambiguity from the first usable experience.
+
+Tasks:
+
+- Add `docs/quickstart.md` or `docs/first-run.md`.
+- Include copy-paste commands for:
+  - install via `npx`
+  - `doctor`
+  - one MCP client config
+  - one worker profile
+  - one `start_run`
+  - inspecting status and result
+  - stopping or restarting the daemon
+- Include expected success output and common failure output.
+- Include a "no model call" diagnostic path for cautious users.
+
+Acceptance criteria:
+
+- A user with Node 22+ can complete the guide without reading implementation
+  docs.
+- The guide clearly states which steps require Codex, Claude, Cursor, or API
+  credentials.
+- The guide avoids asking users to paste secrets into prompts or MCP arguments.
+
+### 5. Add Contributor And Maintainer Files
+
+Goal: make the project feel open to participation and reduce support friction.
+
+Add these files:
+
+- `CONTRIBUTING.md`
+- `SECURITY.md`
+- `SUPPORT.md` or a support section in `CONTRIBUTING.md`
+- `.github/ISSUE_TEMPLATE/bug_report.yml`
+- `.github/ISSUE_TEMPLATE/feature_request.yml`
+- `.github/PULL_REQUEST_TEMPLATE.md`
+- Optional: `CODE_OF_CONDUCT.md`
+
+`CONTRIBUTING.md` should include:
+
+- Supported Node and pnpm versions.
+- Setup commands.
+- Local verification commands.
+- How to run a focused test.
+- How to test packed npm output.
+- How to handle external CLIs in tests.
+- Coding style expectations.
+- Release behavior: contributors should not publish.
+
+`SECURITY.md` should include:
+
+- How to report vulnerabilities.
+- Supported versions.
+- The local trust model.
+- Warnings about prompts, credentials, daemon IPC, run-store files, and worker
+  process privileges.
+
+Acceptance criteria:
+
+- A first-time contributor can open a PR without needing private context.
+- Security-sensitive reports have a clear private reporting path.
+- Issue templates collect OS, Node version, package version, backend, MCP client,
+  command run, and relevant logs.
+
+### 6. Set GitHub Repository Metadata
+
+Goal: the GitHub page should look intentional before users read a file.
+
+Current GitHub metadata inspected:
+
+- Description: empty
+- Homepage: empty
+- Topics: empty
+- Issues: enabled
+- Discussions: disabled
+
+Tasks:
+
+- Add a concise GitHub description, for example:
+
+  ```text
+  Local MCP orchestrator for supervising Codex, Claude, Cursor, and OpenCode worker runs.
+  ```
+
+- Add topics such as:
+
+  ```text
+  mcp, model-context-protocol, agent-orchestration, codex-cli,
+  claude-code, cursor, opencode, typescript, nodejs
+  ```
+
+- Set homepage to the npm page or README.
+- Decide whether to enable GitHub Discussions. If enabled, add categories for
+  questions, ideas, and show-and-tell.
+
+Acceptance criteria:
+
+- GitHub repo header explains the project without opening the README.
+- Topics make the repo discoverable.
+- The chosen support channel is documented.
+
+### 7. Clean Up Release Notes And Public Version History
+
+Goal: release notes should tell users what changed in published versions.
+
+Current state:
+
+- `CHANGELOG.md` begins with an `Unreleased` breaking-change section, while
+  npm `latest` is already `0.2.2`.
+
+Tasks:
+
+- Convert shipped changes into versioned sections such as `0.2.2 - YYYY-MM-DD`.
+- Keep `Unreleased` only for work not yet published.
+- Make breaking changes easy to scan.
+- Link migration docs from the relevant version entry.
+- Keep implementation details out of top-level changelog unless they affect
+  users, contributors, or operators.
+
+Acceptance criteria:
+
+- A user upgrading from npm can map their installed version to release notes.
+- Breaking changes are clearly marked under the version that introduced them.
+- `PUBLISHING.md` and `CHANGELOG.md` agree on release process and dist-tags.
+
+### 8. Decide What To Do With Internal Planning Artifacts
+
+Goal: keep valuable dogfooding material without overwhelming outside visitors.
+
+Current state:
+
+- The repo includes many `plans/` records, review artifacts, `.agents`,
+  `.claude`, `.cursor`, and MCP config files.
+- This may be intentional, but it makes the public tree look more like an
+  internal workspace than a focused open-source package.
+
+Options:
+
+- Keep them, but add a short "Repository map" section explaining why they exist.
+- Move old plans to `docs/internal-plans/` or `archive/plans/`.
+- Keep only active public-facing plans in the repo.
+- Exclude generated tool projections if they are not required for users.
+
+Tasks:
+
+- Decide which files are product docs, contributor docs, dogfood config, or
+  historical artifacts.
+- Add `docs/repository-map.md`.
+- Link that map from README or CONTRIBUTING.
+- Ensure no private data, tokens, local paths, or stale PR snapshots are present.
+
+Acceptance criteria:
+
+- A visitor can tell which files matter for normal use.
+- Internal AI workflow files do not distract from package usage.
+- No sensitive or confusing historical artifacts remain unexplained.
+
+### 9. Add Badges And Public Health Signals
+
+Goal: give visitors quick confidence signals.
+
+Tasks:
+
+- Add README badges for:
+  - CI status
+  - npm version
+  - license
+  - Node version
+  - package provenance if desired
+- Add a short "Project status" section:
+  - current maturity
+  - supported platforms
+  - supported backends
+  - known limitations
+
+Acceptance criteria:
+
+- The README header quickly shows build and package status.
+- The project status is honest and specific.
+- Badges point to real workflows and package pages.
+
+### 10. Create A Public Roadmap And Support Boundary
+
+Goal: help users know what is stable, what is experimental, and where the
+project is going.
+
+Tasks:
+
+- Add `ROADMAP.md` or use GitHub milestones.
+- Include:
+  - stable features
+  - experimental features
+  - known limitations
+  - platform support goals
+  - backend support goals
+  - non-goals
+- Add "Support policy" wording:
+  - best-effort personal project vs maintained package
+  - supported Node versions
+  - supported package versions
+  - expected response times if any
+
+Acceptance criteria:
+
+- Users can decide whether the package is appropriate for serious use.
+- Contributors can pick useful issues without guessing priorities.
+- Security and support expectations are not implied silently.
+
+## Suggested Implementation Order
+
+1. Fix `pnpm verify`.
+2. Add macOS and Windows CI coverage.
+3. Add `CONTRIBUTING.md`, `SECURITY.md`, issue templates, and PR template.
+4. Rewrite README into a newcomer-focused landing page.
+5. Add `docs/first-run.md`.
+6. Clean up `CHANGELOG.md`.
+7. Set GitHub repo description, topics, and homepage.
+8. Add badges.
+9. Add repository map / archive policy for planning artifacts.
+10. Add roadmap and support policy.
+
+## Final Readiness Checklist
+
+Before broadly sharing the project:
+
+- [x] `pnpm install --frozen-lockfile` succeeds from a clean clone.
+- [x] `pnpm verify` passes locally.
+- [ ] CI is green on the supported platform matrix.
+  - CI matrix is configured for Ubuntu/macOS full verification and Windows
+    smoke coverage, but the current tree must be committed and pushed before
+    GitHub Actions can prove this exact change set.
+- [x] `npm pack --dry-run` contains only intended package files.
+- [x] README gives a clear five-minute path to success.
+- [x] Security model is documented.
+- [x] CONTRIBUTING flow is documented.
+- [x] Issue and PR templates exist.
+- [x] CHANGELOG has versioned released entries.
+- [ ] GitHub repo metadata is filled in.
+  - The exact description, homepage, topics, and authenticated `gh api`
+    commands are documented in `docs/repository-map.md`.
+- [x] Public roadmap or project-status statement exists.
+
+## Current Audit Status
+
+Last local readiness audit: 2026-05-10.
+
+Verified from a temporary clean copy of the current working tree:
+
+```text
+pnpm install --frozen-lockfile
+pnpm verify
+```
+
+Evidence from the latest clean-copy run:
+
+- `pnpm install --frozen-lockfile` passed.
+- `pnpm verify` passed.
+- Test summary: 554 tests, 552 passed, 0 failed, 2 skipped.
+- Publish readiness check passed.
+- npm dist-tag resolution selected `latest`.
+- `pnpm audit --prod` reported no known vulnerabilities.
+- `npm pack --dry-run` reported 296 files, about 479.4 kB package size, and
+  about 2.4 MB unpacked size.
+- The temporary clean-copy directory was removed.
+- No `.tgz` artifact remained in the worktree after verification.
+
+Remaining external blockers:
+
+- The current tree is not committed or pushed, so GitHub Actions has not run on
+  this exact change set.
+- Live GitHub repository metadata still needs an authenticated maintainer update.

--- a/OPEN_SOURCE_READINESS.md
+++ b/OPEN_SOURCE_READINESS.md
@@ -401,7 +401,7 @@ Evidence from the latest clean-copy run:
 - Publish readiness check passed.
 - npm dist-tag resolution selected `latest`.
 - `pnpm audit --prod` reported no known vulnerabilities.
-- `npm pack --dry-run` reported 296 files, about 479.4 kB package size, and
+- `npm pack --dry-run` reported 296 files, about 479.8 kB package size, and
   about 2.4 MB unpacked size.
 - The temporary clean-copy directory was removed.
 - No `.tgz` artifact remained in the worktree after verification.

--- a/README.md
+++ b/README.md
@@ -1,121 +1,74 @@
 # Agent Orchestrator
 
-An MCP server that lets a supervising agent coordinate Codex and Claude worker CLI runs through a persistent local daemon.
+[![CI](https://github.com/ralphkrauss/agent-orchestrator/actions/workflows/ci.yml/badge.svg)](https://github.com/ralphkrauss/agent-orchestrator/actions/workflows/ci.yml)
+[![npm](https://img.shields.io/npm/v/@ralphkrauss/agent-orchestrator)](https://www.npmjs.com/package/@ralphkrauss/agent-orchestrator)
+[![license](https://img.shields.io/npm/l/@ralphkrauss/agent-orchestrator)](LICENSE.md)
+[![node](https://img.shields.io/node/v/@ralphkrauss/agent-orchestrator)](package.json)
 
-The package is intentionally host-native. It does not install Codex or Claude. Those CLIs stay external because they have their own installation, authentication, and local session state. The orchestrator detects them at runtime and reports what is available.
+Local MCP orchestrator for supervising Codex, Claude, Cursor, and OpenCode worker runs through a persistent daemon.
+
+## What It Does
+
+Agent Orchestrator lets a supervising MCP client start local worker runs, watch progress, send follow-ups, cancel work, and inspect durable run results. The stdio MCP server stays small; a local daemon owns worker subprocesses, timeouts, notifications, run metadata, logs, and session reuse.
+
+It is meant for developers who already use local agent CLIs and want a safer control plane for delegating work from a supervisor.
+
+## What It Does Not Do
+
+- It does not install Codex, Claude Code, OpenCode, or Cursor credentials.
+- It does not host a remote service or send prompts to an orchestrator-owned cloud.
+- It does not isolate filesystems, create worktrees, or prevent two workers from editing the same file.
+- It does not make missing CLI auth disappear; diagnostics report what the host can actually run.
+
+## Project Status
+
+- Maturity: usable, published, and still evolving before a broad public launch.
+- Runtime: Node.js 22 or newer.
+- Platforms: Linux and macOS run the full CI verification matrix on Node 22 and 24. Windows runs build, focused Windows tests, and packed CLI smoke tests on Node 22 and 24.
+- Backends: Codex, Claude, Cursor, and OpenCode supervision surfaces.
+- Known limitation: Windows Claude orchestration requires Git Bash because Claude Code uses Bash for its `Bash` tool.
 
 ## Install
 
-Use the package directly from npm in any MCP client config:
+Use the published package directly from any MCP client:
 
 ```bash
 npx -y @ralphkrauss/agent-orchestrator@latest
 ```
 
-For local development from a checkout:
+For a local checkout:
 
 ```bash
 pnpm install --frozen-lockfile
 pnpm build
 node dist/cli.js doctor
-node dist/cli.js server
 ```
 
-Bare `agent-orchestrator` (no subcommand) prints this help when run from a
-terminal and starts the stdio MCP server when stdin is piped (the way every MCP
-client launches it). Use `agent-orchestrator server` to start the MCP server
-explicitly from a terminal.
+## Five-Minute Quickstart
 
-To test a checkout without colliding with an npm-installed stable daemon, use
-the short local `just` passthrough:
-
-```bash
-just local status
-just local claude --cwd /path/to/workspace
-just local opencode --cwd /path/to/workspace
-just local stop --force
-just local-clean
-```
-
-`just local ...` builds the branch and runs `dist/cli.js` with an isolated
-`AGENT_ORCHESTRATOR_HOME`. For an npm-style shell session instead, run
-`eval "$(just local-env)"` and then use `agent-orchestrator ...` normally. The
-generated shims are named like the npm package bins (`agent-orchestrator`,
-`agent-orchestrator-claude`, `agent-orchestrator-opencode`, and
-`agent-orchestrator-daemon`) but point at this checkout.
-
-The branch gets its own daemon socket/pipe, PID file, logs, run store, and
-Claude supervisor state. The default store is a deterministic short path under
-`${TMPDIR:-/tmp}/agent-orchestrator-local/<checkout>-<hash>` so POSIX socket
-paths stay below OS limits. `local-clean` force-stops the local branch daemon if
-the build is present and removes both that isolated store and the generated
-command shims. Set
-`AGENT_ORCHESTRATOR_LOCAL_BASE=/short/path` to choose a different base
-directory. The normal global npm installation continues to use
-`${AGENT_ORCHESTRATOR_HOME:-$HOME/.agent-orchestrator}`.
-
-## Prerequisites
-
-- Node.js 22 or newer.
-- Codex CLI installed and authenticated if you want Codex workers.
-- Claude CLI installed and authenticated if you want Claude workers.
-- `@cursor/sdk` installed (ships as an optional dependency) and `CURSOR_API_KEY`
-  available to the daemon (set via `agent-orchestrator auth cursor` or exported
-  in the daemon environment) if you want Cursor workers. Cursor runs use the
-  SDK in-process, local runtime only; tokens are billed to your Cursor account.
-  See `docs/development/cursor-backend.md` and
-  [`docs/development/auth-setup.md`](docs/development/auth-setup.md) for the
-  daemon-managed credential file.
-
-Linux and macOS use Unix sockets and POSIX process groups. Windows uses a
-per-store named pipe for daemon IPC and `taskkill` for worker process-tree
-cancellation.
-
-On Windows, `agent-orchestrator claude` requires Git Bash (the MSYS-flavored
-`bash` that Claude Code uses for its `Bash` tool); PowerShell-only Claude Code
-installs are not supported. The Claude supervisor's pinned monitor command and
-`Bash(...)` permission entries are emitted with forward-slash paths on Windows
-(for example `C:/Users/<name>/AppData/Roaming/npm/...`) so they do not collide
-with the supervisor's Bash deny list.
-
-On Windows, `just` recipes run under PowerShell Desktop and through `node`
-directly for parameter-taking recipes (via `just`'s `[script]` attribute, which
-requires `just >= 1.44`); no Git Bash or `sh.exe` is required for the dev
-workflow. The Git Bash requirement for `agent-orchestrator claude` itself
-(described above) is unchanged because Claude Code uses Bash for its `Bash`
-tool.
-
-The MCP package never installs or bundles worker CLIs. Missing workers are reported by diagnostics and by failed run results, but one missing backend does not prevent the MCP server from starting.
-
-## Diagnostics
-
-Run:
+Run diagnostics first. This makes no model calls.
 
 ```bash
 npx -y @ralphkrauss/agent-orchestrator@latest doctor
 npx -y @ralphkrauss/agent-orchestrator@latest doctor --json
 ```
 
-Diagnostics check:
+Expected shape:
 
-- platform and POSIX process-group availability
-- Node version
-- run-store accessibility
-- `codex` and `claude` binary presence
-- `@cursor/sdk` module resolvability and `CURSOR_API_KEY` presence
-- resolved binary path
-- version when available
-- required help/subcommand flag support
-- best-effort auth readiness from environment variables
+```text
+Agent Orchestrator diagnostics
+Frontend version: 0.2.2
+Platform: darwin
+Node: v24.15.0
+Backends:
+- codex: auth_unknown
+- claude: auth_unknown
+- cursor: auth_unknown
+```
 
-Diagnostics do not make model calls. If auth cannot be proven locally without a model call, the backend reports `auth_unknown` with a next-step hint.
+`missing` means the worker binary or SDK is not available. `auth_unknown` means the backend looks runnable, but the package cannot prove auth without asking that backend to make a model call.
 
-Supervisor agents can use the MCP tool `get_backend_status` to retrieve the same diagnostics.
-When called through the daemon, that report also includes the frontend package version, daemon package version, daemon PID, and whether the two package versions match.
-
-## MCP Client Config
-
-### Claude Code `.mcp.json`
+Add the MCP server to one client:
 
 ```json
 {
@@ -129,7 +82,66 @@ When called through the daemon, that report also includes the frontend package v
 }
 ```
 
-### Codex `.codex/config.toml`
+Then use the MCP tools from that client:
+
+```text
+get_backend_status({})
+```
+
+Create a profile. Choose a model id that your local backend accepts.
+
+```text
+upsert_worker_profile({
+  "profile": "codex-local",
+  "backend": "codex",
+  "model": "<codex-model-id>",
+  "codex_network": "isolated",
+  "description": "Local Codex worker with closed network egress"
+})
+```
+
+Start one run:
+
+```text
+start_run({
+  "profile": "codex-local",
+  "prompt": "Run pwd and summarize the repository in one sentence.",
+  "cwd": "/path/to/workspace"
+})
+```
+
+Expected result:
+
+```json
+{ "ok": true, "run_id": "01..." }
+```
+
+Inspect it:
+
+```text
+get_run_progress({ "run_id": "01..." })
+get_run_result({ "run_id": "01..." })
+```
+
+See [docs/first-run.md](docs/first-run.md) for a complete first-run guide, common failures, daemon restart commands, and no-model-call paths.
+
+## MCP Client Config
+
+Claude Code `.mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "agent-orchestrator": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["-y", "@ralphkrauss/agent-orchestrator@latest"]
+    }
+  }
+}
+```
+
+Codex `.codex/config.toml`:
 
 ```toml
 [mcp_servers.agent-orchestrator]
@@ -137,7 +149,7 @@ command = "npx"
 args = ["-y", "@ralphkrauss/agent-orchestrator@latest"]
 ```
 
-### Cursor `.cursor/mcp.json`
+Cursor `.cursor/mcp.json`:
 
 ```json
 {
@@ -150,7 +162,7 @@ args = ["-y", "@ralphkrauss/agent-orchestrator@latest"]
 }
 ```
 
-### OpenCode `opencode.json`
+OpenCode `opencode.json`:
 
 ```json
 {
@@ -163,668 +175,47 @@ args = ["-y", "@ralphkrauss/agent-orchestrator@latest"]
 }
 ```
 
-### Generic MCP stdio client
+## Supported Backends
 
-Use command:
-
-```text
-npx
-```
-
-Use arguments:
-
-```text
--y @ralphkrauss/agent-orchestrator@latest
-```
-
-If your repository already has a cross-platform `npx` wrapper, use it the same way you would use it for Playwright MCP:
-
-```json
-{
-  "command": "node",
-  "args": ["scripts/run-npx-mcp.mjs", "@ralphkrauss/agent-orchestrator@latest"]
-}
-```
-
-## OpenCode Orchestration Mode
-
-OpenCode orchestration mode starts OpenCode as a constrained supervisor for a
-target workspace. The supervisor can inspect the repository and use
-`agent-orchestrator` MCP tools to start, wait for, inspect, follow up with, and
-cancel worker runs. It cannot directly edit source files, use todo writes,
-commit, push, create pull requests, publish, or mutate external services.
-
-The same supervisor can also create or update project-owned `orchestrate-*`
-skills and the configured profiles manifest. Those paths are the only direct
-writes allowed in OpenCode orchestration mode.
-
-Launch from the repository where workers should run:
-
-```bash
-agent-orchestrator opencode
-agent-orchestrator opencode --cwd /path/to/workspace
-agent-orchestrator-opencode
-agent-orchestrator-opencode --cwd /path/to/workspace
-```
-
-OpenCode passthrough arguments after `--` are intentionally limited to no
-subcommand or `run` followed by positional prompt tokens. The launcher rejects
-non-supervisor subcommands and any option token after `run`, including
-`--agent`, `--attach`, `--dir`, `--share`, `--session`, `--file`, and
-`--dangerously-skip-permissions`.
-
-The launcher does not modify normal OpenCode config. It generates an
-`OPENCODE_CONFIG_CONTENT` overlay, loads project-owned orchestration skills from
-the shared `.agents/skills/` root, and does not generate default skills. The
-target workspace path is included in the supervisor prompt and should be passed
-as `cwd` to worker runs unless the user explicitly chooses another workspace.
-
-The supervisor reads worker profiles from:
-
-```text
-~/.config/agent-orchestrator/profiles.json
-```
-
-This keeps personal model preferences out of git and reusable across
-repositories. OpenCode can start before that file exists so you can discuss the
-profile aliases you need. The supervisor may write this profiles manifest when you
-ask it to configure profiles, but it cannot write other config, source, docs,
-normal skills, secrets, commits, pull requests, run bash, or mutate external
-services. It must not start worker runs until the profiles manifest validates.
-
-Example:
-
-```json
-{
-  "version": 1,
-  "profiles": {
-    "deep-implementation": {
-      "backend": "codex",
-      "model": "gpt-5.5",
-      "reasoning_effort": "high",
-      "description": "Implementation and hardening"
-    },
-    "strict-review": {
-      "backend": "claude",
-      "model": "claude-opus-4-7",
-      "reasoning_effort": "xhigh",
-      "description": "Review and risk assessment"
-    }
-  }
-}
-```
-
-Ask the supervisor to create or refine its orchestration skills. The launcher
-creates the shared skill root before OpenCode starts, then grants edit
-permission only to the profiles manifest and:
-
-```text
-.agents/skills/orchestrate-*/SKILL.md
-```
-
-Project-owned orchestration skills use the same OpenCode skill layout as normal
-skills, with an `orchestrate-*` folder and skill name:
-
-```text
-.agents/skills/orchestrate-{name}/SKILL.md
-```
-
-Orchestration skills should reference profile aliases from the manifest, not raw
-model names, variants, backend names, or effort levels. Each user chooses
-concrete models in the profiles manifest.
-
-When starting workers, the supervisor should normally call `start_run` with a
-live `profile` alias plus `profiles_file`. The daemon reads and validates the
-current manifest at worker-start time, so profile edits take effect without
-restarting OpenCode. Direct `backend`/`model` starts remain available for
-explicit one-off user overrides or when the profile setup is broken. The
-`list_worker_profiles` MCP tool returns usable live profiles plus
-`invalid_profiles` diagnostics, so one broken profile does not hide the rest.
-
-Useful options:
-
-```bash
-agent-orchestrator opencode --print-config
-agent-orchestrator opencode --profiles-file ~/.config/agent-orchestrator/profiles.json
-agent-orchestrator opencode --profiles-json '{"version":1,"profiles":{}}'
-agent-orchestrator opencode --skills .agents/skills
-agent-orchestrator opencode --orchestrator-model anthropic/claude-sonnet-4-6
-agent-orchestrator opencode --orchestrator-small-model openai/gpt-5.4-mini
-```
-
-Environment fallbacks use the `AGENT_ORCHESTRATOR_OPENCODE_*` prefix, including
-`AGENT_ORCHESTRATOR_OPENCODE_CWD`,
-`AGENT_ORCHESTRATOR_OPENCODE_PROFILES_FILE`,
-`AGENT_ORCHESTRATOR_OPENCODE_PROFILES_JSON`,
-`AGENT_ORCHESTRATOR_OPENCODE_ROUTES_FILE`,
-`AGENT_ORCHESTRATOR_OPENCODE_ROUTES_JSON`,
-`AGENT_ORCHESTRATOR_OPENCODE_MANIFEST`,
-`AGENT_ORCHESTRATOR_OPENCODE_SKILLS_PATH`,
-`AGENT_ORCHESTRATOR_OPENCODE_MODEL`,
-`AGENT_ORCHESTRATOR_OPENCODE_SMALL_MODEL`, and
-`AGENT_ORCHESTRATOR_OPENCODE_BIN`.
-
-The current package supports Codex, Claude, and Cursor worker backends.
-Cursor uses the `@cursor/sdk` module in-process (local runtime only) and
-requires `CURSOR_API_KEY`; cursor profiles must declare `model` and must omit
-`reasoning_effort` and `service_tier` (see
-`docs/development/cursor-backend.md`). **BREAKING (codex):** codex profiles
-gain a new optional `codex_network` field (`isolated` / `workspace` /
-`user-config`) that defaults to `'isolated'` when unset. See
-`docs/development/codex-backend.md` for the migration. Claude profiles can opt
-into native multi-account rotation via `claude_account_priority` and the
-`agent-orchestrator auth login claude --account <name>` /
-`auth set claude --account <name>` commands; details in
-`docs/development/claude-multi-account.md`. The profiles manifest stays
-provider-agnostic so future backends can add capability descriptors without
-changing the supervisor workflow.
-
-OpenCode permissions are application-level guardrails, not an operating-system
-sandbox. For stronger enforcement, run the supervisor in a read-only worktree
-mount, under a separate OS user, or inside a container with only intentional
-writable paths exposed.
-
-OpenCode supervision is MCP-only. The OpenCode supervisor does not use Bash,
-`Bash run_in_background`, or `agent-orchestrator monitor`; it starts runs with
-`start_run`, waits with `wait_for_any_run`, fetches state with
-`get_run_progress`/`get_run_status`/`get_run_events`/`get_run_result`, and
-reconciles later turns with `list_run_notifications`.
-
-## Claude Code Orchestration Mode (recommended rich-feature harness)
-
-Claude Code orchestration mode starts Claude Code as a constrained supervisor
-in the target workspace. Claude is positioned as the **recommended
-rich-feature** orchestration harness when its primitives are needed (strong
-isolation flags such as `--strict-mcp-config`, `--setting-sources user`,
-`--tools`, embedded workflow / settings injection, mirrored workspace skills,
-and daemon-owned durable notification reconciliation).
-The OpenCode harness above remains a fully supported peer.
-
-```bash
-agent-orchestrator claude
-agent-orchestrator claude --cwd /path/to/workspace
-agent-orchestrator-claude
-agent-orchestrator-claude --cwd /path/to/workspace
-```
-
-The launcher builds a stable state envelope under
-`${AGENT_ORCHESTRATOR_HOME:-$HOME/.agent-orchestrator}/claude-supervisor/envelopes/<workspace>-<hash>`.
-The hash is derived from the real target workspace path, so generated MCP,
-settings, prompt, inline profile, and debug files are stable per workspace.
-Claude itself is spawned with `cwd = <target workspace>`, matching a normal
-Claude Code launch for workspace-relative context and slash-command UX. On
-every launch the launcher regenerates the supervisor system prompt,
-deny-by-default `settings.json`, `mcp.json`, a redirected user skill mirror
-populated from the target workspace `.claude/skills`, and a curated snapshot of
-the project's `orchestrate-*` SKILL.md files for print-config/debugging; the
-orchestrate workflow instructions are also embedded in the generated system
-prompt for reliability.
-Claude's own account/auth state is redirected to a durable orchestrator-owned
-state directory, defaulting to
-`${AGENT_ORCHESTRATOR_HOME:-$HOME/.agent-orchestrator}/claude-supervisor`, so
-you can log in once without exposing your normal `~/.claude` or target
-workspace `.claude` files. Inside that state directory, the supervisor uses
-`home/.claude` because Claude Code's account auth and user skill source are
-read from `HOME/.claude`.
-The spawn passes:
-
-- `--strict-mcp-config --mcp-config <generated mcp.json>` so only the
-  `agent-orchestrator` MCP server is reachable.
-- `--settings <generated settings.json>` and `--setting-sources user` so only
-  the redirected orchestrator-owned user settings and skill mirror are loaded;
-  project/local settings and the user's real `~/.claude` settings are not
-  loaded.
-- `--append-system-prompt-file <generated system-prompt.md>` so the supervisor
-  contract is appended to Claude's default scaffolding.
-- `--tools "Read,Glob,Grep,Bash,Skill"` so the only available built-in tools
-  are read-only workspace inspection, the pinned monitor command surface, and
-  Claude's skill loader.
-- `--allowed-tools "Read,Glob,Grep,Bash(<node> <cli> monitor * --json-line),Bash(<node> <cli> monitor * --json-line --since *),Bash(pwd),Bash(git status),Bash(git status *),Skill,mcp__agent-orchestrator__..."`
-  (comma-joined) and `--permission-mode dontAsk` pre-approve only read-only
-  inspection, the explicit Bash allowlist (two pinned monitor argv shapes:
-  `agent-orchestrator monitor <run_id> --json-line` and the cursored variant
-  `... --json-line --since <notification_id>`, plus `pwd`, `git status`, and
-  `git status *`), the skill surface, and the Claude-specific safe subset of
-  agent-orchestrator MCP tools. Anything else (including `git log`, `cat`,
-  `ls`, `head`, `tail`, `grep`, `find`, `jq`, `git diff`, `git show`,
-  bypass shapes such as `git -C . add` or `command touch /tmp/x`, etc.) is
-  not in the allow list and is denied. `wait_for_run` and `wait_for_any_run`
-  are denied for the Claude supervisor; the pinned Bash monitor is the
-  current-turn wake path and `list_run_notifications` / `ack_run_notification`
-  handle cross-turn reconciliation. Shell metacharacters such as `;`, `&`
-  (including `&&`), `|`, redirection, command substitution, backslash escapes,
-  and newline are explicitly denied so a shell command cannot chain another
-  command or redirect output into a write.
-- Redirected `HOME`, `XDG_CONFIG_HOME`, and `CLAUDE_CONFIG_DIR` to the durable
-  orchestrator-owned state directory so Claude login survives across launches
-  while the supervisor still cannot read the user's normal `~/.claude/`.
-  `AGENT_ORCHESTRATOR_HOME` is kept explicit so the MCP server still talks to
-  the normal orchestrator daemon store rather than creating one under the
-  supervisor's redirected `HOME`.
-- A regenerated `HOME/.claude/skills` mirror copied from the target workspace
-  `.claude/skills`, so `/skills` can find the same project skills without
-  enabling project `settings.json`, hooks, or project MCP configuration.
-
-### Status hooks (issue #40)
-
-The launcher accepts two opt-in flags that drive the daemon-owned orchestrator
-status surface:
-
-- `--remote-control` embeds the documented `remoteControlAtStartup` and
-  `agentPushNotifEnabled` keys in the generated supervisor `settings.json`
-  (off by default). `--remote-control-session-name-prefix <prefix>` is forwarded
-  to Claude as a CLI flag.
-- `--orchestrator-label <name>` sets the orchestrator's display label
-  surfaced to user-level status hooks. Defaults to `basename(cwd)`.
-
-User-level hooks live in `~/.config/agent-orchestrator/hooks.json` and follow
-the Claude-parity shell-string shape used by `~/.claude/settings.json` hooks.
-The daemon emits a v1 `orchestrator_status_changed` payload to each entry
-and never blocks orchestration on hook execution. See
-[`docs/development/orchestrator-status-hooks.md`](docs/development/orchestrator-status-hooks.md)
-and the example tmux hook at [`examples/hooks/tmux-status.sh`](examples/hooks/tmux-status.sh).
-
-Read the current orchestrator status from a shell with
-`agent-orchestrator supervisor status`. The top-level
-`agent-orchestrator status` subcommand stays reserved for daemon status.
-
-The harness intentionally does **not** pass:
-
-- `--add-dir <target workspace>` because the target workspace is already the
-  process cwd.
-- `--dangerously-skip-permissions` (never).
-
-The supervisor may inspect the workspace with read-only tools, but cannot edit
-files directly. Worker runs are dispatched with `cwd = <target workspace>` via
-`mcp__agent-orchestrator__start_run`; workers have full access in their own
-session. Worker profile setup is handled through `list_worker_profiles` and
-`upsert_worker_profile`; the supervisor must not dispatch workers just to edit
-the profiles manifest. It must not inspect Claude Code internal
-`.claude/projects` or `tool-results` files.
-
-`--dangerously-skip-permissions` is **never** added to the spawn command line.
-Forbidden Claude flags after `--` (the harness owns these or they would break
-isolation): `--mcp-config`, `--strict-mcp-config`, `--allowed-tools`,
-`--disallowed-tools`, `--add-dir`, `--settings`, `--setting-sources`,
-`--system-prompt(-file)`, `--append-system-prompt(-file)`, `--plugin-dir`,
-`--agents`, `--agent`, `--permission-mode`, `--tools`,
-`--disable-slash-commands`, `--bare`. (`--bare` changes Claude memory, plugin,
-auth/keychain, and discovery behavior that the harness owns through the
-restricted supervisor launch.)
-
-The supervisor's tool surface is `Read`, `Glob`, `Grep`, `Bash`, the `Skill`
-tool, and the Claude-specific agent-orchestrator MCP allowlist. The Bash
-allowlist contains exactly five patterns: two explicit pinned monitor argv
-shapes (`Bash(<command-prefix> monitor * --json-line)` and the cursored
-`Bash(<command-prefix> monitor * --json-line --since *)`),
-`Bash(pwd)`, `Bash(git status)`, and `Bash(git status *)`. Other read-only
-commands such as `cat`, `ls`, `head`, `tail`, `grep`, `find`, `jq`, `git log`,
-`git diff`, `git show`, `git rev-parse`, and `git branch` are not in the
-allowlist; use Read, Glob, Grep, and the agent-orchestrator MCP tools for those
-inspections. `Edit`, `Write`, `WebFetch`, `WebSearch`, `Task`, `NotebookEdit`,
-`TodoWrite`, write-shaped shell commands such as `touch`, `rm`, `mv`, `cp`, and
-mutating git commands such as `git add`, `git commit`, `git push`, `git reset`,
-`git checkout`, `git merge`, and `git rebase` are unavailable, including via
-global-option bypass shapes such as `git -C dir add` or `git --git-dir=...`. The MCP blocking
-wait tools `wait_for_run` / `wait_for_any_run` are unavailable to the Claude
-supervisor.
-
-For long-running run supervision, the supervisor starts worker runs through the
-daemon and immediately launches the pinned `agent-orchestrator monitor
-<run_id> --json-line` command with Claude's `Bash` tool in background mode.
-The monitor prints one JSON line for the first `terminal` or `fatal_error`
-notification and exits with the documented monitor exit code.
-`mcp__agent-orchestrator__list_run_notifications` is the cross-turn
-reconciliation path, and `mcp__agent-orchestrator__ack_run_notification` is
-called once a notification has been handled. `wait_for_run` and
-`wait_for_any_run` are MCP blocking wait tools for non-Claude clients and are
-denied in the Claude supervisor.
-
-Supervisor wait behavior is intentionally different by client:
-
-| Supervisor | Current-turn wake path | Fallback | Cross-turn reconciliation |
-|---|---|---|---|
-| OpenCode | `wait_for_any_run` over MCP | bounded `wait_for_run` for older daemons or single-run compatibility | `list_run_notifications` |
-| Claude Code | pinned `agent-orchestrator monitor <run_id> --json-line` through background Bash | relaunch monitor with `--since <notification_id>` when recovering an inherited active run | `mcp__agent-orchestrator__list_run_notifications` |
-
-Inspect the discovery report and the generated envelope without launching
-Claude:
-
-```bash
-agent-orchestrator claude --print-discovery
-agent-orchestrator claude --print-config --cwd /path/to/workspace
-```
-
-## Architecture
-
-There are two processes:
-
-| Process | Responsibility | Lifetime |
+| Backend | How it authenticates | Notes |
 |---|---|---|
-| `agent-orchestrator` | Stdio MCP server. Translates MCP tool calls into JSON-RPC requests over a local daemon IPC endpoint. Holds no run state. | Same lifetime as the MCP client. Restarts are expected. |
-| `agent-orchestrator-daemon` | Owns worker subprocesses, active run handles, timeouts, cancellation, follow-up session reuse, and the durable run store. | Long-lived. Auto-started by the MCP server or controlled manually. |
+| Codex | Codex CLI auth or `OPENAI_API_KEY` / `CODEX_API_KEY` in the daemon environment | `codex_network` controls whether worker network egress is isolated, workspace-enabled, or inherited from user config. |
+| Claude | Claude CLI auth, `ANTHROPIC_API_KEY`, or registered Claude accounts | Account registry supports `config_dir` and `api_env` modes with rotation on rate-limit. |
+| Cursor | `CURSOR_API_KEY` in the daemon environment or daemon-managed secrets file | Uses `@cursor/sdk` as an optional dependency and runs SDK work in-process. |
+| OpenCode | Host OpenCode binary and project configuration | OpenCode orchestration mode constrains a supervisor around MCP tools and project skills. |
 
-The guarantee is deliberately scoped:
+## Security Model
 
-- MCP-client or supervisor restarts preserve run state and in-flight runs because the daemon keeps running.
-- Daemon restarts do not preserve in-flight worker ownership. On daemon startup, any run still marked `running` becomes terminal `orphaned` with the previous daemon PID and worker PID in the error context.
-- Package upgrades can restart the stdio MCP frontend without restarting the daemon. If their package versions differ, tool calls return `DAEMON_VERSION_MISMATCH` with both versions and a restart hint instead of failing later with stale method or result-shape errors.
+This is a trusted-local tool. Worker processes run as the current OS user, inherit the daemon environment, and can access the credentials that the selected backend CLI can access.
 
-## Daemon Lifecycle
+- Do not expose the daemon IPC endpoint to untrusted users.
+- Do not paste API keys into prompts or MCP tool arguments.
+- Prompts, stdout, stderr, events, and results are written to the local run store.
+- Default run store: `~/.agent-orchestrator`.
+- Secret-bearing development MCP configs use the repo-local secret bridge; real tokens must stay outside repo files.
 
-When installed locally or globally, use:
+Read [SECURITY.md](SECURITY.md) before using this with sensitive repositories.
 
-```bash
-agent-orchestrator status
-agent-orchestrator status --verbose
-agent-orchestrator runs
-agent-orchestrator runs --json --prompts
-agent-orchestrator watch
-agent-orchestrator start
-agent-orchestrator stop
-agent-orchestrator stop --force
-agent-orchestrator restart
-agent-orchestrator restart --force
-agent-orchestrator prune --older-than-days 30 --dry-run
-agent-orchestrator prune --older-than-days 30
-```
+## Reference Docs
 
-`agent-orchestrator-daemon` remains available as a standalone daemon-control
-alias for scripts. With `npx`, run daemon commands through the main bin:
+- [First successful run](docs/first-run.md)
+- [Architecture, daemon lifecycle, run store, and MCP tools](docs/reference.md)
+- [Repository map](docs/repository-map.md)
+- [Daemon auth setup](docs/development/auth-setup.md)
+- [Codex backend and `codex_network`](docs/development/codex-backend.md)
+- [Claude multi-account setup](docs/development/claude-multi-account.md)
+- [Cursor backend](docs/development/cursor-backend.md)
+- [MCP tooling for this repository](docs/development/mcp-tooling.md)
+- [Roadmap](ROADMAP.md)
+- [Publishing](PUBLISHING.md)
 
-```bash
-npx -y @ralphkrauss/agent-orchestrator@latest status
-npx -y @ralphkrauss/agent-orchestrator@latest runs
-npx -y @ralphkrauss/agent-orchestrator@latest watch
-npx -y @ralphkrauss/agent-orchestrator@latest stop --force
-npx -y @ralphkrauss/agent-orchestrator@latest restart
-npx -y @ralphkrauss/agent-orchestrator@latest restart --force
-npx -y @ralphkrauss/agent-orchestrator@latest prune --older-than-days 30 --dry-run
-```
+## Contributing
 
-`stop` refuses while runs are active and prints the active run IDs. `stop --force` cancels active runs through the normal cancellation path, waits for terminal statuses, and exits. `restart` uses the same safe default and refuses active runs; `restart --force` cancels active runs before starting a fresh daemon. Direct `SIGTERM`/`SIGINT` to the daemon behaves like `stop --force`; `SIGKILL` cannot be caught and any in-flight runs become `orphaned` on next daemon startup.
-
-After changing the configured npm version or dist-tag, restart the daemon so it picks up the same package build as the MCP frontend:
-
-```bash
-npx -y @ralphkrauss/agent-orchestrator@latest restart
-```
-
-`prune` deletes only terminal runs with `finished_at` older than the requested age. Use `--dry-run` first to inspect the matching run IDs.
-
-## Observability
-
-Use the main CLI to inspect sessions and runs:
-
-```bash
-agent-orchestrator status --verbose
-agent-orchestrator runs
-agent-orchestrator runs --json
-agent-orchestrator runs --json --prompts
-agent-orchestrator watch
-```
-
-`watch` opens an interactive terminal dashboard. Use arrow keys to move through
-sessions and prompts, Enter to open details, Backspace or Escape to return, and
-`q` to quit. Detail views include the raw prompt, recent activity, model/source,
-session-resume audit state, artifact paths, and size indicators.
-
-The dashboard groups runs by backend session ID when available and falls back to
-the parent/child run chain while a backend session is still pending. Follow-up
-runs record both the requested session ID and the backend-observed session ID so
-the dashboard can warn when a resume appears to start or report a different
-session.
-
-Prompts are stored as `prompt.txt` in each private run directory so operators can
-inspect exactly what was sent to a worker. The run store is local and permission
-restricted, but prompts may contain sensitive instructions or secrets supplied by
-callers. Do not pass API keys or other credentials in prompts unless you are
-comfortable with them being written to the local run store.
-
-For human-readable dashboard labels, pass metadata on `start_run` or
-`send_followup`:
-
-```json
-{
-  "metadata": {
-    "session_title": "Release readiness",
-    "session_summary": "Prepare and verify the npm package",
-    "prompt_title": "Run release checks",
-    "prompt_summary": "Build, test, and inspect publish readiness"
-  }
-}
-```
-
-`title` and `summary` are also accepted as shorthand. Follow-up runs inherit the
-session title and summary from the parent unless overridden. Prompt title and
-summary are per run.
-
-## Run Store
-
-Default location:
-
-```text
-~/.agent-orchestrator/
-  daemon.log
-  daemon.pid
-  config.json
-  daemon.sock        (POSIX only)
-  runs/
-    <run-id>/
-      meta.json
-      events.jsonl
-      prompt.txt
-      stdout.log
-      stderr.log
-      result.json
-```
-
-Override it with:
-
-```bash
-AGENT_ORCHESTRATOR_HOME=/path/to/store
-```
-
-Security behavior:
-
-- The root directory is created with user-only permissions where the platform supports POSIX modes.
-- On POSIX, if the root directory exists and is owned by another UID, startup aborts.
-- On POSIX, if the root directory is owned by the current UID but has broader permissions, startup coerces it to `0700`.
-- On POSIX, `daemon.sock` is bound under a restrictive umask so the socket file is `0600`.
-- On Windows, the daemon listens on a named pipe derived from the run-store path; there is no socket file to remove.
-- `daemon.pid` is written with `0600` mode where supported.
-- A stale POSIX socket is unlinked only when it is owned by the current UID.
-
-Secrets and CLI credentials are not stored in MCP tool arguments. Worker
-authentication comes from the host CLI's normal auth state or from environment
-variables already present when the MCP server/daemon starts. The Claude Code
-supervisor launcher uses a dedicated orchestrator-owned state directory for its
-own Claude login so that account auth can survive across isolated supervisor
-launches. Do not pass API keys as MCP tool arguments; those requests can be
-logged by clients.
-
-Manual cleanup:
-
-```bash
-agent-orchestrator prune --older-than-days 30 --dry-run
-agent-orchestrator prune --older-than-days 30
-agent-orchestrator stop --force
-rm -rf "${AGENT_ORCHESTRATOR_HOME:-$HOME/.agent-orchestrator}"
-```
-
-## Tool Response Envelope
-
-Every MCP tool returns:
-
-```ts
-type ToolResponse<TPayload> =
-  | ({ ok: true } & TPayload)
-  | { ok: false; error: OrchestratorError };
-```
-
-Expected operational failures use `{ ok: false, error }`. MCP `isError: true` is reserved for unexpected internal failures such as uncaught exceptions or IPC framing breaks.
-
-## MCP Tools
-
-| Tool | Input | Success payload |
-|---|---|---|
-| `get_backend_status` | `{}` | `{ status: BackendStatusReport }` |
-| `get_observability_snapshot` | `{ limit?: number, include_prompts?: boolean, recent_event_limit?: number, diagnostics?: boolean }` | `{ snapshot: ObservabilitySnapshot }` |
-| `list_worker_profiles` | `{ profiles_file?: string, cwd?: string }` | `{ profiles_file: string, profiles: WorkerProfile[], invalid_profiles: InvalidWorkerProfile[], diagnostics: string[] }` |
-| `upsert_worker_profile` | `{ profiles_file?: string, cwd?: string, profile: string, backend: "codex" \| "claude" \| "cursor", model?: string, variant?: string, reasoning_effort?: string, service_tier?: string, codex_network?: "isolated" \| "workspace" \| "user-config", description?: string, metadata?: object, create_if_missing?: boolean }` | `{ profiles_file: string, profile: WorkerProfile, previous_profile: object \| null, created: boolean, invalid_profiles: InvalidWorkerProfile[], diagnostics: string[] }` |
-| `start_run` | Profile mode: `{ profile: string, profiles_file?: string, prompt: string, cwd: string, metadata?: object, idle_timeout_seconds?: number, execution_timeout_seconds?: number }`; direct mode: `{ backend: "codex" \| "claude" \| "cursor", prompt: string, cwd: string, model?: string, reasoning_effort?: string, service_tier?: string, codex_network?: "isolated" \| "workspace" \| "user-config", metadata?: object, idle_timeout_seconds?: number, execution_timeout_seconds?: number }` | `{ run_id: string }` |
-| `list_runs` | `{}` | `{ runs: RunSummary[] }` |
-| `get_run_status` | `{ run_id: string }` | `{ run_summary: RunSummary }` |
-| `get_run_events` | `{ run_id: string, after_sequence?: number, limit?: number }` | `{ events: WorkerEvent[], next_sequence: number, has_more: boolean }` |
-| `get_run_progress` | `{ run_id: string, after_sequence?: number, limit?: number, max_text_chars?: number }` | `{ run_summary: RunSummary, progress: { event_count, next_sequence, has_more, latest_event_sequence, latest_event_at, latest_text, recent_events } }` |
-| `wait_for_run` | `{ run_id: string, wait_seconds: number }` | Terminal status or `{ status: "still_running", wait_exceeded: true, run_summary }` |
-| `wait_for_any_run` | `{ run_ids: string[], wait_seconds: number, after_notification_id?: string, kinds?: ("terminal" \| "fatal_error")[] }` | `{ notifications: RunNotification[], wait_exceeded: boolean }` |
-| `list_run_notifications` | `{ run_ids?: string[], since_notification_id?: string, kinds?: ("terminal" \| "fatal_error")[], include_acked?: boolean, limit?: number }` | `{ notifications: RunNotification[] }` |
-| `ack_run_notification` | `{ notification_id: string }` | `{ acked: boolean, notification_id: string }` |
-| `get_run_result` | `{ run_id: string }` | `{ run_summary: RunSummary, result: WorkerResult \| null }` |
-| `send_followup` | `{ run_id: string, prompt: string, model?: string, reasoning_effort?: string, service_tier?: string, codex_network?: "isolated" \| "workspace" \| "user-config", metadata?: object, idle_timeout_seconds?: number, execution_timeout_seconds?: number }` (codex_network is direct-mode-only and rejected when the parent run is profile-mode) | `{ run_id: string }` for a new child run |
-| `cancel_run` | `{ run_id: string }` | `{ accepted: true, status: RunStatus }` |
-
-`wait_for_any_run` blocks against the local daemon until any of the supplied
-run ids has a `terminal` or `fatal_error` notification newer than
-`after_notification_id`, bounded by `wait_seconds` (1-300). Default wake
-semantics are the union of `terminal` and `fatal_error`. The MCP server also
-relays `notifications/run/changed` push hints with the minimal payload
-`{ run_id, notification_id, kind, status }`. Push is advisory; the durable
-notification journal is authoritative.
-
-`get_run_progress` is the preferred user-facing progress/status tool. It
-returns a bounded tail or cursor page of compact event summaries plus extracted
-text snippets, so supervisors do not need to fetch large raw event pages or
-parse client tool-result files. Use `get_run_events` only when raw backend
-events are explicitly needed, with a small `limit` and an `after_sequence`
-cursor.
-
-For backends that emit a terminal result event without a summary, such as some
-Codex JSON streams, `get_run_result` falls back to the latest assistant message
-so terminal results still include the worker's final text.
-
-The `agent-orchestrator monitor <run_id>` CLI is a one-shot notification bridge
-that blocks against the daemon, prints exactly one JSON line when a terminal or
-fatal-error notification arrives, and exits with a documented code: `0`
-completed, `1` failed/orphaned, `2` cancelled, `3` timed_out, `10` fatal_error,
-`4` unknown run, `5` daemon unavailable, `6` argument error. The Claude Code
-supervisor uses this CLI as its current-turn wake path through a pinned
-background Bash invocation and reconciles cross-turn with
-`list_run_notifications`. OpenCode and other notification-aware MCP clients use
-`wait_for_any_run` for the same wake purpose.
-
-Most worker preparation failures are run failures rather than envelope failures. For example, if `codex` is missing, `start_run` creates a durable run and that run lands in `failed` with `WORKER_BINARY_MISSING` details.
-
-`model` is passed through to the selected worker CLI as provided. Codex model
-names change over time, so Codex validates only that the value is a non-empty
-string. Claude aliases such as `opus` and `sonnet` are rejected when supplied
-explicitly; pass a direct model id such as `claude-opus-4-7` or
-`claude-opus-4-7[1m]` so the dashboard and worker invocation are auditable.
-Follow-up runs inherit the parent run model unless a new `model` is supplied.
-
-`reasoning_effort` is mapped to Codex `model_reasoning_effort` or Claude
-`--effort`. Codex accepts `none`, `minimal`, `low`, `medium`, `high`, and
-`xhigh`. Claude accepts `low`, `medium`, `high`, `xhigh`, and `max` on supported
-direct model ids; `xhigh` is accepted only for Opus 4.7 to avoid Claude Code's
-documented fallback to `high` on older models. `service_tier` is Codex-only:
-`fast` and `flex` are passed through; `normal` is suppressed in the codex argv
-because it is the codex CLI default. **BREAKING (codex):** as of this release
-the codex backend's network egress posture is controlled by a separate
-`codex_network` profile field (`isolated`, `workspace`, `user-config`) rather
-than by `service_tier`. Codex profiles that omit `codex_network` default to
-`'isolated'` (closed network egress, `--ignore-user-config` passed to
-`codex exec`). See `docs/development/codex-backend.md` for the migration
-table, the three migration options, and the per-run warning copy emitted in
-the run event log.
-
-The observability snapshot includes additive fields for model source, display
-metadata, raw prompt artifacts, activity summaries, artifact sizes, and
-session-resume audit state. Older runs without these fields load with
-`legacy_unknown` or `null` defaults.
-
-### Long-Running Runs
-
-The daemon supervises long work with an idle-progress timeout rather than a long
-default wall-clock timeout. New generated config uses
-`default_idle_timeout_seconds: 1200`, `max_idle_timeout_seconds: 7200`,
-`default_execution_timeout_seconds: null`, and
-`max_execution_timeout_seconds: 14400`. `idle_timeout_seconds` cancels only after
-the worker has been quiet for that many seconds; stdout, stderr, parsed backend
-events, errors, start, and terminalization all count as activity.
-`execution_timeout_seconds` remains available as an explicit hard elapsed-time
-cap for tasks that truly need one.
-
-Supervisors should use the client-specific wake path documented above. Claude
-Code uses the pinned background Bash monitor and reconciles cross-turn with
-`list_run_notifications`; `wait_for_run` and `wait_for_any_run` are denied for
-the Claude supervisor. OpenCode and generic notification-aware MCP clients use
-`wait_for_any_run` with a bounded wait and notification cursor.
-`wait_for_run` remains a bounded single-run compatibility fallback for clients
-that cannot use `wait_for_any_run`.
-
-For fallback polling, a useful cadence is a first check-in around 30 seconds
-after `start_run`, then roughly 2 minutes, 5 minutes, and a 10-15 minute ceiling
-while `last_activity_at` continues advancing. At each check-in, inspect
-`get_run_status` for `last_activity_at`, `last_activity_source`,
-`idle_timeout_seconds`, `execution_timeout_seconds`, `timeout_reason`,
-`terminal_reason`, and `latest_error`; use `get_run_progress` when the activity
-or error state changed. Reserve `get_run_events` for raw-event debugging.
-
-Known fatal backend errors from structured events or stderr, such as auth,
-quota, rate limit, invalid model, permission, protocol, backend availability,
-or missing worker binaries, are surfaced as `latest_error` and fail the run
-promptly. Do not keep waiting for the idle timeout after `latest_error.fatal` is
-visible. Do not cancel a run only because elapsed time is high when activity is
-still advancing; choose a larger `idle_timeout_seconds` for known quiet work.
-
-## Operational Notes
-
-This package is for trusted local MCP clients. Worker processes run with the current user's OS privileges, inherit the daemon environment, and can use whatever credentials the host Codex or Claude CLI can access. Do not expose the daemon IPC endpoint to untrusted users or pass secrets as MCP tool arguments.
-
-Concurrent runs against the same `cwd` are the supervisor's responsibility. The orchestrator does not create worktrees, isolate file systems, or lock a working directory. If two workers edit the same files, they can conflict.
-
-If a daemon restart marks a run `orphaned`, the previous worker process may still be consuming CPU or API tokens. Inspect `~/.agent-orchestrator/daemon.log` and the run result for the previous daemon PID and worker PID, then clean up manually if needed.
-
-On POSIX, prefer killing the process group when you know the PGID:
-
-```bash
-kill -TERM -<worker-pgid>
-sleep 5
-kill -KILL -<worker-pgid>
-```
-
-On Windows, use the worker PID from the run result:
-
-```powershell
-taskkill /PID <worker-pid> /T
-taskkill /PID <worker-pid> /T /F
-```
-
-## Development
+See [CONTRIBUTING.md](CONTRIBUTING.md). The release-quality local gate is:
 
 ```bash
 pnpm install --frozen-lockfile
 pnpm verify
-npm pack --dry-run
 ```
 
-Installed-package smoke test:
-
-```bash
-package_file="$(npm pack --silent | tail -n 1)"
-temp_dir="$(mktemp -d)"
-cd "$temp_dir"
-npm init -y >/dev/null
-npm install "/path/to/agent-orchestrator/$package_file"
-./node_modules/.bin/agent-orchestrator doctor --json
-```
-
-## Publishing
-
-See [PUBLISHING.md](PUBLISHING.md) for:
-
-- first manual npm publish
-- GitHub Actions Trusted Publishing setup
-- CodeArtifact publish workflow inputs
-- license readiness guard
+`pnpm verify` builds, runs tests, checks publish readiness, audits production dependencies, resolves the npm dist-tag, and runs an npm pack dry run.

--- a/README.md
+++ b/README.md
@@ -68,7 +68,9 @@ Backends:
 
 `missing` means the worker binary or SDK is not available. `auth_unknown` means the backend looks runnable, but the package cannot prove auth without asking that backend to make a model call.
 
-Add the MCP server to one client:
+Add the MCP server to one client. Persistent MCP client entries should pin a
+concrete package version so restarts use the same MCP surface; the examples
+below use `0.2.2`.
 
 ```json
 {
@@ -76,7 +78,7 @@ Add the MCP server to one client:
     "agent-orchestrator": {
       "type": "stdio",
       "command": "npx",
-      "args": ["-y", "@ralphkrauss/agent-orchestrator@latest"]
+      "args": ["-y", "@ralphkrauss/agent-orchestrator@0.2.2"]
     }
   }
 }
@@ -127,6 +129,10 @@ See [docs/first-run.md](docs/first-run.md) for a complete first-run guide, commo
 
 ## MCP Client Config
 
+Persistent MCP client entries should pin a concrete package version. Use
+`@latest` for one-off diagnostics, and update pinned client config versions
+when intentionally upgrading.
+
 Claude Code `.mcp.json`:
 
 ```json
@@ -135,7 +141,7 @@ Claude Code `.mcp.json`:
     "agent-orchestrator": {
       "type": "stdio",
       "command": "npx",
-      "args": ["-y", "@ralphkrauss/agent-orchestrator@latest"]
+      "args": ["-y", "@ralphkrauss/agent-orchestrator@0.2.2"]
     }
   }
 }
@@ -146,7 +152,7 @@ Codex `.codex/config.toml`:
 ```toml
 [mcp_servers.agent-orchestrator]
 command = "npx"
-args = ["-y", "@ralphkrauss/agent-orchestrator@latest"]
+args = ["-y", "@ralphkrauss/agent-orchestrator@0.2.2"]
 ```
 
 Cursor `.cursor/mcp.json`:
@@ -156,7 +162,7 @@ Cursor `.cursor/mcp.json`:
   "mcpServers": {
     "agent-orchestrator": {
       "command": "npx",
-      "args": ["-y", "@ralphkrauss/agent-orchestrator@latest"]
+      "args": ["-y", "@ralphkrauss/agent-orchestrator@0.2.2"]
     }
   }
 }
@@ -169,7 +175,7 @@ OpenCode `opencode.json`:
   "mcp": {
     "agent-orchestrator": {
       "type": "local",
-      "command": ["npx", "-y", "@ralphkrauss/agent-orchestrator@latest"]
+      "command": ["npx", "-y", "@ralphkrauss/agent-orchestrator@0.2.2"]
     }
   }
 }

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,55 @@
+# Roadmap
+
+Agent Orchestrator is published and usable, but it is still a `0.x` package. The near-term roadmap focuses on trust, setup clarity, platform confidence, and stable contracts rather than new features.
+
+## Stable Today
+
+- Local daemon-backed MCP server.
+- Durable run store with status, events, prompts, stdout, stderr, and results.
+- Codex worker runs and follow-ups.
+- Claude worker runs, follow-ups, account registry, and rate-limit rotation.
+- Cursor SDK worker runs.
+- OpenCode and Claude supervision harnesses.
+- Diagnostics through CLI and MCP tools.
+- npm package publication with Trusted Publishing.
+
+## Experimental Or Still Hardening
+
+- Broad Windows coverage beyond focused smoke and platform-specific tests.
+- Claude account rotation edge cases around vendor CLI session files.
+- OpenCode orchestration UX and supervisor permissions.
+- Long-running task ergonomics across different MCP clients.
+- Public support workflow and issue triage cadence.
+
+## Near-Term Priorities
+
+- Keep `pnpm verify` green on local macOS and CI.
+- Expand CI coverage while keeping Windows expectations explicit.
+- Improve first-run docs and failure messages from real user reports.
+- Keep package contents intentional and small enough to inspect.
+- Preserve backward-compatible MCP contracts during `0.x` hardening.
+
+## Platform Goals
+
+- Linux: full build, test, pack, and smoke coverage.
+- macOS: full build, test, pack, and smoke coverage.
+- Windows: build, focused platform tests, packed CLI smoke coverage, and documented caveats.
+
+## Backend Goals
+
+- Codex: deterministic network posture through explicit `codex_network`.
+- Claude: reliable account isolation, session-copy behavior, and rotation auditability.
+- Cursor: clear SDK installation and auth diagnostics.
+- OpenCode: constrained supervisor setup that remains understandable to users.
+
+## Non-Goals
+
+- Hosted orchestration service.
+- Secret broker for third-party providers.
+- Filesystem isolation beyond backend-provided sandboxing.
+- Automatic worktree management.
+- Guaranteed support for every backend vendor beta flag.
+
+## Support Policy
+
+The latest npm version and `main` receive best-effort fixes. No response-time SLA is offered. Security reports should use `SECURITY.md`; normal bugs and features should use GitHub issues.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,54 @@
+# Security Policy
+
+## Reporting A Vulnerability
+
+Please report vulnerabilities privately through GitHub Security Advisories:
+
+```text
+https://github.com/ralphkrauss/agent-orchestrator/security/advisories/new
+```
+
+Do not include exploit details, private repository names, tokens, or sensitive logs in public issues. If private vulnerability reporting is unavailable, open a public issue with only a high-level description and ask for a private contact path.
+
+## Supported Versions
+
+Security fixes target the latest published npm version and the current `main` branch. Older `0.x` versions are best-effort unless a maintainer explicitly marks them supported in a release note.
+
+## Local Trust Model
+
+Agent Orchestrator is a trusted-local MCP server. It does not sandbox worker processes beyond what the selected backend CLI provides.
+
+- Worker processes run with the current user's OS privileges.
+- Worker processes inherit the daemon environment after daemon startup.
+- Codex, Claude, Cursor, and OpenCode credentials remain owned by those tools or by the daemon owner.
+- The daemon IPC endpoint is local and should not be exposed to untrusted users.
+- Prompts, events, stdout, stderr, metadata, and results are written to the local run store.
+- Run-store files can reveal repository paths, prompts, model output, tool events, and failure details.
+
+## Credential Boundaries
+
+Do not pass credentials in prompts, MCP tool arguments, issue templates, docs, examples, or committed config files.
+
+Use one of these paths instead:
+
+- Backend CLI auth state, such as Codex or Claude Code login.
+- Daemon environment variables owned by the local user or service manager.
+- `~/.config/agent-orchestrator/secrets.env` for daemon-managed provider keys.
+- `~/.config/agent-orchestrator/mcp-secrets.env` for this repository's development MCP bridge.
+
+The daemon refuses overly permissive daemon secrets files on POSIX. Restart the daemon after changing credential files or environment variables.
+
+## Prompts And Logs
+
+Prompts are persisted as `prompt.txt` in each run directory. Logs and event JSONL files may contain model output, command output, file paths, and error messages.
+
+Before sharing logs:
+
+- Remove secrets and private tokens.
+- Remove private repository names if needed.
+- Keep excerpts minimal.
+- Prefer `doctor --json` and `get_backend_status` diagnostics when possible; they do not print secret values.
+
+## Platform Notes
+
+On POSIX, the run store and daemon socket are created with user-only permissions where supported. On Windows, the daemon uses a named pipe derived from the run-store path; protect the user profile and run-store directory with normal Windows account isolation.

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,31 @@
+# Support
+
+Agent Orchestrator is maintained as a public package with best-effort support.
+
+## Where To Ask
+
+- Bugs: open a GitHub issue with the bug report template.
+- Feature requests: open a GitHub issue with the feature request template.
+- Security vulnerabilities: use the private reporting path in `SECURITY.md`.
+- Setup questions: start with `README.md`, `docs/first-run.md`, and `docs/development/auth-setup.md`.
+
+## What To Include
+
+For support requests, include:
+
+- OS and version.
+- Node.js version.
+- Package version.
+- Backend: Codex, Claude, Cursor, or OpenCode.
+- MCP client.
+- Exact command or MCP tool call.
+- `doctor --json` output when relevant.
+- Minimal logs with secrets removed.
+
+## Boundaries
+
+The project can help with package behavior, diagnostics, daemon lifecycle, MCP contracts, and documented backend invocation shapes.
+
+The project cannot provide private support for backend vendor accounts, billing, model availability, or credentials that belong to Codex, Claude, Cursor, OpenCode, npm, or GitHub.
+
+No response-time SLA is currently offered.

--- a/docs/first-run.md
+++ b/docs/first-run.md
@@ -1,0 +1,200 @@
+# First Successful Run
+
+This guide gets from a fresh machine to one safe diagnostic check and one worker run. Commands assume Node.js 22 or newer.
+
+## 1. Install-Free Diagnostic
+
+Run diagnostics through `npx`:
+
+```bash
+npx -y @ralphkrauss/agent-orchestrator@latest doctor
+npx -y @ralphkrauss/agent-orchestrator@latest doctor --json
+```
+
+Diagnostics do not make model calls. They check the platform, Node version, run-store access, backend binary or SDK availability, backend version/help support, and auth hints.
+
+Expected human-readable shape:
+
+```text
+Agent Orchestrator diagnostics
+Frontend version: 0.2.2
+Daemon version: not connected
+Platform: darwin
+Node: v24.15.0
+Run store: /Users/example/.agent-orchestrator (accessible)
+
+Backends:
+- codex: auth_unknown
+- claude: missing
+- cursor: missing
+```
+
+Common statuses:
+
+| Status | Meaning |
+|---|---|
+| `available` | The backend is installed and auth can be proven locally without a model call. |
+| `auth_unknown` | The backend looks runnable, but auth cannot be proven without asking it to call a model. |
+| `missing` | The CLI binary or optional SDK is not available to the daemon. |
+| `unsupported` | The installed CLI exists but lacks required flags. |
+
+## 2. Configure One MCP Client
+
+Use the package as an MCP stdio server:
+
+```json
+{
+  "mcpServers": {
+    "agent-orchestrator": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["-y", "@ralphkrauss/agent-orchestrator@latest"]
+    }
+  }
+}
+```
+
+For client-specific examples, see the README.
+
+After restarting the MCP client, run this tool:
+
+```text
+get_backend_status({})
+```
+
+That is the MCP equivalent of `doctor` and still makes no model calls.
+
+## 3. Create One Worker Profile
+
+Pick a backend that diagnostics reports as `available` or `auth_unknown`. The examples below use placeholders for model ids because accepted model names belong to the backend CLI or SDK.
+
+Codex profile with closed worker network egress:
+
+```text
+upsert_worker_profile({
+  "profile": "codex-local",
+  "backend": "codex",
+  "model": "<codex-model-id>",
+  "codex_network": "isolated",
+  "description": "Local Codex worker with closed network egress"
+})
+```
+
+Claude profile using a direct model id:
+
+```text
+upsert_worker_profile({
+  "profile": "claude-local",
+  "backend": "claude",
+  "model": "<claude-model-id>",
+  "description": "Local Claude worker"
+})
+```
+
+Cursor profile:
+
+```text
+upsert_worker_profile({
+  "profile": "cursor-local",
+  "backend": "cursor",
+  "model": "<cursor-model-id>",
+  "description": "Local Cursor SDK worker"
+})
+```
+
+Profiles are stored in `~/.config/agent-orchestrator/profiles.json` unless a client passes `profiles_file`.
+
+## 4. Start One Run
+
+Use a small prompt in a disposable or clean workspace:
+
+```text
+start_run({
+  "profile": "codex-local",
+  "prompt": "Run pwd and summarize the repository in one sentence.",
+  "cwd": "/path/to/workspace",
+  "metadata": {
+    "session_title": "First run",
+    "prompt_title": "Repository summary"
+  }
+})
+```
+
+Expected response:
+
+```json
+{ "ok": true, "run_id": "01..." }
+```
+
+If the backend is missing or unauthenticated, `start_run` may still create a durable failed run. Inspect it with the tools below.
+
+## 5. Inspect Progress And Result
+
+```text
+get_run_progress({ "run_id": "01..." })
+get_run_status({ "run_id": "01..." })
+get_run_result({ "run_id": "01..." })
+```
+
+For long work, prefer `get_run_progress`; it returns a bounded summary instead of the full raw event log.
+
+Common failure shapes:
+
+```json
+{
+  "ok": true,
+  "run_summary": {
+    "status": "failed",
+    "latest_error": {
+      "category": "worker_binary_missing"
+    }
+  }
+}
+```
+
+```json
+{
+  "ok": false,
+  "error": {
+    "code": "INVALID_INPUT",
+    "message": "..."
+  }
+}
+```
+
+`ok: false` means the MCP tool request itself was rejected. `ok: true` with a failed run means the run was created and the worker failure is recorded in the run store.
+
+## 6. Stop Or Restart The Daemon
+
+The MCP server auto-starts the daemon when needed. You can also control it explicitly:
+
+```bash
+npx -y @ralphkrauss/agent-orchestrator@latest status
+npx -y @ralphkrauss/agent-orchestrator@latest runs
+npx -y @ralphkrauss/agent-orchestrator@latest restart
+npx -y @ralphkrauss/agent-orchestrator@latest stop
+```
+
+Safe defaults refuse to stop or restart while runs are active. To cancel active runs first:
+
+```bash
+npx -y @ralphkrauss/agent-orchestrator@latest restart --force
+npx -y @ralphkrauss/agent-orchestrator@latest stop --force
+```
+
+Use `--force` deliberately; it sends cancellation through the normal run lifecycle.
+
+## 7. No-Model-Call Path
+
+For cautious setup, stop after these checks:
+
+```bash
+npx -y @ralphkrauss/agent-orchestrator@latest doctor --json
+```
+
+```text
+get_backend_status({})
+list_worker_profiles({})
+```
+
+These checks do not require Codex, Claude, Cursor, or OpenCode to make model calls. The first model call happens only when you start a worker run on a backend that performs one.

--- a/docs/first-run.md
+++ b/docs/first-run.md
@@ -40,7 +40,9 @@ Common statuses:
 
 ## 2. Configure One MCP Client
 
-Use the package as an MCP stdio server:
+Use the package as an MCP stdio server. Persistent MCP client entries should
+pin a concrete package version so restarts use the same MCP surface; this guide
+uses `0.2.2`.
 
 ```json
 {
@@ -48,7 +50,7 @@ Use the package as an MCP stdio server:
     "agent-orchestrator": {
       "type": "stdio",
       "command": "npx",
-      "args": ["-y", "@ralphkrauss/agent-orchestrator@latest"]
+      "args": ["-y", "@ralphkrauss/agent-orchestrator@0.2.2"]
     }
   }
 }

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -1,0 +1,185 @@
+# Reference
+
+This page holds the operational details that used to make the README long. Start with [first-run.md](first-run.md) if you are trying the package for the first time.
+
+## Architecture
+
+| Process | Responsibility | Lifetime |
+|---|---|---|
+| `agent-orchestrator` | Stdio MCP server. Translates MCP tool calls into JSON-RPC requests over a local daemon IPC endpoint. Holds no run state. | Same lifetime as the MCP client. Restarts are expected. |
+| `agent-orchestrator-daemon` | Owns worker subprocesses, active run handles, timeouts, cancellation, follow-up session reuse, and the durable run store. | Long-lived. Auto-started by the MCP server or controlled manually. |
+
+MCP-client restarts preserve run state because the daemon keeps running. Daemon restarts do not preserve active worker ownership; any run still marked `running` becomes terminal `orphaned` with the previous daemon PID and worker PID in the error context.
+
+Package-version skew between the MCP frontend and daemon returns a version-mismatch error with a restart hint instead of failing later with stale methods or result shapes.
+
+## Daemon Lifecycle
+
+```bash
+agent-orchestrator status
+agent-orchestrator status --verbose
+agent-orchestrator runs
+agent-orchestrator runs --json --prompts
+agent-orchestrator watch
+agent-orchestrator start
+agent-orchestrator stop
+agent-orchestrator stop --force
+agent-orchestrator restart
+agent-orchestrator restart --force
+agent-orchestrator prune --older-than-days 30 --dry-run
+agent-orchestrator prune --older-than-days 30
+```
+
+`agent-orchestrator-daemon` is also available as a standalone daemon-control alias. With `npx`, run daemon commands through the main bin:
+
+```bash
+npx -y @ralphkrauss/agent-orchestrator@latest status
+npx -y @ralphkrauss/agent-orchestrator@latest runs
+npx -y @ralphkrauss/agent-orchestrator@latest watch
+npx -y @ralphkrauss/agent-orchestrator@latest restart
+```
+
+`stop` and `restart` refuse while runs are active. `--force` cancels active runs through the normal cancellation path before stopping or restarting.
+
+## Run Store
+
+Default location:
+
+```text
+~/.agent-orchestrator/
+  daemon.log
+  daemon.pid
+  config.json
+  daemon.sock        (POSIX only)
+  runs/
+    <run-id>/
+      meta.json
+      events.jsonl
+      prompt.txt
+      stdout.log
+      stderr.log
+      result.json
+```
+
+Override it with:
+
+```bash
+AGENT_ORCHESTRATOR_HOME=/path/to/store
+```
+
+Security behavior:
+
+- The root directory is created with user-only permissions where the platform supports POSIX modes.
+- On POSIX, startup aborts if the root directory is owned by another UID.
+- On POSIX, broader permissions on a current-user-owned root are coerced to `0700`.
+- On POSIX, `daemon.sock` is bound under a restrictive umask so the socket file is `0600`.
+- On Windows, the daemon listens on a named pipe derived from the run-store path.
+- `daemon.pid` is written with `0600` mode where supported.
+
+Prompts are stored as `prompt.txt` in each private run directory. Do not pass secrets in prompts unless you are comfortable with them being written to the local run store.
+
+## Observability
+
+Use:
+
+```bash
+agent-orchestrator status --verbose
+agent-orchestrator runs
+agent-orchestrator runs --json
+agent-orchestrator runs --json --prompts
+agent-orchestrator watch
+```
+
+`watch` opens an interactive terminal dashboard. Detail views include raw prompt, recent activity, model/source, session-resume audit state, artifact paths, and size indicators.
+
+For readable dashboard labels, pass metadata on `start_run` or `send_followup`:
+
+```json
+{
+  "metadata": {
+    "session_title": "Release readiness",
+    "session_summary": "Prepare and verify the npm package",
+    "prompt_title": "Run release checks",
+    "prompt_summary": "Build, test, and inspect publish readiness"
+  }
+}
+```
+
+## Tool Response Envelope
+
+Every MCP tool returns:
+
+```ts
+type ToolResponse<TPayload> =
+  | ({ ok: true } & TPayload)
+  | { ok: false; error: OrchestratorError };
+```
+
+Expected operational failures use `{ ok: false, error }`. MCP `isError: true` is reserved for unexpected internal failures such as uncaught exceptions or IPC framing breaks.
+
+## MCP Tools
+
+| Tool | Purpose |
+|---|---|
+| `get_backend_status` | Return the same diagnostics as `doctor`. |
+| `get_observability_snapshot` | Return sessions, prompts, run summaries, diagnostics, and recent activity. |
+| `list_worker_profiles` | Load profile aliases and report invalid profiles without hiding valid ones. |
+| `upsert_worker_profile` | Create or update one profile alias. |
+| `start_run` | Start a profile-mode or direct-mode worker run. |
+| `list_runs` | List known runs. |
+| `get_run_status` | Return one run summary. |
+| `get_run_events` | Return raw event pages with a sequence cursor. |
+| `get_run_progress` | Return a bounded, user-facing progress summary. |
+| `wait_for_run` | Block until one run reaches terminal status, bounded by seconds. |
+| `wait_for_any_run` | Block until any listed run has a terminal or fatal-error notification. |
+| `list_run_notifications` | Read durable run notifications. |
+| `ack_run_notification` | Mark a durable notification acknowledged. |
+| `get_run_result` | Return terminal result details when available. |
+| `send_followup` | Start a child run that follows up on a terminal parent. |
+| `cancel_run` | Request cancellation for a running worker. |
+
+`get_run_progress` is the preferred user-facing progress tool. Use `get_run_events` only when raw backend events are needed.
+
+`wait_for_any_run` is the notification-aware wake path for clients that can block on MCP tools. The Claude Code supervisor instead uses the pinned `agent-orchestrator monitor <run_id>` Bash command and reconciles with `list_run_notifications`.
+
+## Model And Network Settings
+
+`model` is passed through to the selected backend as provided. Codex validates only that it is a non-empty string. Claude aliases such as `opus` and `sonnet` are rejected when supplied explicitly; pass a direct model id accepted by Claude Code.
+
+`reasoning_effort` maps to Codex `model_reasoning_effort` or Claude `--effort`. `service_tier` is Codex-only.
+
+`codex_network` is Codex-only:
+
+| Value | Behavior |
+|---|---|
+| `isolated` | Passes `--ignore-user-config`; network remains closed by Codex defaults. |
+| `workspace` | Passes `--ignore-user-config` and enables workspace-write network access. |
+| `user-config` | Lets Codex read `$CODEX_HOME/config.toml` verbatim. |
+
+Codex profiles that omit `codex_network` default to `isolated`. See [development/codex-backend.md](development/codex-backend.md) for the migration table.
+
+## Long-Running Runs
+
+The daemon supervises long work with an idle-progress timeout. Generated config defaults to:
+
+```text
+default_idle_timeout_seconds: 1200
+max_idle_timeout_seconds: 7200
+default_execution_timeout_seconds: null
+max_execution_timeout_seconds: 14400
+```
+
+`idle_timeout_seconds` cancels only after the worker has been quiet for that many seconds. stdout, stderr, parsed backend events, errors, start, and terminalization all count as activity. `execution_timeout_seconds` remains available as an explicit hard elapsed-time cap.
+
+Known fatal backend errors such as auth, quota, rate limit, invalid model, permission, protocol, backend availability, or missing worker binaries are surfaced as `latest_error` and fail the run promptly.
+
+## Manual Cleanup
+
+```bash
+agent-orchestrator prune --older-than-days 30 --dry-run
+agent-orchestrator prune --older-than-days 30
+agent-orchestrator stop --force
+rm -rf "${AGENT_ORCHESTRATOR_HOME:-$HOME/.agent-orchestrator}"
+```
+
+On Windows, remove the configured run-store directory after stopping the daemon.

--- a/docs/repository-map.md
+++ b/docs/repository-map.md
@@ -1,0 +1,117 @@
+# Repository Map
+
+This repository includes the published package, development docs, and dogfooding material for the agent workspace used to build the package. The non-package files are intentional, but most users only need the README and `docs/`.
+
+## Public Package Surface
+
+| Path | Purpose |
+|---|---|
+| `src/` | TypeScript source for the MCP server, daemon, backends, CLI, contracts, and tests. |
+| `package.json` | npm metadata, scripts, engines, bin entries, dependencies, and package file allowlist. |
+| `README.md` | Newcomer-focused landing page and quickstart. |
+| `docs/` | User, operator, and development reference docs. |
+| `CHANGELOG.md` | Versioned public release notes. |
+| `PUBLISHING.md` | Release process and npm Trusted Publishing notes. |
+| `LICENSE.md` | MIT license. |
+
+## Contributor Surface
+
+| Path | Purpose |
+|---|---|
+| `CONTRIBUTING.md` | Setup, verification, testing, style, and PR expectations. |
+| `SECURITY.md` | Vulnerability reporting and local trust model. |
+| `SUPPORT.md` | Support channels and boundaries. |
+| `ROADMAP.md` | Public stability notes, near-term priorities, and non-goals. |
+| `.github/ISSUE_TEMPLATE/` | Structured bug and feature issue templates. |
+| `.github/PULL_REQUEST_TEMPLATE.md` | PR checklist for contributors. |
+| `.github/workflows/` | CI and publish workflows. |
+
+## GitHub Repository Settings
+
+The live GitHub repository metadata is not managed by package code. Before a
+public launch, a maintainer with repository settings access should set:
+
+| Setting | Value |
+|---|---|
+| Description | `Local MCP orchestrator for supervising Codex, Claude, Cursor, and OpenCode worker runs.` |
+| Homepage | `https://www.npmjs.com/package/@ralphkrauss/agent-orchestrator` |
+| Topics | `mcp`, `model-context-protocol`, `agent-orchestration`, `codex-cli`, `claude-code`, `cursor`, `opencode`, `typescript`, `nodejs` |
+| Issues | Enabled |
+| Discussions | Disabled unless `SUPPORT.md` is updated with a discussions policy. |
+
+An authenticated maintainer can apply the metadata with GitHub CLI:
+
+```bash
+gh api -X PATCH repos/ralphkrauss/agent-orchestrator \
+  -f description='Local MCP orchestrator for supervising Codex, Claude, Cursor, and OpenCode worker runs.' \
+  -f homepage='https://www.npmjs.com/package/@ralphkrauss/agent-orchestrator'
+
+gh api -X PUT repos/ralphkrauss/agent-orchestrator/topics \
+  -H 'Accept: application/vnd.github+json' \
+  -f names[]=mcp \
+  -f names[]=model-context-protocol \
+  -f names[]=agent-orchestration \
+  -f names[]=codex-cli \
+  -f names[]=claude-code \
+  -f names[]=cursor \
+  -f names[]=opencode \
+  -f names[]=typescript \
+  -f names[]=nodejs
+```
+
+Verify the live settings after applying them:
+
+```bash
+gh repo view ralphkrauss/agent-orchestrator --json description,homepageUrl,repositoryTopics
+```
+
+If GitHub CLI is not installed, use the repository Settings page in the GitHub
+web UI, or use the REST API with a maintainer token kept outside the repo:
+
+```bash
+curl -fsS -X PATCH https://api.github.com/repos/ralphkrauss/agent-orchestrator \
+  -H "Authorization: Bearer $GITHUB_TOKEN" \
+  -H "Accept: application/vnd.github+json" \
+  -d '{"description":"Local MCP orchestrator for supervising Codex, Claude, Cursor, and OpenCode worker runs.","homepage":"https://www.npmjs.com/package/@ralphkrauss/agent-orchestrator"}'
+
+curl -fsS -X PUT https://api.github.com/repos/ralphkrauss/agent-orchestrator/topics \
+  -H "Authorization: Bearer $GITHUB_TOKEN" \
+  -H "Accept: application/vnd.github+json" \
+  -d '{"names":["mcp","model-context-protocol","agent-orchestration","codex-cli","claude-code","cursor","opencode","typescript","nodejs"]}'
+```
+
+## Dogfooding And AI Workspace Files
+
+| Path | Purpose |
+|---|---|
+| `.agents/` | Canonical source for reusable skills, rules, and agent definitions used while developing this repository. |
+| `.claude/` | Generated Claude projection produced from `.agents/`. Do not edit it directly. |
+| `.cursor/rules/` | Generated Cursor projection produced from `.agents/`. Do not edit it directly. |
+| `.codex/`, `.mcp.json`, `.cursor/mcp.json`, `opencode.json` | Repo-local MCP and client config used for development. Secret-bearing launches go through `scripts/mcp-secret-bridge.mjs`. |
+| `plans/` | Historical and active planning, review, and resolution artifacts. They document the project history and are not required for normal package use. |
+| `.githooks/` | Optional local hooks. They are not activated by clone or install. |
+
+Generated projections are checked with:
+
+```bash
+node scripts/sync-ai-workspace.mjs --check
+```
+
+Regenerate them with:
+
+```bash
+node scripts/sync-ai-workspace.mjs
+```
+
+## Secrets Policy
+
+Real tokens must not appear in repo files, examples, docs, issue templates, command arguments, or committed MCP config. The repository uses placeholders and a local secret bridge for development-only MCP launches.
+
+User-level secret files live outside the repo:
+
+```text
+~/.config/agent-orchestrator/secrets.env
+~/.config/agent-orchestrator/mcp-secrets.env
+```
+
+The first file is for daemon-managed provider credentials. The second is for repo-development MCP bridge launches.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ralphkrauss/agent-orchestrator",
   "version": "0.2.2",
-  "description": "MCP agent orchestrator for Codex and Claude worker runs",
+  "description": "Local MCP orchestrator for supervising Codex, Claude, Cursor, and OpenCode worker runs.",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -32,6 +32,13 @@
     "!dist/__tests__/",
     "!src/__tests__/",
     "README.md",
+    "CHANGELOG.md",
+    "CONTRIBUTING.md",
+    "SECURITY.md",
+    "SUPPORT.md",
+    "ROADMAP.md",
+    "CODE_OF_CONDUCT.md",
+    "docs/",
     "PUBLISHING.md",
     "LICENSE.md"
   ],
@@ -47,6 +54,17 @@
   },
   "homepage": "https://github.com/ralphkrauss/agent-orchestrator#readme",
   "license": "MIT",
+  "keywords": [
+    "mcp",
+    "model-context-protocol",
+    "agent-orchestration",
+    "codex-cli",
+    "claude-code",
+    "cursor",
+    "opencode",
+    "typescript",
+    "nodejs"
+  ],
   "publishConfig": {
     "access": "public"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -353,8 +353,8 @@ packages:
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
-  fast-uri@3.1.0:
-    resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
+  fast-uri@3.1.2:
+    resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
 
   file-uri-to-path@1.0.0:
     resolution: {integrity: sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==}
@@ -422,8 +422,8 @@ packages:
     resolution: {integrity: sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==}
     engines: {node: '>= 0.4'}
 
-  hono@4.12.16:
-    resolution: {integrity: sha512-jN0ZewiNAWSe5khM3EyCmBb250+b40wWbwNILNfEvq84VREWwOIkuUsFONk/3i3nqkz7Oe1PcpM2mwQEK2L9Kg==}
+  hono@4.12.18:
+    resolution: {integrity: sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==}
     engines: {node: '>=16.9.0'}
 
   http-cache-semantics@4.2.0:
@@ -955,9 +955,9 @@ snapshots:
   '@gar/promisify@1.1.3':
     optional: true
 
-  '@hono/node-server@1.19.14(hono@4.12.16)':
+  '@hono/node-server@1.19.14(hono@4.12.18)':
     dependencies:
-      hono: 4.12.16
+      hono: 4.12.18
 
   '@isaacs/fs-minipass@4.0.1':
     dependencies:
@@ -966,7 +966,7 @@ snapshots:
 
   '@modelcontextprotocol/sdk@1.29.0(zod@3.25.76)':
     dependencies:
-      '@hono/node-server': 1.19.14(hono@4.12.16)
+      '@hono/node-server': 1.19.14(hono@4.12.18)
       ajv: 8.20.0
       ajv-formats: 3.0.1(ajv@8.20.0)
       content-type: 1.0.5
@@ -976,7 +976,7 @@ snapshots:
       eventsource-parser: 3.0.8
       express: 5.2.1
       express-rate-limit: 8.4.1(express@5.2.1)
-      hono: 4.12.16
+      hono: 4.12.18
       jose: 6.2.3
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1
@@ -1046,7 +1046,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.0
+      fast-uri: 3.1.2
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -1292,7 +1292,7 @@ snapshots:
 
   fast-deep-equal@3.1.3: {}
 
-  fast-uri@3.1.0: {}
+  fast-uri@3.1.2: {}
 
   file-uri-to-path@1.0.0:
     optional: true
@@ -1382,7 +1382,7 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
-  hono@4.12.16: {}
+  hono@4.12.18: {}
 
   http-cache-semantics@4.2.0:
     optional: true

--- a/src/__tests__/claudeRotation.test.ts
+++ b/src/__tests__/claudeRotation.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, beforeEach, afterEach } from 'node:test';
 import assert from 'node:assert/strict';
-import { chmod, mkdtemp, writeFile } from 'node:fs/promises';
+import { chmod, mkdtemp, realpath, writeFile } from 'node:fs/promises';
 import { delimiter, join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { createBackendRegistry } from '../backend/registry.js';
@@ -185,6 +185,10 @@ async function setupFixture(): Promise<Fixture> {
   const service = new OrchestratorService(store, createBackendRegistry(store));
   await service.initialize();
   return { home, cwd, service };
+}
+
+async function encodeWorkerCwd(cwd: string): Promise<string> {
+  return (await realpath(cwd)).replace(/\//g, '-');
 }
 
 describe('claude account-bound spawn env scrubbing (end-to-end through fake claude)', () => {
@@ -569,7 +573,7 @@ describe('T-COR4 — copy-on-rotate-resume end-to-end (config_dir accounts)', ()
     // Pinned: parent observed a session id and the JSONL exists under A's projects/.
     assert.ok(parent.observedSessionId, 'parent must have observed a session id');
     const sid = parent.observedSessionId!;
-    const encodedCwd = fixture.cwd.replace(/\//g, '-');
+    const encodedCwd = await encodeWorkerCwd(fixture.cwd);
     const sourcePath = join(aDir, 'projects', encodedCwd, `${sid}.jsonl`);
     const { readFile, stat } = await import('node:fs/promises');
     const sourceBytesBefore = await readFile(sourcePath);
@@ -671,7 +675,7 @@ describe('T-COR4 — copy-on-rotate-resume end-to-end (config_dir accounts)', ()
     const parent = await rateLimitParent(fixture, { firstAccount: 'A', priority: ['A', 'B'] });
     assert.ok(parent.observedSessionId);
     const sid = parent.observedSessionId!;
-    const encodedCwd = fixture.cwd.replace(/\//g, '-');
+    const encodedCwd = await encodeWorkerCwd(fixture.cwd);
     const aSourcePath = join(aDir, 'projects', encodedCwd, `${sid}.jsonl`);
     const bTargetPath = join(bDir, 'projects', encodedCwd, `${sid}.jsonl`);
     void bTargetPath;
@@ -704,7 +708,7 @@ describe('T-COR4 — copy-on-rotate-resume end-to-end (config_dir accounts)', ()
     const parent = await rateLimitParent(fixture, { firstAccount: 'A', priority: ['A', 'B'] });
     assert.ok(parent.observedSessionId);
     const sid = parent.observedSessionId!;
-    const encodedCwd = fixture.cwd.replace(/\//g, '-');
+    const encodedCwd = await encodeWorkerCwd(fixture.cwd);
     void aDir;
 
     // Pre-seed B's JSONL with DIFFERENT contents so the collision-different
@@ -803,15 +807,24 @@ describe('T-COR4 — copy-on-rotate-resume end-to-end (config_dir accounts)', ()
     // merge the rotation marker into the failure terminal_context so the
     // supervisor still sees `kind: "resumed_after_rotation"`.
     const fixture = await setupFixture();
-    await registerConfigDirAccount(fixture.home, 'A');
+    const aDir = await registerConfigDirAccount(fixture.home, 'A');
     await registerConfigDirAccount(fixture.home, 'B');
 
     const parent = await rateLimitParent(fixture, { firstAccount: 'A', priority: ['A', 'B'] });
     assert.ok(parent.observedSessionId);
 
+    const workerEncodedCwd = await encodeWorkerCwd(fixture.cwd);
+    const fallbackEncodedCwd = fixture.cwd.replace(/\//g, '-');
+    const sid = parent.observedSessionId!;
+    const { copyFile, mkdir, rm } = await import('node:fs/promises');
+    await mkdir(join(aDir, 'projects', fallbackEncodedCwd), { recursive: true });
+    await copyFile(
+      join(aDir, 'projects', workerEncodedCwd, `${sid}.jsonl`),
+      join(aDir, 'projects', fallbackEncodedCwd, `${sid}.jsonl`),
+    );
+
     // Wipe the cwd so the rotation child's startManagedRun fails the
     // access(R_OK | W_OK) check and routes through failPreSpawn.
-    const { rm } = await import('node:fs/promises');
     await rm(fixture.cwd, { recursive: true, force: true });
 
     const fu = await fixture.service.sendFollowup({ run_id: parent.runId, prompt: 'fu' });

--- a/src/__tests__/claudeRotation.test.ts
+++ b/src/__tests__/claudeRotation.test.ts
@@ -11,6 +11,7 @@ import {
   loadAccountRegistry,
   upsertAccount,
 } from '../claude/accountRegistry.js';
+import { encodeProjectCwd } from '../claude/sessionCopy.js';
 
 let originalPath: string | undefined;
 let originalAnthropic: string | undefined;
@@ -188,7 +189,7 @@ async function setupFixture(): Promise<Fixture> {
 }
 
 async function encodeWorkerCwd(cwd: string): Promise<string> {
-  return (await realpath(cwd)).replace(/\//g, '-');
+  return encodeProjectCwd(await realpath(cwd));
 }
 
 describe('claude account-bound spawn env scrubbing (end-to-end through fake claude)', () => {

--- a/src/__tests__/claudeSessionCopy.test.ts
+++ b/src/__tests__/claudeSessionCopy.test.ts
@@ -44,6 +44,8 @@ describe('encodeProjectCwd', () => {
     assert.equal(encodeProjectCwd('/'), '-');
     assert.equal(encodeProjectCwd('/foo'), '-foo');
     assert.equal(encodeProjectCwd('/a/b'), '-a-b');
+    assert.equal(encodeProjectCwd('C:\\Users\\ralph\\workspace'), 'C:-Users-ralph-workspace');
+    assert.equal(encodeProjectCwd('\\\\?\\C:\\Users\\ralph\\workspace'), 'C:-Users-ralph-workspace');
   });
 });
 

--- a/src/__tests__/claudeSessionCopy.test.ts
+++ b/src/__tests__/claudeSessionCopy.test.ts
@@ -1,7 +1,7 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { promises as fs } from 'node:fs';
-import { mkdtemp, mkdir, writeFile, chmod, symlink, readFile, stat } from 'node:fs/promises';
+import { mkdtemp, mkdir, writeFile, chmod, symlink, readFile, realpath, stat } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import {
@@ -73,6 +73,41 @@ describe('copySessionJsonlForRotation — happy path', () => {
     assert.equal(targetStat.mode & 0o777, 0o600);
     const written = await readFile(outcome.target_path, 'utf8');
     assert.equal(written, contents);
+  });
+
+  it('looks up project JSONL files using the cwd realpath seen by worker processes', {
+    skip: process.platform === 'win32'
+      ? 'directory symlink privileges vary on Windows; this covers POSIX/macOS cwd alias behavior'
+      : false,
+  }, async () => {
+    const accountsRoot = await newAccountsRoot();
+    const root = await mkdtemp(join(tmpdir(), 'claude-cwd-alias-'));
+    const physicalCwd = join(root, 'physical');
+    const aliasCwd = join(root, 'alias');
+    await mkdir(physicalCwd);
+    await symlink(physicalCwd, aliasCwd, 'dir');
+    const workerCwd = await realpath(aliasCwd);
+    const contents = '{"session":"realpath"}\n';
+    const sourcePath = await seedSourceJsonl({
+      accountsRoot,
+      account: 'A',
+      cwd: workerCwd,
+      sessionId: VALID_SESSION_ID,
+      contents,
+    });
+
+    const outcome = await copySessionJsonlForRotation({
+      accountsRoot,
+      priorAccount: 'A',
+      newAccount: 'B',
+      cwd: aliasCwd,
+      sessionId: VALID_SESSION_ID,
+    });
+
+    assert.equal(outcome.ok, true);
+    if (!outcome.ok) return;
+    assert.equal(outcome.source_path, sourcePath);
+    assert.equal(await readFile(outcome.target_path, 'utf8'), contents);
   });
 });
 

--- a/src/__tests__/gitSnapshot.test.ts
+++ b/src/__tests__/gitSnapshot.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, beforeEach, afterEach } from 'node:test';
 import assert from 'node:assert/strict';
-import { chmod, mkdir, mkdtemp, symlink, unlink, writeFile } from 'node:fs/promises';
+import { chmod, mkdir, mkdtemp, realpath, symlink, unlink, writeFile } from 'node:fs/promises';
 import { delimiter, join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { execFile } from 'node:child_process';
@@ -64,7 +64,7 @@ process.exit(1);
     const capture = await captureGitSnapshot(repo);
     assert.equal(capture.status, 'captured');
     assert.ok(capture.snapshot);
-    assert.equal(capture.snapshot.root, repo);
+    assert.equal(capture.snapshot.root, await realpath(repo));
     assert.equal(capture.snapshot.branch, (await execFileAsync('git', ['branch', '--show-current'], { cwd: repo })).stdout.trim() || null);
 
     await writeFile(join(repo, 'tracked.txt'), 'dirty after\n');

--- a/src/__tests__/opencodeHarness.test.ts
+++ b/src/__tests__/opencodeHarness.test.ts
@@ -1,7 +1,7 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { existsSync } from 'node:fs';
-import { chmod, mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { chmod, mkdir, mkdtemp, readFile, realpath, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
 import { Writable } from 'node:stream';
@@ -249,7 +249,7 @@ describe('OpenCode orchestration harness', () => {
         argv: string[];
         config: { default_agent: string; agent: Record<string, { prompt: string; permission: Record<string, unknown> }> };
       };
-      assert.equal(invocation.cwd, root);
+      assert.equal(invocation.cwd, await realpath(root));
       assert.deepStrictEqual(invocation.argv, ['run', '--agent', 'agent-orchestrator', 'configure profiles']);
       assert.equal(invocation.config.default_agent, 'agent-orchestrator');
       assert.match(invocation.config.agent['agent-orchestrator']?.prompt ?? '', /Worker profiles manifest not found/);

--- a/src/claude/sessionCopy.ts
+++ b/src/claude/sessionCopy.ts
@@ -10,13 +10,13 @@ const DIR_MODE = 0o700;
 
 /**
  * Encode an absolute cwd into Claude Code's `projects/` subdirectory name
- * (D-COR4). Slashes become `-`; the leading slash becomes a leading `-`.
+ * (D-COR4). Path separators become `-`; the leading slash becomes a leading `-`.
  *
  * Pinned by the live on-disk path under
  * `<run_store>/claude/accounts/<name>/projects/...`.
  */
 export function encodeProjectCwd(absoluteCwd: string): string {
-  return absoluteCwd.replace(/\//g, '-');
+  return absoluteCwd.replace(/^\\\\\?\\/, '').replace(/\\/g, '/').replace(/\//g, '-');
 }
 
 export interface ComputeSessionJsonlPathInput {

--- a/src/claude/sessionCopy.ts
+++ b/src/claude/sessionCopy.ts
@@ -94,17 +94,18 @@ export async function copySessionJsonlForRotation(input: CopySessionJsonlInput):
     return { ok: false, reason: 'unsafe_account_name', details: { account: input.newAccount, role: 'new' } };
   }
 
+  const projectCwd = await resolveProjectCwd(input.cwd);
   const sourcePath = computeSessionJsonlPath({
     accountsRoot: input.accountsRoot,
     account: input.priorAccount,
-    cwd: input.cwd,
+    cwd: projectCwd,
     sessionId: input.sessionId,
   });
   const priorAccountRoot = join(input.accountsRoot, input.priorAccount);
   const targetPath = computeSessionJsonlPath({
     accountsRoot: input.accountsRoot,
     account: input.newAccount,
-    cwd: input.cwd,
+    cwd: projectCwd,
     sessionId: input.sessionId,
   });
   const newAccountRoot = join(input.accountsRoot, input.newAccount);
@@ -251,6 +252,14 @@ export async function copySessionJsonlForRotation(input: CopySessionJsonlInput):
     copied_bytes: copiedBytes,
     copy_duration_ms: now() - startedAt,
   };
+}
+
+async function resolveProjectCwd(cwd: string): Promise<string> {
+  try {
+    return await fs.realpath(cwd);
+  } catch {
+    return cwd;
+  }
 }
 
 async function checkContainment(


### PR DESCRIPTION
## Summary

- Refresh README, first-run/reference docs, repository map, and package metadata for public launch.
- Add contributor, security, support, roadmap, code-of-conduct files, plus GitHub issue and PR templates.
- Expand CI platform coverage and fix macOS cwd realpath/session-copy verification blockers.

## GitHub Metadata

- Set the live repository description, homepage, and topics to the documented public launch values.

## Verification

- [x] `pnpm install --frozen-lockfile` in a clean temporary copy of the current tree.
- [x] `pnpm verify` in a clean temporary copy of the current tree.
- [x] Tests: 554 total, 552 pass, 0 fail, 2 skipped.
- [x] Publish readiness, npm dist-tag resolution, production audit, and `npm pack --dry-run` passed.
- [x] Pack dry run: 296 files, 479.6 kB package size, 2.4 MB unpacked size.
- [x] Local Markdown link check passed.
- [x] `git diff --check` passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added roadmap, first-run quickstart, and expanded onboarding guides.

* **Documentation**
  * Rewrote README; added CONTRIBUTING, CODE_OF_CONDUCT, SECURITY, SUPPORT, OPEN_SOURCE_READINESS, CHANGELOG updates, reference docs, repository map, and first-run/how-to docs.

* **Chores**
  * Added PR and issue templates, updated package metadata, expanded .gitignore, and upgraded CI to multi-platform verification with Windows smoke tests.

* **Bug Fixes**
  * Improved session/resume handling for symlinked and realpath project directories.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ralphkrauss/agent-orchestrator/pull/54)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->