### PR TITLE
feat(workers): worker_posture for backend-native parity (#58)

### DIFF
--- a/.agents/rules/worker-posture.md
+++ b/.agents/rules/worker-posture.md
@@ -1,0 +1,46 @@
+---
+description: "Worker posture: trusted is the default; supervisor stays curated; isolation is profile opt-in"
+paths:
+  - "src/backend/**/*.ts"
+  - "src/orchestratorService.ts"
+  - "src/contract.ts"
+  - "src/harness/capabilities.ts"
+  - "src/mcpTools.ts"
+globs:
+  - "src/backend/**/*.ts"
+  - "src/orchestratorService.ts"
+  - "src/contract.ts"
+  - "src/harness/capabilities.ts"
+  - "src/mcpTools.ts"
+---
+
+# Worker Posture
+
+Issue #58 introduces a `worker_posture: 'trusted' | 'restricted'` field on
+the `WorkerProfile`, the direct-mode `start_run` / `send_followup` inputs,
+and the persisted `RunModelSettings`. Defaults to `'trusted'`.
+
+- Workers default to `trusted`: backend-native parity with a manual run from
+  the project worktree. Each backend translates `trusted` to its own
+  surface — Claude broadens `--setting-sources` to `user,project,local` and
+  adds `enableAllProjectMcpServers`; Codex drops `--ignore-user-config` and
+  uses resume-safe `-c` overrides; Cursor passes `local.settingSources:
+  ['all']` to the SDK.
+- The Claude **supervisor** envelope (`buildClaudeSpawnArgs`) is always
+  restricted. It must not read `worker_posture` or branch on it.
+- `restricted` posture is the profile opt-in for the pre-#58 closed-by-default
+  envelope. New code paths that change worker behavior should ask "what does
+  this look like under restricted?" before changing the default.
+- Profile mode rejects `profile + worker_posture` (and direct-mode
+  `worker_posture` on profile-mode chains in `send_followup`) the same way
+  `codex_network` is rejected today — to keep the profile manifest
+  authoritative for the chain.
+- The resolved posture is persisted on `RunModelSettings.worker_posture`.
+  Legacy `null` is tolerated on read and normalized to a concrete posture on
+  child-record write (same pattern as `codex_network: null → 'isolated'`).
+- Every worker spawn emits one `{ type: 'lifecycle', payload: { state:
+  'worker_posture', backend, worker_posture, ... } }` event so operators
+  can see the chosen posture in `get_run_events`. CLI backends emit via
+  `WorkerInvocation.initialEvents`; Cursor emits via
+  `store.appendEvent()` after `Agent.create`/`Agent.resume` succeeds and
+  before the first SDK stream message.

--- a/.agents/rules/worker-safety.md
+++ b/.agents/rules/worker-safety.md
@@ -1,0 +1,43 @@
+---
+description: "Worker safety contracts: hooks disabled, bypass permissions pinned, dangerously-skip-permissions banned"
+paths:
+  - "src/backend/claude.ts"
+  - "src/backend/codex.ts"
+  - "src/backend/cursor/**/*.ts"
+  - "src/claude/launcher.ts"
+globs:
+  - "src/backend/claude.ts"
+  - "src/backend/codex.ts"
+  - "src/backend/cursor/**/*.ts"
+  - "src/claude/launcher.ts"
+---
+
+# Worker Safety Contracts
+
+These invariants apply to **every** worker spawn under both `trusted` and
+`restricted` postures (issue #58). They are independent of MCP / config
+access posture; they exist so non-interactive workers do not stall or fire
+unintended user hooks.
+
+- Claude workers always pin `disableAllHooks: true` in the per-run settings
+  body (issue #40 T5/T13). Project `.claude/settings.json` cannot re-enable
+  hooks under `trusted` because the per-run `--settings <path>` file takes
+  precedence over the setting-sources merge.
+- Claude workers always pin `permissions.defaultMode: 'bypassPermissions'`
+  in the per-run settings body AND `--permission-mode bypassPermissions` on
+  the spawn argv (issue #47). The CLI flag survives precedence drift if
+  Claude Code ever flips precedence between settings and flags.
+- `--dangerously-skip-permissions` is banned on every worker and supervisor
+  invocation (issue #13 Decisions 7 / 21). The bypass posture is expressed
+  via the documented `defaultMode` / `--permission-mode` surface only.
+- Cursor workers must not weaken the SDK's pre-#58 safety defaults. Under
+  `restricted`, the shim omits `settingSources` so the SDK behaves as it did
+  before issue #58.
+- Codex workers must not emit `--sandbox` or `--cd` from the shared
+  `sandboxArgs()` helper because `codex exec resume` rejects them. Use
+  `-c key=value` overrides that both `codex exec` and `codex exec resume`
+  accept.
+
+If you are tempted to make a worker change that touches one of these
+invariants, stop and discuss — every one of them was load-bearing in a
+prior incident.

--- a/.claude/rules/worker-posture.md
+++ b/.claude/rules/worker-posture.md
@@ -1,0 +1,41 @@
+---
+paths:
+  - "src/backend/**/*.ts"
+  - "src/orchestratorService.ts"
+  - "src/contract.ts"
+  - "src/harness/capabilities.ts"
+  - "src/mcpTools.ts"
+---
+<!-- Generated from .agents/ by scripts/sync-ai-workspace.mjs. Do not edit directly. -->
+
+
+# Worker Posture
+
+Issue #58 introduces a `worker_posture: 'trusted' | 'restricted'` field on
+the `WorkerProfile`, the direct-mode `start_run` / `send_followup` inputs,
+and the persisted `RunModelSettings`. Defaults to `'trusted'`.
+
+- Workers default to `trusted`: backend-native parity with a manual run from
+  the project worktree. Each backend translates `trusted` to its own
+  surface — Claude broadens `--setting-sources` to `user,project,local` and
+  adds `enableAllProjectMcpServers`; Codex drops `--ignore-user-config` and
+  uses resume-safe `-c` overrides; Cursor passes `local.settingSources:
+  ['all']` to the SDK.
+- The Claude **supervisor** envelope (`buildClaudeSpawnArgs`) is always
+  restricted. It must not read `worker_posture` or branch on it.
+- `restricted` posture is the profile opt-in for the pre-#58 closed-by-default
+  envelope. New code paths that change worker behavior should ask "what does
+  this look like under restricted?" before changing the default.
+- Profile mode rejects `profile + worker_posture` (and direct-mode
+  `worker_posture` on profile-mode chains in `send_followup`) the same way
+  `codex_network` is rejected today — to keep the profile manifest
+  authoritative for the chain.
+- The resolved posture is persisted on `RunModelSettings.worker_posture`.
+  Legacy `null` is tolerated on read and normalized to a concrete posture on
+  child-record write (same pattern as `codex_network: null → 'isolated'`).
+- Every worker spawn emits one `{ type: 'lifecycle', payload: { state:
+  'worker_posture', backend, worker_posture, ... } }` event so operators
+  can see the chosen posture in `get_run_events`. CLI backends emit via
+  `WorkerInvocation.initialEvents`; Cursor emits via
+  `store.appendEvent()` after `Agent.create`/`Agent.resume` succeeds and
+  before the first SDK stream message.

--- a/.claude/rules/worker-safety.md
+++ b/.claude/rules/worker-safety.md
@@ -1,0 +1,39 @@
+---
+paths:
+  - "src/backend/claude.ts"
+  - "src/backend/codex.ts"
+  - "src/backend/cursor/**/*.ts"
+  - "src/claude/launcher.ts"
+---
+<!-- Generated from .agents/ by scripts/sync-ai-workspace.mjs. Do not edit directly. -->
+
+
+# Worker Safety Contracts
+
+These invariants apply to **every** worker spawn under both `trusted` and
+`restricted` postures (issue #58). They are independent of MCP / config
+access posture; they exist so non-interactive workers do not stall or fire
+unintended user hooks.
+
+- Claude workers always pin `disableAllHooks: true` in the per-run settings
+  body (issue #40 T5/T13). Project `.claude/settings.json` cannot re-enable
+  hooks under `trusted` because the per-run `--settings <path>` file takes
+  precedence over the setting-sources merge.
+- Claude workers always pin `permissions.defaultMode: 'bypassPermissions'`
+  in the per-run settings body AND `--permission-mode bypassPermissions` on
+  the spawn argv (issue #47). The CLI flag survives precedence drift if
+  Claude Code ever flips precedence between settings and flags.
+- `--dangerously-skip-permissions` is banned on every worker and supervisor
+  invocation (issue #13 Decisions 7 / 21). The bypass posture is expressed
+  via the documented `defaultMode` / `--permission-mode` surface only.
+- Cursor workers must not weaken the SDK's pre-#58 safety defaults. Under
+  `restricted`, the shim omits `settingSources` so the SDK behaves as it did
+  before issue #58.
+- Codex workers must not emit `--sandbox` or `--cd` from the shared
+  `sandboxArgs()` helper because `codex exec resume` rejects them. Use
+  `-c key=value` overrides that both `codex exec` and `codex exec resume`
+  accept.
+
+If you are tempted to make a worker change that touches one of these
+invariants, stop and discuss — every one of them was load-bearing in a
+prior incident.

--- a/.cursor/rules/worker-posture.mdc
+++ b/.cursor/rules/worker-posture.mdc
@@ -1,0 +1,43 @@
+---
+description: "Worker posture: trusted is the default; supervisor stays curated; isolation is profile opt-in"
+globs:
+  - "src/backend/**/*.ts"
+  - "src/orchestratorService.ts"
+  - "src/contract.ts"
+  - "src/harness/capabilities.ts"
+  - "src/mcpTools.ts"
+alwaysApply: false
+---
+<!-- Generated from .agents/ by scripts/sync-ai-workspace.mjs. Do not edit directly. -->
+
+
+# Worker Posture
+
+Issue #58 introduces a `worker_posture: 'trusted' | 'restricted'` field on
+the `WorkerProfile`, the direct-mode `start_run` / `send_followup` inputs,
+and the persisted `RunModelSettings`. Defaults to `'trusted'`.
+
+- Workers default to `trusted`: backend-native parity with a manual run from
+  the project worktree. Each backend translates `trusted` to its own
+  surface — Claude broadens `--setting-sources` to `user,project,local` and
+  adds `enableAllProjectMcpServers`; Codex drops `--ignore-user-config` and
+  uses resume-safe `-c` overrides; Cursor passes `local.settingSources:
+  ['all']` to the SDK.
+- The Claude **supervisor** envelope (`buildClaudeSpawnArgs`) is always
+  restricted. It must not read `worker_posture` or branch on it.
+- `restricted` posture is the profile opt-in for the pre-#58 closed-by-default
+  envelope. New code paths that change worker behavior should ask "what does
+  this look like under restricted?" before changing the default.
+- Profile mode rejects `profile + worker_posture` (and direct-mode
+  `worker_posture` on profile-mode chains in `send_followup`) the same way
+  `codex_network` is rejected today — to keep the profile manifest
+  authoritative for the chain.
+- The resolved posture is persisted on `RunModelSettings.worker_posture`.
+  Legacy `null` is tolerated on read and normalized to a concrete posture on
+  child-record write (same pattern as `codex_network: null → 'isolated'`).
+- Every worker spawn emits one `{ type: 'lifecycle', payload: { state:
+  'worker_posture', backend, worker_posture, ... } }` event so operators
+  can see the chosen posture in `get_run_events`. CLI backends emit via
+  `WorkerInvocation.initialEvents`; Cursor emits via
+  `store.appendEvent()` after `Agent.create`/`Agent.resume` succeeds and
+  before the first SDK stream message.

--- a/.cursor/rules/worker-safety.mdc
+++ b/.cursor/rules/worker-safety.mdc
@@ -1,0 +1,41 @@
+---
+description: "Worker safety contracts: hooks disabled, bypass permissions pinned, dangerously-skip-permissions banned"
+globs:
+  - "src/backend/claude.ts"
+  - "src/backend/codex.ts"
+  - "src/backend/cursor/**/*.ts"
+  - "src/claude/launcher.ts"
+alwaysApply: false
+---
+<!-- Generated from .agents/ by scripts/sync-ai-workspace.mjs. Do not edit directly. -->
+
+
+# Worker Safety Contracts
+
+These invariants apply to **every** worker spawn under both `trusted` and
+`restricted` postures (issue #58). They are independent of MCP / config
+access posture; they exist so non-interactive workers do not stall or fire
+unintended user hooks.
+
+- Claude workers always pin `disableAllHooks: true` in the per-run settings
+  body (issue #40 T5/T13). Project `.claude/settings.json` cannot re-enable
+  hooks under `trusted` because the per-run `--settings <path>` file takes
+  precedence over the setting-sources merge.
+- Claude workers always pin `permissions.defaultMode: 'bypassPermissions'`
+  in the per-run settings body AND `--permission-mode bypassPermissions` on
+  the spawn argv (issue #47). The CLI flag survives precedence drift if
+  Claude Code ever flips precedence between settings and flags.
+- `--dangerously-skip-permissions` is banned on every worker and supervisor
+  invocation (issue #13 Decisions 7 / 21). The bypass posture is expressed
+  via the documented `defaultMode` / `--permission-mode` surface only.
+- Cursor workers must not weaken the SDK's pre-#58 safety defaults. Under
+  `restricted`, the shim omits `settingSources` so the SDK behaves as it did
+  before issue #58.
+- Codex workers must not emit `--sandbox` or `--cd` from the shared
+  `sandboxArgs()` helper because `codex exec resume` rejects them. Use
+  `-c key=value` overrides that both `codex exec` and `codex exec resume`
+  accept.
+
+If you are tempted to make a worker change that touches one of these
+invariants, stop and discuss — every one of them was load-bearing in a
+prior incident.

--- a/README.md
+++ b/README.md
@@ -90,15 +90,22 @@ Then use the MCP tools from that client:
 get_backend_status({})
 ```
 
-Create a profile. Choose a model id that your local backend accepts.
+Create a profile. Choose a model id that your local backend accepts. The
+example below uses `worker_posture: "restricted"` together with
+`codex_network: "isolated"` to keep the worker on the closed-network,
+`--ignore-user-config` envelope. Omit both fields (or use
+`worker_posture: "trusted"`, the default since #58) for backend-native parity
+with a manual `codex exec` run — see [`docs/reference.md`](docs/reference.md#model-and-network-settings)
+for the two-axis posture × `codex_network` argv table.
 
 ```text
 upsert_worker_profile({
   "profile": "codex-local",
   "backend": "codex",
   "model": "<codex-model-id>",
+  "worker_posture": "restricted",
   "codex_network": "isolated",
-  "description": "Local Codex worker with closed network egress"
+  "description": "Local Codex worker with closed network egress (restricted posture)"
 })
 ```
 

--- a/docs/development/codex-backend.md
+++ b/docs/development/codex-backend.md
@@ -34,7 +34,19 @@ value is a non-empty string.
 `codex_network` is a codex-only profile field with three values. Each value
 maps to a specific argv shape that controls whether codex reads
 `$CODEX_HOME/config.toml` and whether bash-tool network egress inside the
-worker sandbox is allowed.
+worker sandbox is allowed. **The exact argv depends on `worker_posture`**
+(issue #58); the table below has one row per posture × value.
+
+Under `worker_posture: 'trusted'` (the default since issue #58):
+
+| `codex_network`  | Argv added to `codex exec` (and `codex exec resume`)             | Persisted `model_settings.codex_network` | Effect                                                                                                                                  |
+|------------------|------------------------------------------------------------------|------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------|
+| absent / unset   | `-c sandbox_mode="workspace-write" -c sandbox_workspace_write.network_access=true` | `null` (intentionally — distinguishes the trusted-default from explicit `'isolated'`) | Workspace-write sandbox with network on. Codex loads user + project `config.toml`. Matches a manual `codex exec` from the project. |
+| `isolated`       | (no sandbox flags)                                               | `'isolated'` | Codex defaults apply. Codex still loads user + project `config.toml`.                                                                  |
+| `workspace`      | `-c sandbox_workspace_write.network_access=true`                 | `'workspace'` | Workspace-write network enabled. Codex loads user + project `config.toml`. **No `--ignore-user-config`** — see migration note below.   |
+| `user-config`    | (no flags)                                                       | `'user-config'` | Codex defaults apply. Codex reads user + project `config.toml`.                                                                        |
+
+Under `worker_posture: 'restricted'` (issue #31 v1 envelope; profile opt-in):
 
 | `codex_network`  | Argv added to `codex exec`                                               | Effect                                                                                                                                             |
 |------------------|--------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -42,15 +54,34 @@ worker sandbox is allowed.
 | `workspace`      | `--ignore-user-config -c sandbox_workspace_write.network_access=true`    | Codex skips `$CODEX_HOME/config.toml`; bash sandbox network is granted via the explicit codex CLI override. Deterministic across machines.         |
 | `user-config`    | (no flags added)                                                         | Codex reads `$CODEX_HOME/config.toml` verbatim and honors whatever sandbox / network policy lives there. Per-machine; can be non-deterministic.    |
 
-> Per `codex exec --help` on codex-cli 0.128.0, `--ignore-user-config`
-> "skips `$CODEX_HOME/config.toml`". This is the precise effect — the wording
-> in this doc matches the codex CLI's own help text to avoid drift.
+> Per `codex exec --help` on codex-cli 0.130.0, `--ignore-user-config`
+> "skips `$CODEX_HOME/config.toml`". The trusted-posture argv uses
+> `-c sandbox_mode="workspace-write"` (not `--sandbox`) because
+> `codex exec resume --help` does not accept `--sandbox`; the daemon's shared
+> `sandboxArgs()` helper produces argv accepted by both `codex exec` and
+> `codex exec resume`.
+
+> **Migration (issue #58):** existing profiles with explicit
+> `codex_network: 'workspace'` no longer emit `--ignore-user-config` under
+> the new `trusted` default. If you depended on the side effect of skipping
+> `$CODEX_HOME/config.toml`, set `worker_posture: 'restricted'` on the
+> profile to preserve the pre-#58 argv.
 
 ### Default
 
 When a codex profile (or a direct-mode `start_run`) does **not** set
-`codex_network`, the daemon resolves it to `'isolated'`. This default is
-**uniform for every codex profile**, regardless of `service_tier`.
+`codex_network`, the daemon's resolution depends on `worker_posture`
+(issue #58):
+
+- **`worker_posture: 'trusted'` (the default since #58)** — the run record
+  persists `codex_network: null` and the worker spawns with
+  `-c sandbox_mode="workspace-write" -c sandbox_workspace_write.network_access=true`.
+  No `--ignore-user-config`; user + project `config.toml` load normally.
+  This null value is intentional and distinct from explicit `'isolated'`
+  (which would emit no sandbox flags at all).
+- **`worker_posture: 'restricted'` (opt-in)** — the daemon resolves to
+  `'isolated'`, matching the pre-#58 OD1=B uniform default. Used by callers
+  that want the closed-by-default envelope.
 
 ### Where to set it
 
@@ -97,18 +128,26 @@ When a codex profile (or a direct-mode `start_run`) does **not** set
 
 ## Per-Run Warning
 
-When a codex worker run starts and `codex_network` was not set explicitly on
-the profile or on the direct-mode `start_run` argument, the daemon emits a
-single non-blocking lifecycle event into the run's event log:
+When a `worker_posture: 'restricted'` codex worker run starts and
+`codex_network` was not set explicitly on the profile or on the direct-mode
+`start_run` argument, the daemon emits a single non-blocking lifecycle event
+into the run's event log:
 
 ```text
-agent-orchestrator codex_network not set on <profile or direct-mode run>; defaulting to 'isolated' (no network access). Set codex_network explicitly to silence this warning. See docs/development/codex-backend.md for migration.
+agent-orchestrator codex_network not set on <profile or direct-mode run> (worker_posture=restricted); defaulting to 'isolated' (no network access, --ignore-user-config). Set codex_network explicitly to silence this warning, or move the profile to worker_posture: 'trusted' to opt into backend-native parity. See docs/development/codex-backend.md for migration.
 ```
 
+Issue #58 review follow-up: under the default `worker_posture: 'trusted'`,
+this warning is **suppressed**. The trusted default (workspace-write sandbox
++ network on; `codex_network` persisted as `null`) is the intended product
+direction, not a surprise breaking change. The warning still fires for
+`worker_posture: 'restricted'` runs that omit `codex_network`, since those
+preserve the issue #31 closed-by-default isolated argv.
+
 The warning never blocks the run. It is per-run (so silencing the warning by
-setting `codex_network` on a profile silences it for every subsequent run on
-that profile) and it surfaces alongside any failing tool calls so users
-hitting the breaking change can correlate.
+setting `codex_network` on a restricted profile silences it for every
+subsequent run on that profile) and it surfaces alongside any failing tool
+calls so users hitting the breaking change can correlate.
 
 The warning is emitted as a `lifecycle` event with payload
 `state: 'codex_network_defaulted'`. The full warning text lives on the event
@@ -119,62 +158,81 @@ event log directly).
 
 ## Migration: BREAKING (codex)
 
-> **Affected releases:** the locked OD1 = B decision in issue #31 (2026-05-05)
-> changes the codex backend's default network egress posture from
-> "honor `~/.codex/config.toml`" to `'isolated'` for every codex profile that
-> does not set `codex_network` explicitly.
+> **Affected releases:** two breaking changes affect codex profile defaults.
+>
+> 1. Issue #31 (locked 2026-05-05): when `worker_posture: 'restricted'` and
+>    `codex_network` is omitted, the daemon now resolves to `'isolated'`
+>    (instead of "honor `~/.codex/config.toml`"). This is the change documented
+>    in the migration table below; it still applies under restricted posture.
+> 2. Issue #58 (this release): `worker_posture` now defaults to `'trusted'`,
+>    which loads user + project `config.toml` and emits the trusted-default
+>    sandbox argv (workspace-write + network on) when `codex_network` is
+>    omitted. **Most operators do not need the #31 migration anymore** because
+>    the trusted default closely matches the pre-#31 manual-run experience.
+>    Set `worker_posture: 'restricted'` explicitly to opt into the #31
+>    closed-by-default envelope described below.
 
-### Who is affected
+### Who is affected (restricted posture, post-#58)
 
 A codex profile that:
 
 1. Has `backend: 'codex'`, **and**
-2. Has `service_tier` set to `'fast'` or `'flex'`, **or** has no
-   `service_tier` set, **and**
+2. Has `worker_posture: 'restricted'` (explicit since #58), **and**
 3. Relies on `~/.codex/config.toml` for network access (the most common shape
    today is `[sandbox_workspace_write]\nnetwork_access = true`), **and**
 4. Does not yet set `codex_network`.
 
-After upgrade, that profile passes `--ignore-user-config` to `codex exec`, so
-codex stops reading `~/.codex/config.toml`, so the user's network allowlist is
-no longer applied, so bash tools inside the worker that rely on outbound HTTP
-(`gh api`, `curl`, `npm install` from a private registry, etc.) will fail.
+Under restricted with no `codex_network`, that profile passes
+`--ignore-user-config` to `codex exec`, so codex stops reading
+`~/.codex/config.toml`, so the user's network allowlist is no longer applied,
+so bash tools inside the worker that rely on outbound HTTP (`gh api`, `curl`,
+`npm install` from a private registry, etc.) will fail.
 
-### Migration table
+Under `worker_posture: 'trusted'` (the default since #58), no `codex_network`
+emits the trusted-default sandbox (`-c sandbox_mode="workspace-write" -c
+sandbox_workspace_write.network_access=true`) without `--ignore-user-config`,
+so user + project `config.toml` and the workspace network are both available.
 
-| Existing profile shape                              | Today's argv                      | Argv after upgrade with no manifest change | Required action                                                                                                |
+### Migration table (restricted posture)
+
+| Existing restricted profile shape                   | Today's argv                      | Argv after upgrade with no manifest change | Required action                                                                                                |
 |-----------------------------------------------------|-----------------------------------|--------------------------------------------|----------------------------------------------------------------------------------------------------------------|
 | `service_tier: 'normal'`                            | includes `--ignore-user-config`   | includes `--ignore-user-config`            | **None — same posture.** Pre-fetch external data in the supervisor when needed.                                |
-| `service_tier: 'fast'`                              | no `--ignore-user-config`         | **includes `--ignore-user-config`**        | Set `codex_network: 'user-config'` to restore prior behavior, or `'workspace'` for codex-managed network-on.   |
-| `service_tier: 'flex'`                              | no `--ignore-user-config`         | **includes `--ignore-user-config`**        | Same as above.                                                                                                  |
-| `service_tier` unset                                | no `--ignore-user-config`         | **includes `--ignore-user-config`**        | Same as above.                                                                                                  |
-| `codex_network` set explicitly                      | per C3 mapping                    | per C3 mapping                             | None — explicit value wins over the default.                                                                   |
+| `service_tier: 'fast'` / `'flex'` / unset           | no `--ignore-user-config`         | **includes `--ignore-user-config`**        | Set `codex_network: 'user-config'` to restore prior behavior, or `'workspace'` for codex-managed network-on, or move to `worker_posture: 'trusted'` for backend-native parity. |
+| `codex_network` set explicitly                      | per restricted mapping            | per restricted mapping                     | None — explicit value wins over the default.                                                                   |
 
-### Three concrete migration options
+### Three concrete migration options (still restricted posture)
 
-In increasing security cost:
+In increasing openness:
 
-1. **`codex_network: 'user-config'`** — keep today's behavior verbatim. Codex
-   continues to read `~/.codex/config.toml`. This is the closest to a no-op
-   migration and is the recommended default for users who relied on the legacy
-   posture.
-2. **`codex_network: 'workspace'`** — use the codex CLI's own network
-   override. Network is on; sandbox is deterministic across machines.
-3. **`codex_network: 'isolated'`** (the new default) — keep network closed.
-   Recommended for review-only or implementation profiles that do not need
-   outbound HTTP. Combine with the supervisor-side pre-fetch pattern (see
-   `orchestrate-resolve-pr-comments`) for skills that need to fetch external
-   data.
+1. **`worker_posture: 'trusted'`** (the new default since #58) — workers see
+   user + project `config.toml` and the trusted-default sandbox. Closest to a
+   manual `codex exec` run. Recommended unless you specifically need the
+   closed-by-default envelope.
+2. **`codex_network: 'user-config'`** — keep the pre-#31 behavior verbatim
+   under restricted. Codex continues to read `~/.codex/config.toml`.
+3. **`codex_network: 'workspace'`** — under restricted, this still emits
+   `--ignore-user-config` but adds the codex CLI's own network override. Use
+   when you want deterministic codex config but workspace-write network on.
+4. **`codex_network: 'isolated'`** (the restricted default since #31) — keep
+   network closed and user config skipped. Recommended for review-only or
+   implementation profiles that do not need outbound HTTP. Combine with the
+   supervisor-side pre-fetch pattern (see `orchestrate-resolve-pr-comments`).
 
 ### Why this changed
 
-Previously, codex network egress was an unintended side effect of
+Originally (pre-#31), codex network egress was an unintended side effect of
 `service_tier: 'normal'`: the daemon mapped that to an internal `mode='normal'`
 flag, which then triggered `--ignore-user-config`. Profiles with `service_tier`
 set to anything else (or unset) silently honored `~/.codex/config.toml`. Users
 who only knew about `service_tier` could not predict whether their codex
-config was being applied. Decoupling network egress from speed-tier and making
-the posture explicit (and uniform) closes that foot-gun.
+config was being applied. Issue #31 decoupled network egress from speed-tier
+and made the posture explicit and uniform under restricted.
+
+Issue #58 then reframed the contract again: workers default to backend-native
+parity (`worker_posture: 'trusted'`) with a manual run, and the curated
+restricted envelope is opt-in. Most operators no longer need to migrate
+because the trusted default matches what they would have gotten manually.
 
 ## Recommended Patterns
 

--- a/docs/development/codex-backend.md
+++ b/docs/development/codex-backend.md
@@ -60,7 +60,7 @@ Under `worker_posture: 'restricted'` (issue #31 v1 envelope; profile opt-in):
 > `codex exec resume --help` does not accept `--sandbox`; the daemon's shared
 > `sandboxArgs()` helper produces argv accepted by both `codex exec` and
 > `codex exec resume`.
-
+>
 > **Migration (issue #58):** existing profiles with explicit
 > `codex_network: 'workspace'` no longer emit `--ignore-user-config` under
 > the new `trusted` default. If you depended on the side effect of skipping
@@ -201,9 +201,10 @@ so user + project `config.toml` and the workspace network are both available.
 | `service_tier: 'fast'` / `'flex'` / unset           | no `--ignore-user-config`         | **includes `--ignore-user-config`**        | Set `codex_network: 'user-config'` to restore prior behavior, or `'workspace'` for codex-managed network-on, or move to `worker_posture: 'trusted'` for backend-native parity. |
 | `codex_network` set explicitly                      | per restricted mapping            | per restricted mapping                     | None — explicit value wins over the default.                                                                   |
 
-### Three concrete migration options (still restricted posture)
+### Migration options
 
-In increasing openness:
+Listed in increasing openness; the first option moves off restricted entirely,
+options 2-4 stay within restricted.
 
 1. **`worker_posture: 'trusted'`** (the new default since #58) — workers see
    user + project `config.toml` and the trusted-default sandbox. Closest to a

--- a/docs/development/cursor-backend.md
+++ b/docs/development/cursor-backend.md
@@ -69,11 +69,16 @@ Other deferred areas:
 | `model` | Required. Pass a Cursor-side model id (e.g. `composer-2`). Resume calls thread per-run model overrides through `SendOptions.model`. |
 | `reasoning_effort` | Rejected with `INVALID_INPUT`. The SDK exposes per-model parameter discovery (`Cursor.models.list()`) which is deferred. |
 | `service_tier` | Rejected with `INVALID_INPUT`. |
+| `worker_posture` | Optional; defaults to `'trusted'`. Under `'trusted'`, `Agent.create` and `Agent.resume` receive `local.settingSources: ['all']` so the SDK loads every ambient settings layer (project, user, team, MDM, plugins). Under `'restricted'`, the shim omits `settingSources` and the SDK falls back to its pre-#58 in-process defaults. |
 
 Profiles in the worker profiles manifest follow the same rules: cursor
 profiles must declare `model`, must omit `reasoning_effort` and
 `service_tier`, and must not declare a `variant` (catalog declares
 `variants: []`).
+
+`worker_posture` is a backend-agnostic field — see
+[`mcp-tooling.md`](mcp-tooling.md#workers-and-project-mcp-servers) for the
+per-backend mapping and the trust-boundary documentation.
 
 ## Sessions and resume
 

--- a/docs/development/mcp-tooling.md
+++ b/docs/development/mcp-tooling.md
@@ -52,6 +52,66 @@ into the secrets file.
 > belongs in `~/.config/agent-orchestrator/secrets.env`; see
 > [`auth-setup.md`](auth-setup.md).
 
+## Workers And Project MCP Servers
+
+Worker runs (the local Codex / Claude / Cursor processes spawned by the
+daemon, distinct from the supervisor) opt into backend-native parity via the
+`worker_posture` profile field introduced by issue #58. The field is also
+accepted as a direct-mode override on `start_run` and `send_followup`. Two
+values:
+
+- `trusted` (default) — worker behaves like a manual run from the project
+  worktree. Loads project MCP servers, project / user / local Claude Code
+  scopes, and project / user codex config.
+- `restricted` — worker keeps the pre-#58 isolated envelope. Closed by
+  default; opt in per profile when needed.
+
+Per-backend mapping under `trusted`:
+
+| Backend | What `trusted` does | What changes vs. pre-#58 |
+|---|---|---|
+| Claude (worker) | `--setting-sources user,project,local`, per-run settings body includes `enableAllProjectMcpServers: true`. `disableAllHooks: true` and CLI `--permission-mode bypassPermissions` still pinned by precedence — project hooks cannot fire and project `permissionMode` cannot stall the worker. | Was `--setting-sources user` only; project `.mcp.json` and `.claude/settings.json` were invisible. |
+| Codex (worker) | `--ignore-user-config` is **never** emitted. Sandbox / network argv driven by `codex_network` via `-c key=value` overrides (resume-safe on `codex exec resume`). When `codex_network` is unset, trusted defaults to `-c sandbox_mode="workspace-write" -c sandbox_workspace_write.network_access=true`. | Was `--ignore-user-config` by default; existing profiles with explicit `codex_network: workspace` also lose `--ignore-user-config` under trusted (migration note in [`codex-backend.md`](codex-backend.md)). |
+| Cursor (worker) | `Agent.create` and `Agent.resume` receive `local.settingSources: ['all']` — every ambient Cursor settings layer (project, user, team, MDM, plugins) loads. | Shim previously forwarded only `cwd`; project / global Cursor settings were invisible. |
+
+The Claude **supervisor** envelope (`agent-orchestrator claude` and
+`buildClaudeSpawnArgs` in `src/claude/launcher.ts`) is **always restricted**
+and ignores `worker_posture`. It keeps `--strict-mcp-config` plus the
+orchestrator-owned MCP config and the `--tools` / `dontAsk` deny-by-default
+surface, so the supervisor's tool envelope stays curated.
+
+A `worker_posture` lifecycle event is appended at the head of every worker
+run's event stream so `get_run_events` answers "what did this worker
+actually load?" deterministically. The Claude and Codex backends emit the
+event via `WorkerInvocation.initialEvents`, which `ProcessManager.start()`
+flushes once per actual spawn; `CliRuntime.buildStartInvocation()` strips
+the field on the pre-bake retry path so a retry that never spawns does not
+record false telemetry. The Cursor SDK runtime (which does not produce a
+`WorkerInvocation`) appends the same event via `store.appendEvent()` after
+`Agent.create` / `Agent.resume` succeeds and before the first SDK stream
+message; pre-spawn failures emit no event.
+
+### Trust Boundary
+
+Enabling project MCP on workers means treating `.mcp.json` (Claude) and
+`.codex/config.toml` (Codex) entries as **executable local config** that
+runs in the worker process environment. Project stdio MCP servers spawn at
+MCP init outside the model tool path, so a malicious or compromised entry
+runs as the same OS user as the daemon. This is the same trust model as a
+manual `claude` or `codex exec` invocation from the project worktree.
+
+Two implications:
+
+1. Workers were already trusted-local, full-access processes — `worker_posture: 'trusted'`
+   does not weaken any sandbox; it widens *what worker processes can see*.
+2. Secret-bearing project MCP entries must continue to route through
+   `scripts/mcp-secret-bridge.mjs` so credentials are resolved from
+   `~/.config/agent-orchestrator/mcp-secrets.env`, process env, or `gh auth
+   token` — never committed to the repo.
+
+Set `worker_posture: 'restricted'` on a profile (or pass it as a direct-mode
+argument on `start_run`) when you need the pre-#58 closed-by-default envelope.
+
 ## Client Setup
 
 Claude Code reads:

--- a/docs/first-run.md
+++ b/docs/first-run.md
@@ -70,15 +70,23 @@ That is the MCP equivalent of `doctor` and still makes no model calls.
 
 Pick a backend that diagnostics reports as `available` or `auth_unknown`. The examples below use placeholders for model ids because accepted model names belong to the backend CLI or SDK.
 
-Codex profile with closed worker network egress:
+Codex profile with closed worker network egress. Since #58, "closed network
+egress" requires **both** `worker_posture: "restricted"` (so the daemon emits
+`--ignore-user-config`) and `codex_network: "isolated"` (so no
+`sandbox_workspace_write.network_access=true` override is added). Omit both
+fields (or use the default `worker_posture: "trusted"`) to get backend-native
+parity with a manual `codex exec` run — see
+[reference.md](reference.md#model-and-network-settings) for the two-axis argv
+table.
 
 ```text
 upsert_worker_profile({
   "profile": "codex-local",
   "backend": "codex",
   "model": "<codex-model-id>",
+  "worker_posture": "restricted",
   "codex_network": "isolated",
-  "description": "Local Codex worker with closed network egress"
+  "description": "Local Codex worker with closed network egress (restricted posture)"
 })
 ```
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -148,15 +148,37 @@ Expected operational failures use `{ ok: false, error }`. MCP `isError: true` is
 
 `reasoning_effort` maps to Codex `model_reasoning_effort` or Claude `--effort`. `service_tier` is Codex-only.
 
-`codex_network` is Codex-only:
+`worker_posture` (issue #58) controls whether workers see project / user
+configuration and MCP servers, independently of `codex_network`:
 
 | Value | Behavior |
 |---|---|
-| `isolated` | Passes `--ignore-user-config`; network remains closed by Codex defaults. |
-| `workspace` | Passes `--ignore-user-config` and enables workspace-write network access. |
-| `user-config` | Lets Codex read `$CODEX_HOME/config.toml` verbatim. |
+| `trusted` (default) | Worker gets backend-native parity with a manual run from the project worktree. Claude loads project/user/local setting-sources and auto-approves project MCP servers; Codex loads user + project `config.toml`; Cursor loads every ambient SDK settings layer. |
+| `restricted` | Orchestrator-curated isolated envelope (pre-#58 closed-by-default). Codex emits `--ignore-user-config`; Claude restricts setting-sources to `user`; Cursor omits ambient `settingSources`. |
 
-Codex profiles that omit `codex_network` default to `isolated`. See [development/codex-backend.md](development/codex-backend.md) for the migration table.
+The Claude supervisor envelope is always restricted and ignores
+`worker_posture`. Direct-mode `start_run` / `send_followup` accept the field;
+profile-mode rejects mixing (set it on the profile manifest).
+
+`codex_network` is Codex-only and independent of `worker_posture`. The effective
+argv depends on both axes (issue #58 review follow-up):
+
+| Posture × `codex_network` | Argv |
+|---|---|
+| `trusted` + unset | `-c sandbox_mode="workspace-write" -c sandbox_workspace_write.network_access=true` (persisted as `codex_network: null`) |
+| `trusted` + `isolated` | (no sandbox flags; codex defaults apply) |
+| `trusted` + `workspace` | `-c sandbox_workspace_write.network_access=true` |
+| `trusted` + `user-config` | (no flags) |
+| `restricted` + unset or `isolated` | `--ignore-user-config` |
+| `restricted` + `workspace` | `--ignore-user-config -c sandbox_workspace_write.network_access=true` |
+| `restricted` + `user-config` | (no flags) |
+
+Under `worker_posture: 'restricted'`, codex profiles that omit
+`codex_network` resolve to `'isolated'` and emit a one-off
+`codex_network_defaulted` lifecycle warning the first time the run starts;
+under `'trusted'` the warning is suppressed since the absence is the
+intended default. See [development/codex-backend.md](development/codex-backend.md)
+for the migration table.
 
 ## Long-Running Runs
 

--- a/plans/58-issue-with-setting-sources/plan.md
+++ b/plans/58-issue-with-setting-sources/plan.md
@@ -1,0 +1,10 @@
+# Plan Index
+
+Branch: `58-issue-with-setting-sources`
+Updated: 2026-05-12 (rev. 3 — tightened after Codex review rev. 2)
+
+## Sub-Plans
+
+| Plan | Scope | Status | File |
+|---|---|---|---|
+| Worker backend-native parity (trusted worker posture) | Introduce a `worker_posture: 'trusted' \| 'restricted'` profile field defaulting to `'trusted'`, persisted on `RunModelSettings` and inherited on `send_followup`. Under `'trusted'`: Claude `--setting-sources user,project,local` + `enableAllProjectMcpServers`; Codex drops `--ignore-user-config` and uses resume-safe `-c sandbox_mode="workspace-write" -c sandbox_workspace_write.network_access=true`; Cursor SDK gains `local.settingSources: ['all']` for full ambient parity. Supervisor stays curated. Spawn-time `worker_posture` telemetry (CLI via `initialEvents`; Cursor via `store.appendEvent` direct). T5/T13/#47 safety contracts preserved across both postures. (Rev. 3 after `reviews/review-plan-rev2-2026-05-12.md`; rev. 2 after `reviews/review-plan-2026-05-12.md`.) | complete | [plans/58-worker-project-mcp-access.md](plans/58-worker-project-mcp-access.md) |

--- a/plans/58-issue-with-setting-sources/plans/58-worker-project-mcp-access.md
+++ b/plans/58-issue-with-setting-sources/plans/58-worker-project-mcp-access.md
@@ -1,0 +1,403 @@
+# Worker Backend-Native Parity (Trusted Worker Posture)
+
+Branch: `58-issue-with-setting-sources`
+Plan Slug: `58-worker-project-mcp-access`
+Parent Issue: #58
+Created: 2026-05-12
+Updated: 2026-05-12 (rev. 3 after `reviews/review-plan-rev2-2026-05-12.md`; rev. 2 after `reviews/review-plan-2026-05-12.md`)
+Status: complete
+
+## Context
+
+Issue #58 reports that workers cannot reach project MCP servers (the trigger
+was `coderabbit` in `.mcp.json`). After review (`review-plan-2026-05-12.md`,
+including its Product Direction Addendum and Documentation Verification
+Addendum), the product framing is:
+
+> The orchestrator/supervisor is the restricted agent. Worker agents are
+> trusted execution agents and should have the same practical access the user
+> would get when launching the same backend manually in the project: normal
+> network posture, normal project/user configuration, and normal MCP access.
+
+This plan therefore is no longer scoped to "Claude MCP exception." It is
+scoped to "restore backend-native worker parity across all three backends,
+keeping the supervisor envelope curated, while expressing isolation as an
+explicit profile opt-in."
+
+A new worker-posture vocabulary makes the contract explicit:
+
+- **`trusted` (new default)** — workers get backend-native parity with a
+  manual run from the project worktree: normal project/user config, project
+  MCP servers, normal network posture for that backend, normal CLAUDE.md /
+  subagents / plugins discovery where applicable. Non-interactive
+  approval/permission knobs are still pinned so the worker does not stall
+  waiting for a human.
+- **`restricted` (profile opt-in)** — the current closed-by-default
+  isolation posture survives intact for callers who want it: `--setting-sources
+  user`, `--ignore-user-config`, no project MCP, etc. Selected per profile,
+  never by default for this plan's behavioral change.
+- **Supervisor** — always restricted. The supervisor envelope
+  (`src/claude/launcher.ts::buildClaudeSpawnArgs`) keeps its curated
+  `--strict-mcp-config --mcp-config`, `--setting-sources user`, `--tools`
+  allowlist, and `dontAsk` deny-by-default. Out of scope for #58.
+
+Worker safety contracts that must continue to hold under `trusted`:
+
+- `disableAllHooks: true` in the per-run settings file (issue #40, T5/T13;
+  user confirmation: keep pinned). Hooks are typically interactive surfaces
+  (notifications, prompts) and have no place in a non-interactive worker.
+- `permissions.defaultMode: "bypassPermissions"` in the per-run settings file
+  plus `--permission-mode bypassPermissions` on the spawn argv (issue #47;
+  required for non-interactive workers).
+- `--dangerously-skip-permissions` remains banned everywhere (#13 Decisions
+  7/21).
+- For Claude project MCP servers: workers cannot answer the project-MCP
+  approval prompt, so the per-run settings file pins
+  `enableAllProjectMcpServers: true`. (Profile-level opt-out lands later if
+  ever needed — Decision 12.)
+
+### Sources read
+
+- Issue #58 body.
+- `plans/58-issue-with-setting-sources/reviews/review-plan-2026-05-12.md`
+  (full review including both addenda).
+- `src/backend/claude.ts:50-84` — `CLAUDE_WORKER_SETTINGS_BODY`,
+  `prepareWorkerIsolation`, `start`, `resume`.
+- `src/backend/codex.ts:1-160` — codex argv shape; `sandboxArgs(codex_network)`.
+- `src/backend/cursor/sdk.ts:126-143` — `CursorAgentCreateOptions` /
+  `CursorAgentResumeOptions` shim; today it forwards only
+  `apiKey | model | local.cwd | agentId | name`.
+- `src/backend/cursor/runtime.ts:60-80` — runtime entry point and
+  pre-spawn failures.
+- `src/backend/runtime.ts:70-120` — `CliRuntime.buildStartInvocation()`
+  pre-bake path; calls `backend.start()` for a retry-invocation that may
+  never actually spawn (`src/orchestratorService.ts:973-1009`).
+- `src/claude/launcher.ts:540-597` — supervisor envelope (out of scope; only
+  referenced for parity reasoning).
+- `src/claude/discovery.ts:11-64` — `--setting-sources` is a required
+  detected surface; the value passed is not validated by discovery.
+- `src/__tests__/claudeWorkerIsolation.test.ts:14-100` — existing T5/T13/#47
+  worker isolation assertions.
+- `plans/47-claude-workers-lose-bypass-permissions-under-generated-settings/plans/47-claude-worker-bypass-permissions.md`
+  — Decisions 1/2/5 on the worker envelope.
+- `plans/40-make-tmux-status-and-remote-control-reliable-for-claude-orchestrator-supervisors/plans/40-orchestrator-status-hooks.md`
+  — Decisions 9/9b/26/T5/T13 on hook isolation.
+- `docs/development/mcp-tooling.md` — per-client MCP file map.
+- `docs/development/codex-backend.md` — `codex_network` semantics; `isolated`
+  default for this backend (issue #31).
+- `docs/development/cursor-backend.md` — Cursor SDK local-runtime contract.
+- Local Cursor SDK 1.0.12 type defs
+  (`node_modules/@cursor/sdk/dist/esm/options.d.ts`):
+  `LocalAgentOptions.settingSources?: SettingSource[]` with values
+  `"project" | "user" | "team" | "mdm" | "plugins" | "all"`;
+  `AgentOptions.mcpServers?: Record<string, McpServerConfig>`.
+- Local `codex exec --help` (codex-cli 0.130.0): `-c key=value`, `-p/--profile`,
+  `-s/--sandbox <read-only|workspace-write|danger-full-access>`,
+  `--add-dir`, `--skip-git-repo-check`, `--ignore-user-config`,
+  `--ignore-rules`, `--dangerously-bypass-approvals-and-sandbox`. No
+  `--config-file` or `--config-dir`.
+- Local `claude --help` (Claude Code 2.1.139) and
+  `cursor-agent --help` (2026.05.01-eea359f).
+- `.mcp.json`, `.cursor/mcp.json`, `.codex/config.toml` repo fixtures.
+- `AGENTS.md`, `CLAUDE.md`, `.agents/rules/node-typescript.md`,
+  `.agents/rules/mcp-tool-configs.md`.
+
+## Decisions
+
+| # | Decision | Choice | Rationale | Rejected Alternatives |
+|---|---|---|---|---|
+| 1 | Worker posture vocabulary | Add a `worker_posture: 'trusted' \| 'restricted'` field to `WorkerProfile` (and to the direct-mode `start_run` schema), defaulting to `'trusted'`. Each backend translates the posture to its own surface (Decisions 5/6/7). The supervisor stays restricted always. | Names the product contract the reviewer asked for ("trusted" / "manual-parity" vs "restricted"), and maps it consistently across three CLIs/SDKs that don't share one identical network switch. Operators no longer interpret "same access as a manual run" inconsistently per backend. | A single boolean `isolated` (rejected: ambiguous across backends, less self-documenting). Per-backend booleans (rejected: would proliferate over time as new backends land; one posture concept reused is cleaner). |
+| 2 | Default posture | `'trusted'` for new and existing profiles that don't set `worker_posture`. Backward-compat default for legacy run records: `'trusted'`. | The user's #58 reads as "workers should have full access" and the review's Product Direction Addendum confirms it. Defaulting to `'trusted'` aligns the product with the issue. | Defaulting to `'restricted'` (rejected: contradicts the explicit product direction). Refusing to load profiles without `worker_posture` (rejected: breaks existing profile manifests; the new field must be optional). |
+| 3 | Supervisor posture | Unchanged; supervisor envelope (`buildClaudeSpawnArgs`) is hard-coded restricted and never reads `worker_posture`. | Issue #58 says workers; review addendum says supervisor stays curated. Supervisor's `--strict-mcp-config --mcp-config <orchestrator-owned>`, `--tools` allowlist, and `dontAsk` deny-by-default are load-bearing for the tmux smoke contract and skill discovery. | Mapping `worker_posture` to supervisor too (rejected: widens blast radius, breaks supervisor invariants the harness relies on). |
+| 4 | Blast radius accepted for Claude `'trusted'` | We are explicitly opting Claude workers back into normal project/user/local Claude Code scope behavior — settings, subagents, plugins, MCP servers, and CLAUDE.md — not only MCP. | Documented behavior of Claude Code's `--setting-sources`: scopes apply to all listed surfaces. The reviewer's High finding asked this be an explicit decision rather than an incidental side effect. Workers are full-access, trusted-local processes, so loading project subagents/plugins/memory in a worker is correct and matches what a manual run sees. | "MCP-only via `--mcp-config <cwd>/.mcp.json`" (rejected: contradicts the trusted-worker product direction; would still leave subagents/plugins missing under trusted posture). Conditional broadening keyed on `.mcp.json` (rejected: same behavior split across MCP-having vs MCP-not-having projects, which the reviewer flagged as inconsistent). |
+| 5 | Claude `'trusted'` mapping | `--settings <per-run> --setting-sources user,project,local --permission-mode bypassPermissions`. Per-run settings body: `disableAllHooks: true`, `permissions.defaultMode: "bypassPermissions"`, `skipDangerousModePermissionPrompt: true`, **`enableAllProjectMcpServers: true`** (new), no `enabledMcpjsonServers` / `disabledMcpjsonServers` allowlists. | `user,project,local` mirrors Claude Code's documented precedence. CLI `--permission-mode` overrides settings-file values so project `permissionMode: "ask"` cannot stall the worker. `--settings <path>` overrides setting-sources merged keys so project hooks cannot run under workers. `enableAllProjectMcpServers: true` is required to avoid the project-MCP approval prompt that a non-interactive worker cannot answer (Claude docs on project-scoped MCP; user-confirmed). | Carrying through the user's saved per-project MCP approval state (rejected: requires reading and translating user state, differs per developer machine, less deterministic). Profile-level allowlist (rejected: postponed to Decision 12; no current caller; would add schema surface unused on day one). |
+| 6 | Codex `'trusted'` mapping | `--cd <cwd>` (start only — codex `exec resume` does not accept `--cd`; unchanged from today) + **drop** `--ignore-user-config` + `-c sandbox_mode="workspace-write"` + `-c sandbox_workspace_write.network_access=true`. Project `.codex/config.toml` continues to be discovered by codex automatically (trusted-project loader); we no longer suppress user config. Both `-c` overrides are accepted by **both** `codex exec` and `codex exec resume` per local 0.130.0 help (review rev. 2 F1). | Matches what a developer launching `codex exec` in the project would get for MCP, model, profile, and auth: codex layers user config under project config under CLI overrides. Network is enabled because trusted workers run real work (e.g. PR comments, `gh` calls); a developer running codex manually with `workspace-write` would expect the same with the standard `network_access = true` override. Codex MCP servers live in `mcp_servers.*` tables under the discovered config files, so removing `--ignore-user-config` plus letting project discovery happen is the whole config-side fix. Using `-c sandbox_mode="workspace-write"` instead of `--sandbox workspace-write` keeps `sandboxArgs()` shared between `start()` and `resume()`; `--sandbox` is start-only in codex-cli 0.130.0 and would break follow-ups. | `--sandbox workspace-write` (rejected: not accepted by `codex exec resume`; would force splitting start/resume argv builders, contradicting `src/backend/codex.ts:8-33` shared `sandboxArgs()`). Defaulting to no sandbox override at all (rejected: per-machine and non-deterministic across operators; loses the determinism gains of the issue #31 plan). Switching to `danger-full-access` (rejected: that's the equivalent of `--dangerously-skip-permissions`; banned in spirit). |
+| 7 | Cursor `'trusted'` mapping (revised after review rev. 2 F4) | Extend `CursorAgentCreateOptions` / `CursorAgentResumeOptions` shim (`src/backend/cursor/sdk.ts`) to include `local.settingSources` and `local.sandboxOptions`. For `'trusted'` runs, pass `local.settingSources: ['all']` so workers get full Cursor parity — `project`, `user`, `team`, `mdm`, and `plugins` settings layers — matching what a manual Cursor run on the same machine would load. Sandbox is left at SDK default unless a profile sets it. No `mcpServers` is forwarded by default (per SDK docs they don't persist across `Agent.resume()`; `settingSources` is the file-backed parity path). | Cursor SDK 1.0.12 (`node_modules/@cursor/sdk/dist/esm/options.d.ts`) defines `SettingSource = "project" \| "user" \| "team" \| "mdm" \| "plugins" \| "all"`. Manual Cursor runs honor `team` (organizational settings), `mdm` (managed-device settings), and `plugins`. Passing only `['project','user']` would silently exclude those layers and break the "manual parity" contract for orgs that use Cursor team/MDM features. `['all']` is the single SDK-documented value that means "everything ambient." | `['project','user']` (rejected: review rev. 2 F4 — drops team/MDM/plugins; not full parity). Switching to a `cursor-agent` CLI runtime (rejected: would add a second worker runtime alongside the SDK one; the SDK already exposes the needed surface). Passing inline `mcpServers` instead of `settingSources` (rejected: SDK doc warning about resume; would silently drift between start and resume). Enumerating `['project','user','team','mdm','plugins']` (rejected: brittle if Cursor SDK adds new sources later; `'all'` is the documented forward-compatible primitive). |
+| 8 | `'restricted'` mapping (opt-in) | Preserves today's behavior verbatim per backend. Claude: `--setting-sources user`, no `enableAllProjectMcpServers`. Codex: `--ignore-user-config`, current `codex_network` flags. Cursor: SDK adapter passes no `settingSources` (current behavior). | Lets callers who need closed-by-default keep it via a single profile field. No behavior change for opt-in callers. | A separate "restricted" code path per backend with new code (rejected: re-uses the existing implementations, just under a profile flag). |
+| 9 | Codex `codex_network` interaction (revised after review rev. 2 F3) | Decouple **config source** from **network posture** under `'trusted'`. `worker_posture` controls whether `--ignore-user-config` is emitted; `codex_network` controls only the sandbox/network argv. Concretely: under `'trusted'`, `--ignore-user-config` is **never** emitted regardless of `codex_network`. The sandbox argv is then `codex_network`-driven: absent → `-c sandbox_mode="workspace-write" -c sandbox_workspace_write.network_access=true` (Decision 6); explicit `'workspace'` → `-c sandbox_workspace_write.network_access=true` (no `--ignore-user-config`); explicit `'isolated'` → no `-c` overrides (codex defaults). Under `'restricted'`, today's argv shapes are preserved verbatim for backward compatibility: absent or `'isolated'` → `--ignore-user-config`; `'workspace'` → `--ignore-user-config -c sandbox_workspace_write.network_access=true`; `'user-config'` → no flags. Documented as a migration risk in `docs/development/codex-backend.md`: profiles that explicitly set `codex_network: 'workspace'` will now see user/project codex config under the new default trusted posture and must opt into `worker_posture: 'restricted'` if they relied on the old `--ignore-user-config` side effect. | Closes the review rev. 2 F3 hole: existing `'workspace'` profiles would otherwise still emit `--ignore-user-config` and silently miss the user MCP/config the trusted contract promises. Decoupling makes the contract single-axis: `worker_posture` = whose config loads; `codex_network` = sandbox/network shape. | Keeping `codex_network: 'workspace'` argv unchanged under trusted (rejected: hides user MCP from any caller that historically chose `'workspace'` for network, contradicting the trusted product direction). Mapping `codex_network` to imply a posture (rejected: re-couples the two axes and breaks #31's stable contract). |
+| 10 | Lifecycle telemetry placement — CLI backends (review Medium 3) | Add `WorkerInvocation.initialEvents?: ParsedBackendEvent[]` (or equivalent array of lifecycle event payloads). Claude and Codex backends populate this from `start()` / `resume()`. `ProcessManager.start()` (the single spawn site for CLI backends) flushes them into the run event stream **only when the spawn actually fires**. `CliRuntime.buildStartInvocation()` discards `initialEvents` on the pre-bake retry path. Cursor uses a different mechanism — see Decision 18. | Closes the review rev. 1 Medium 3 false-telemetry hole: `buildStartInvocation` calls `backend.start()` purely to pre-bake a retry invocation that may never run; emitting from inside `prepareWorkerIsolation` would record state for a never-spawned attempt. Spawn-time flush keeps the event ordering correct relative to `ProcessManager`'s `status: started` marker. | Dropping the telemetry (rejected: operators need to confirm at run time which posture and settings-sources a worker actually used; otherwise debug regresses). Emitting from the orchestrator service before spawn (rejected: spreads the spawn ordering invariant across two callers). Reusing this mechanism for Cursor (rejected: Cursor doesn't produce a `WorkerInvocation` and doesn't go through `ProcessManager.start()` — review rev. 2 F5). |
+| 11 | Diagnostics payload | One spawn-time event per worker: `{ type: 'lifecycle', payload: { state: 'worker_posture', backend, worker_posture, claude?: { setting_sources, enable_all_project_mcp_servers }, codex?: { ignore_user_config, sandbox, network_access }, cursor?: { setting_sources } } }`. Single event per spawn, per backend's own subset of fields. | Lets `get_run_events` answer "what did this worker actually see?" deterministically. Reuses the existing `lifecycle` event type so no contract/schema change is needed (per `.agents/rules/node-typescript.md` MCP contract rule). | Three distinct event types (rejected: schema bloat; `lifecycle.payload.state` already differentiates). Logging at `console.warn` level (rejected: invisible to non-interactive callers). |
+| 12 | Profile-level MCP allowlist for Claude | Out of scope for this plan. If a future caller needs per-server granularity (`enabledMcpjsonServers` / `disabledMcpjsonServers`), file a follow-up issue. | `enableAllProjectMcpServers: true` is the documented blanket primitive and matches the "trusted worker" contract. Per-server allowlisting has no current caller in this repo. | Adding the allowlist now (rejected: schema surface for no caller, premature abstraction; #47 Decision 4 set the same precedent). |
+| 13 | Codex audit acceptance phrasing (review Low) | Phrase Codex audit acceptance as "capture the codex config-loading surface, including whether any config-file/config-dir flag exists" — without expecting those flags. Local 0.130.0 confirmed they do not. | Matches the reviewer's Low; avoids future drift if codex CLI adds them later. | Hard-coding "no `--config-file`/`--config-dir`" (rejected: drift trap). |
+| 14 | #58 closure rule (review Medium 4) | This plan may land in stages, but **#58 closes only when all three backends ship the trusted posture and the verify gate passes**. If a backend has to be split into a follow-up issue, #58 stays open with a comment linking the follow-up. | Issue #58 explicitly says "all backends, not just claude." Avoids appearing to close the issue with a Claude-only fix that the reviewer flagged. | Closing #58 on Claude-only fix with codex/cursor opened as follow-ups (rejected: the issue's text is explicit). |
+| 15 | Final verify placement (review Medium 4 continued) | Move the single `pnpm verify` task to the **end** of the task list, after all backend implementations, audits if any, doc updates, and rule candidates. No intermediate `pnpm verify`. | A mid-plan verify is not a final gate. Keeping one verify at the end makes the gate authoritative. | Running `pnpm verify` after each backend (rejected: slower, doesn't materially de-risk versus the end-of-plan gate). |
+| 16 | Trust boundary docs (review High 2 and Medium "approval") | Add an explicit "Trust boundary" subsection to `docs/development/mcp-tooling.md`: enabling project MCP on Claude workers (and project codex MCP on codex workers) means trusting `.mcp.json` / `.codex/config.toml` command entries as executable local config that runs in the worker environment. Secret-bearing entries must keep using `scripts/mcp-secret-bridge.mjs`. | The reviewer's High 2 finding is correct: stdio MCP servers spawn at MCP init outside the model tool path. Workers were already trusted-local but readers should be told this explicitly. | Implicit ("workers were always trusted") (rejected: explicit documentation prevents future surprise). |
+| 17 | `worker_posture` persistence and follow-up inheritance (review rev. 2 F2) | Persist resolved `worker_posture` on `RunModelSettingsSchema` (sibling field to `codex_network`), backend-agnostic, default `null` for legacy records. Resolution rules: (a) `start_run` profile mode: posture comes from profile; profile + a direct `worker_posture` field is rejected with `INVALID_INPUT` (mirroring the existing `codex_network` direct-mode-only rule at `src/orchestratorService.ts:756-758`). (b) `start_run` direct mode: posture comes from the direct input, defaulting to `'trusted'` when absent. (c) `send_followup`: inherits `parent.meta.model_settings.worker_posture`. A `worker_posture` override on `send_followup` is rejected when the chain originated from profile mode (mirrors the `chainOriginatedFromProfileMode` check at `src/orchestratorService.ts:755-758`) and accepted in direct-mode chains. (d) Legacy parents with `worker_posture === null` are normalized to `'trusted'` on the child record at the same point `codex_network` is normalized for legacy parents (`src/orchestratorService.ts:813-821`). The child record's persisted posture must reflect the *effective* posture used at spawn, not the input shape, so `run_summary.model_settings.worker_posture` is always one of `'trusted' \| 'restricted'`. | Closes review rev. 2 F2's "underspecified persistence and inheritance" hole. Storing on `RunModelSettingsSchema` reuses the existing inheritance path (`src/orchestratorService.ts:794-808`) so `send_followup` already routes the value through the right merge function with one targeted addition. The profile/direct-mode rejection rule mirrors an already-shipped invariant (`codex_network` direct-mode-only) so operators do not need to learn a new mental model. Normalizing legacy `null` to `'trusted'` at child-write time, not read time, matches the issue #31 B2 pattern for `codex_network: null` → `'isolated'`. | Persisting posture on a separate sibling field outside `RunModelSettings` (rejected: doubles the inheritance plumbing; misses the existing legacy-normalization pattern). Defining `profile + worker_posture` precedence so the direct field wins (rejected: would diverge from the established `codex_network` precedent and let profile-mode runs silently drift from their manifest). Treating absence on `send_followup` as "reset to default" instead of "inherit from parent" (rejected: a `restricted` parent could silently spawn a `trusted` child on a follow-up that didn't intend to change posture). |
+| 18 | Cursor lifecycle telemetry path (review rev. 2 F5) | Cursor does not produce a `WorkerInvocation` and does not flow through `ProcessManager.start()` (`src/backend/cursor/runtime.ts:60-208`); the runtime appends events directly via `store.appendEvent()` (`src/backend/cursor/runtime.ts:288,351`). For Cursor, the `worker_posture` lifecycle event is appended by `CursorSdkRuntime.spawn()` **after** `Agent.create` / `Agent.resume` succeeds and **before** the first SDK message is appended to the run, using the same `store.appendEvent(runId, { type: 'lifecycle', payload: ... })` channel as today's cursor lifecycle events. The append is wrapped in the existing pre-spawn-failure guard (`src/backend/cursor/runtime.ts:60-80`) so a failed `Agent.create` does not emit a `worker_posture` event for a worker that never started. | Closes review rev. 2 F5: the CLI-backend `initialEvents` mechanism cannot cover Cursor because the SDK runtime has no `WorkerInvocation`. Using `store.appendEvent()` directly matches the existing Cursor event-append pattern at `runtime.ts:288,351` and gates on actual SDK spawn success so we get the same "no false telemetry on never-spawned runs" property the CLI design has. | Forcing Cursor through a synthetic `WorkerInvocation` and `ProcessManager.start()` (rejected: would re-architect the in-process SDK runtime for a single telemetry event). Emitting before `Agent.create` resolves (rejected: SDK construction can fail with `WORKER_BINARY_MISSING`/`SPAWN_FAILED`; telemetry must follow the same "only on actual spawn" rule as CLI backends). |
+
+## Open Human Decisions
+
+None — the four product questions raised by this review were answered:
+keep `disableAllHooks: true` pinned; drop `--ignore-user-config` + enable
+workspace network for codex; extend cursor SDK shim with `settingSources`;
+Claude project-MCP approval via `enableAllProjectMcpServers: true`.
+
+## Reviewer Questions
+
+To be revisited after implementation review. Review mappings:
+
+- **Rev. 1 review** (`reviews/review-plan-2026-05-12.md`):
+  Decision 4 (High 1 + High 6), Decision 16 (High 2 + Medium "approval"),
+  Decision 10 (Medium 3), Decisions 14+15 (Medium 4), Decision 13 (Low),
+  Decision 6 (High 7 — but see rev. 2 F1 revision), Decision 7 (High 8 — but
+  see rev. 2 F4 revision), Decision 11 (Medium "network access posture
+  vocabulary").
+- **Rev. 2 review** (`reviews/review-plan-rev2-2026-05-12.md`):
+  Decisions 6 + 9 + Risk 14 + T-Codex-1 (High F1 — codex resume argv
+  compatibility), Decision 17 + Risks 16/19 + T-Persist-1 + T-Persist-2
+  (High F2 — posture persistence and follow-up inheritance), Decision 9 +
+  Risk 15 + T-Docs (Medium F3 — explicit `codex_network: "workspace"` was
+  still suppressing user config), Decision 7 + Risk 17 + T-Cursor-1
+  (Medium F4 — Cursor `['all']` for full parity), Decision 18 + Risk 18 +
+  T-Cursor-2 (Medium F5 — Cursor lifecycle telemetry path), T-Profile-1
+  scope expansion (Low F6 — `upsert_worker_profile`, `list_worker_profiles`,
+  MCP tool descriptions, profile rendering).
+
+## Scope
+
+### In Scope
+
+- `WorkerProfile` and the full profile management surface (review rev. 2 F6):
+  add optional `worker_posture: 'trusted' | 'restricted'` field; default
+  `'trusted'`; valid for all backends; preserve backward compat for manifests
+  that omit it. Wire through `WorkerProfile`, `UpsertWorkerProfileInputSchema`
+  (`src/contract.ts:439-485`), `workerProfileFromUpsert()` and
+  `formatValidProfile()` (`src/orchestratorService.ts:2079-2115`), the MCP
+  tool descriptions in `src/mcpTools.ts:65-82`, and `start_run` /
+  `send_followup` direct-mode schemas. `upsert_worker_profile` and
+  `list_worker_profiles` round-trip the field.
+- `RunModelSettingsSchema` (`src/contract.ts:260-265`): add `worker_posture`
+  sibling to `codex_network`; legacy `null` tolerated on read, normalized to
+  a concrete posture on child-record write (review rev. 2 F2; Decision 17).
+- `sendFollowup` (`src/orchestratorService.ts:740-822`) inherits parent's
+  posture; rejects `worker_posture` overrides on profile-mode chains,
+  accepts them on direct-mode chains (Decision 17).
+- `src/backend/claude.ts::prepareWorkerIsolation` + `CLAUDE_WORKER_SETTINGS_BODY`:
+  branch on `worker_posture`. Under `'trusted'`: emit `--setting-sources
+  user,project,local` and add `enableAllProjectMcpServers: true` to the
+  per-run settings body. Under `'restricted'`: today's `--setting-sources user`
+  and current body. Both postures retain `disableAllHooks: true`, the bypass
+  permission keys, and the CLI `--permission-mode bypassPermissions` flag.
+- `src/backend/codex.ts::sandboxArgs` (`src/backend/codex.ts:144-160`) and
+  the orchestrator-side default for `codex_network`: decouple config-source
+  from sandbox/network per Decision 9. Under `'trusted'`, never emit
+  `--ignore-user-config` regardless of `codex_network`; emit
+  `-c sandbox_mode="workspace-write"` and
+  `-c sandbox_workspace_write.network_access=true` when `codex_network` is
+  absent. Under `'restricted'`, preserve today's argv shapes verbatim. All
+  emitted argv must be accepted by **both** `codex exec` and `codex exec
+  resume` (review rev. 2 F1) — never `--sandbox` or `--cd` in shared
+  helpers. Explicit `codex_network` values keep their meaning within their
+  posture (Decision 9).
+- `src/backend/cursor/sdk.ts`: extend `CursorAgentCreateOptions` and
+  `CursorAgentResumeOptions` to include `local.settingSources?: SettingSource[]`
+  and `local.sandboxOptions?: { enabled: boolean }` matching the SDK 1.0.12
+  shape. `src/backend/cursor/runtime.ts`: for `'trusted'` workers, pass
+  `local.settingSources: ['all']` on `Agent.create` and `Agent.resume`
+  (review rev. 2 F4 — full Cursor parity, not just project+user).
+- `WorkerInvocation`: add optional `initialEvents` array (CLI backends only —
+  Claude and Codex). `ProcessManager.start()` flushes them at spawn into the
+  existing event stream; `CliRuntime.buildStartInvocation()` discards them
+  (pre-bake path). Cursor uses a separate path (Decision 18).
+- Claude's and Codex's `start()` / `resume()` populates `initialEvents` with
+  one spawn-time `{ type: 'lifecycle', payload: { state: 'worker_posture', ... } }`
+  per Decision 11.
+- Cursor emits the same lifecycle event via `store.appendEvent()` directly
+  from `CursorSdkRuntime.spawn()` after `Agent.create`/`Agent.resume` succeeds
+  (Decision 18; review rev. 2 F5). No `initialEvents` field on the cursor
+  runtime path.
+- Tests (one focused set per backend; see Acceptance Criteria below). Adds
+  fixtures for hostile project `.claude/settings.json` (hooks enabled,
+  `permissionMode: "ask"`) and a sample `.mcp.json`.
+- Documentation:
+  - `src/backend/claude.ts`'s `CLAUDE_WORKER_SETTINGS_BODY` doc comment
+    documents `enableAllProjectMcpServers: true` and the `trusted`/`restricted`
+    branching.
+  - `docs/development/mcp-tooling.md` gains two new subsections:
+    "Workers and project MCP servers" (per-backend table) and "Trust boundary"
+    (Decision 16).
+  - `docs/development/codex-backend.md` updates `codex_network` defaults
+    table to reflect Decision 9.
+  - `docs/development/cursor-backend.md` documents the new SDK
+    `settingSources` wiring.
+- Rules under `.agents/rules/`: rule candidates listed below.
+
+### Out Of Scope
+
+- Supervisor envelope changes (`src/claude/launcher.ts`,
+  `src/claude/permission.ts`) — Decision 3.
+- Per-server Claude MCP allowlists (`enabledMcpjsonServers` /
+  `disabledMcpjsonServers`) — Decision 12.
+- Cursor `mcpServers` inline forwarding — Decision 7 (resume-safety reason).
+- `cursor-agent` CLI worker runtime — Decision 7 (SDK already exposes the
+  needed surface).
+- `--strict-mcp-config` adoption on workers — supervisor-only by design.
+- Changing the `--dangerously-skip-permissions` ban (#13 Decisions 7/21).
+- New MCP tool surface, MCP contract changes, or schema additions beyond the
+  `worker_posture` profile field and the `initialEvents` invocation field.
+
+## Risks And Edge Cases
+
+| # | Scenario | Mitigation | Covered By |
+|---|---|---|---|
+| 1 | Project `.claude/settings.json` defines hooks; broadened sources cause them to load and fire under a worker. | `disableAllHooks: true` in `--settings <per-run>` takes precedence over setting-sources merge. New regression test asserts hooks stay off with a hostile project fixture loaded. | T-Claude-3 |
+| 2 | Project `.claude/settings.json` defines `permissionMode: "ask"` or `"plan"`; worker stalls awaiting an interactive prompt. | CLI `--permission-mode bypassPermissions` overrides settings-file values per documented Claude Code precedence. Regression test asserts the CLI flag is emitted and the resulting worker init reports `permissionMode: "bypassPermissions"`. | T-Claude-3 |
+| 3 | Project `.mcp.json` requires approval that workers cannot answer. | `enableAllProjectMcpServers: true` in the per-run settings file. Test asserts it is on disk. | T-Claude-1 / T-Claude-3 |
+| 4 | Project `.mcp.json` stdio entry executes a local command at MCP init outside the model tool path; secret-bearing entries leak credentials. | `docs/development/mcp-tooling.md` "Trust boundary" subsection states secret-bearing entries must keep using `scripts/mcp-secret-bridge.mjs`. The bridge is unchanged; no new secret-handling code. | T-Docs |
+| 5 | Codex worker accidentally inherits a user `~/.codex/config.toml` that disables network or sets a different sandbox; trusted worker now stricter than intended. | Decision 6 explicitly sets `--sandbox workspace-write` and `-c sandbox_workspace_write.network_access=true` on the spawn argv. CLI overrides win in codex precedence, so user config can't quietly downshift the worker. | T-Codex-1 |
+| 6 | Codex worker inherits user MCP servers that conflict with project MCP servers (same name, different command). | Codex's documented precedence is "CLI overrides > profile > project trusted > user > system > default." Project config wins over user config; documented behavior. Tested in T-Codex-2. | T-Codex-2 |
+| 7 | Cursor `Agent.resume` after a `'trusted'` start drops the `settingSources` (SDK docs warn about inline state not persisting). | We pass `settingSources` on **both** `Agent.create` and `Agent.resume` so file-backed ambient settings reload. Test asserts both paths receive `settingSources: ['project', 'user']`. | T-Cursor-2 |
+| 8 | A legacy run record without `worker_posture` is replayed (e.g. resumed across upgrade). | Default resolution applies `'trusted'`. Test exercises a meta record with no `worker_posture` field. | T-Profile-2 |
+| 9 | Operator misreads the new defaults and assumes workers are still isolated. | Documented in `docs/development/mcp-tooling.md`, `codex-backend.md`, and `cursor-backend.md`. `worker_posture` event is emitted at spawn (Decision 11) so `get_run_events` shows the chosen posture per run. | T-Telemetry, T-Docs |
+| 10 | `WorkerInvocation.initialEvents` populated on a `buildStartInvocation()` pre-bake retry that never spawns, recording false telemetry. | `ProcessManager.start()` is the single flusher; `CliRuntime.buildStartInvocation()` strips `initialEvents` from the returned invocation. Test asserts the pre-bake path emits zero spawn-time events. | T-Telemetry |
+| 11 | `--setting-sources user,project,local` rejected by an older Claude CLI in the wild. | Plan pins to the discovered surface; `discoverClaudeSurface` reports `setting_sources_flag` presence already. `local` has been documented since the flag was introduced. If a future Claude version drops `local`, document the regression and adjust. Not gated. | T-Docs |
+| 12 | `WorkerProfile` consumers that read the manifest as strict-shaped types break on the new optional field. | Field is optional; schema parsing must accept manifests without `worker_posture`. Test loads an existing-shape manifest and asserts it resolves to `'trusted'`. | T-Profile-1 |
+| 13 | The plan ships Claude-only and #58 closes prematurely. | Decision 14: #58 closure requires all three backends to ship `'trusted'`. Plan tasks T-Codex-* and T-Cursor-* are in scope, not deferred to follow-ups. | Decision 14 |
+| 14 | Codex resume invocation rejects argv produced by the shared `sandboxArgs()` helper (review rev. 2 F1). | Decision 6 forbids `--sandbox` and `--cd` in `sandboxArgs()` output and uses `-c` overrides that both `codex exec` and `codex exec resume` accept on codex-cli 0.130.0. T-Codex-1 asserts resume argv shape across the full posture × codex_network matrix. | T-Codex-1, Decision 6 |
+| 15 | Existing `codex_network: 'workspace'` profile silently misses user MCP under trusted (review rev. 2 F3). | Decision 9 redefines: under trusted, `--ignore-user-config` is never emitted regardless of `codex_network`. Documented as a migration risk in `docs/development/codex-backend.md` so operators who relied on the old `--ignore-user-config` side effect know to set `worker_posture: 'restricted'`. | T-Codex-1, T-Docs |
+| 16 | `worker_posture` not persisted; a restricted parent silently spawns a trusted child on follow-up (review rev. 2 F2). | Decision 17 + T-Persist-1 + T-Persist-2: posture lands on `RunModelSettingsSchema`, inherits like `codex_network`, and rejects `profile + worker_posture` mode-mixing on both `start_run` and `send_followup`. | T-Persist-1, T-Persist-2 |
+| 17 | Cursor trusted workers miss team/MDM/plugins settings layers (review rev. 2 F4). | Decision 7 + T-Cursor-1 pass `local.settingSources: ['all']`, the SDK-documented forward-compatible primitive that includes every ambient source. | T-Cursor-1 |
+| 18 | Cursor `worker_posture` telemetry never reaches `get_run_events` because `WorkerInvocation.initialEvents` is CLI-only (review rev. 2 F5). | Decision 18 + T-Cursor-2: Cursor emits the lifecycle event via `store.appendEvent()` directly from `CursorSdkRuntime.spawn()` after SDK spawn succeeds. Pre-spawn failures emit zero events. | T-Cursor-2 |
+| 19 | Direct-mode follow-up override of `worker_posture` allowed on a chain that originated from profile mode, drifting silently from the profile's manifest. | Decision 17(c): `sendFollowup` rejects a `worker_posture` override with `INVALID_INPUT` when `chainOriginatedFromProfileMode(parent.meta)` is true, mirroring the existing `codex_network` rule at `src/orchestratorService.ts:756-758`. | T-Persist-2 |
+
+## Implementation Tasks
+
+| Task ID | Title | Depends On | Status | Acceptance Criteria |
+|---|---|---|---|---|
+| T-Profile-1 | Add optional `worker_posture` field across all profile and direct-mode surfaces (review rev. 2 F6) | — | pending | New field is optional, accepts `'trusted' \| 'restricted'`, defaults to `'trusted'` when absent, accepted by every profile/direct-mode surface: `WorkerProfile` schema; `UpsertWorkerProfileInputSchema` (`src/contract.ts:439-485`); `workerProfileFromUpsert()` (`src/orchestratorService.ts:2079`); `formatValidProfile()` (`src/orchestratorService.ts:2094`) so `list_worker_profiles` exposes the field; `StartRunInputSchema` and `SendFollowupInputSchema` direct-mode shapes; MCP tool descriptions in `src/mcpTools.ts:65-82` and any supervisor profile-rendering text. Validation rejects other strings with a clear error. Round-trip test: `upsert_worker_profile` writes a manifest with `worker_posture`, `list_worker_profiles` returns it verbatim, `start_run` profile mode picks it up. Existing test profiles without the field continue to load. |
+| T-Profile-2 | Backward-compat default resolution | T-Profile-1 | pending | A run record / meta entry without `worker_posture` resolves to `'trusted'` everywhere it's read. Unit test covers a legacy meta record (no field) and a fresh meta record. Also covers a legacy `RunModelSettings` with `worker_posture: null` flowing through `sendFollowup` inheritance. |
+| T-Persist-1 | Persist resolved `worker_posture` on `RunModelSettingsSchema` (review rev. 2 F2) | T-Profile-1 | pending | `RunModelSettingsSchema` (`src/contract.ts:260-265`) gains `worker_posture: WorkerPostureSchema.nullable().optional().default(null)`. `defaultRunModelSettings` defaults to `null`. `modelSettingsForBackend()` and `validateInheritedModelSettingsForBackend()` propagate the value. `start_run` writes the *effective* resolved posture (never `null`) into `meta.model_settings.worker_posture` at the same place `codex_network` is normalized for codex (`src/orchestratorService.ts:813-821`). Legacy meta records with `null` are tolerated for read paths but child records always persist a non-null value. |
+| T-Persist-2 | `send_followup` inherits posture; mode-mixing rejected (review rev. 2 F2) | T-Persist-1 | pending | `sendFollowup` (`src/orchestratorService.ts:740-822`): (a) inherits `parent.meta.model_settings.worker_posture` when the follow-up does not pass `worker_posture`; (b) when the follow-up passes `worker_posture` and `chainOriginatedFromProfileMode(parent.meta)` is true, returns `INVALID_INPUT` with a message mirroring the existing `codex_network` rejection at `src/orchestratorService.ts:756-758`; (c) when chain is direct-mode, the follow-up override is accepted and persisted on the child. `start_run` rejects `profile + worker_posture` in the same way `start_run` rejects `profile + codex_network` today (`src/contract.ts:361-390` schema-level `superRefine`). Tests cover: profile start, direct start, profile-mode follow-up (with and without override attempt), direct follow-up override, legacy parent (null posture). |
+| T-Inv-1 | Add `WorkerInvocation.initialEvents?: ParsedBackendEvent[]` (or equivalent) | — | pending | Field is optional; existing call sites unchanged when absent. `WorkerInvocation` types updated, no other public-contract changes. |
+| T-Inv-2 | `ProcessManager.start()` flushes `initialEvents` at spawn time | T-Inv-1 | pending | Events appear in `get_run_events` ordered before the next event written by the spawned process. `CliRuntime.buildStartInvocation()` strips `initialEvents` from the returned retry invocation. Unit test asserts: (a) normal `start()` emits events; (b) `buildStartInvocation()` path returns an invocation with `initialEvents` unset; (c) resume path emits events. |
+| T-Claude-1 | Implement Claude `trusted` mapping in `prepareWorkerIsolation` + body | T-Profile-1, T-Profile-2, T-Inv-1 | pending | Under `'trusted'`: argv includes `--setting-sources user,project,local`, `--permission-mode bypassPermissions`, `--settings <per-run-path>`. Per-run settings body deep-equals `{ disableAllHooks: true, permissions: { defaultMode: 'bypassPermissions' }, skipDangerousModePermissionPrompt: true, enableAllProjectMcpServers: true }`. Under `'restricted'`: argv and body match today's behavior exactly. Both `start()` and `resume()` paths exercise the new branching. |
+| T-Claude-2 | Populate `initialEvents` with the Claude `worker_posture` lifecycle event | T-Claude-1, T-Inv-2 | pending | The event payload carries `state: 'worker_posture'`, `backend: 'claude'`, `worker_posture`, `claude.setting_sources`, `claude.enable_all_project_mcp_servers`. Test asserts the event flows through `ProcessManager.start()` only on the actual-spawn path. |
+| T-Claude-3 | Safety-contract regression test with hostile project fixture | T-Claude-1 | pending | Fixture: `cwd/.mcp.json` (minimal valid) and `cwd/.claude/settings.json` with `disableAllHooks: false`, `permissions.defaultMode: "ask"`, and a synthetic `hooks.PreToolUse` block. Trusted worker still emits `--permission-mode bypassPermissions` and writes the per-run settings with the four required keys (incl. `enableAllProjectMcpServers: true`). Test asserts the on-disk per-run file body and the spawn argv. |
+| T-Codex-1 | Implement Codex `trusted` mapping in `sandboxArgs` + default resolver (review rev. 2 F1, F3) | T-Profile-1, T-Profile-2, T-Persist-1, T-Inv-1 | pending | `sandboxArgs()` (`src/backend/codex.ts:144-160`) gains a `worker_posture` parameter and decouples config-source from sandbox/network per Decision 9. Argv contracts that must hold under **both** `start()` and `resume()` (shared helper): **trusted + absent** → `-c sandbox_mode="workspace-write" -c sandbox_workspace_write.network_access=true`, no `--ignore-user-config`. **trusted + 'workspace'** → `-c sandbox_workspace_write.network_access=true`, no `--ignore-user-config`. **trusted + 'isolated'** → no flags, no `--ignore-user-config`. **trusted + 'user-config'** → no flags, no `--ignore-user-config`. **restricted + absent or 'isolated'** → `--ignore-user-config` (today's behavior). **restricted + 'workspace'** → `--ignore-user-config -c sandbox_workspace_write.network_access=true` (today's behavior). **restricted + 'user-config'** → no flags (today's behavior). Critical resume-safety guard: argv emitted under any combination above MUST be accepted by `codex exec resume` (no `--sandbox`, no `--cd`). Test asserts argv shape on both `start()` and `resume()` invocations for every cell of the (`worker_posture` × `codex_network`) matrix. |
+| T-Codex-2 | Populate `initialEvents` with the Codex `worker_posture` lifecycle event | T-Codex-1, T-Inv-2 | pending | Event payload carries `state: 'worker_posture'`, `backend: 'codex'`, `worker_posture`, `codex.ignore_user_config`, `codex.sandbox`, `codex.network_access`. Test asserts on the actual-spawn path. |
+| T-Cursor-1 | Extend Cursor SDK shim with `local.settingSources` and `local.sandboxOptions` (review rev. 2 F4) | T-Profile-1, T-Profile-2, T-Persist-1 | pending | `CursorAgentCreateOptions` and `CursorAgentResumeOptions` in `src/backend/cursor/sdk.ts:126-143` accept `local.settingSources?: SettingSource[]` (`"project" \| "user" \| "team" \| "mdm" \| "plugins" \| "all"`) and `local.sandboxOptions?: { enabled: boolean }`. `CursorSdkRuntime.spawn()` forwards them to `Agent.create` / `Agent.resume`. **Trusted runs pass `local.settingSources: ['all']`** (full Cursor parity — project, user, team, MDM, plugins). Restricted runs omit the field (today's behavior). Both create and resume paths exercised; both received the same `settingSources` argument so resume parity holds. |
+| T-Cursor-2 | Cursor-specific `worker_posture` lifecycle event via `store.appendEvent` (review rev. 2 F5) | T-Cursor-1 | pending | `CursorSdkRuntime.spawn()` calls `store.appendEvent(runId, { type: 'lifecycle', payload: { state: 'worker_posture', backend: 'cursor', worker_posture, cursor: { setting_sources } } })` **after** `Agent.create` / `Agent.resume` resolves successfully and **before** the first SDK stream message is appended (Decision 18). Pre-spawn failures (`WORKER_BINARY_MISSING`, `SPAWN_FAILED`) emit no `worker_posture` event. Test asserts: (a) successful create path emits one `worker_posture` event ordered before any backend stream event; (b) successful resume path emits one event; (c) pre-spawn failure path emits zero `worker_posture` events. Asserted via the run event log returned by `get_run_events`, not just by inspecting adapter call args. |
+| T-Telemetry | Spawn-time telemetry plumbing tested in isolation | T-Inv-2 | pending | Unit test: a backend whose `start()` returns `initialEvents` flushes them through `ProcessManager.start()` once per actual spawn, never on `buildStartInvocation()` pre-bake. Covers the review Medium 3 hole. |
+| T-Codex-Audit | Capture codex config-loading surface (review Low) | T-Codex-1 | pending | Plan execution log records the codex 0.130.0 `--help` surface, names the absence of `--config-file`/`--config-dir`, and confirms project `.codex/config.toml` is loaded by codex's own discovery when `--ignore-user-config` is removed. Phrased per Decision 13 (not gated on flags that don't exist). |
+| T-Docs | Update docs | T-Claude-1, T-Codex-1, T-Cursor-1 | pending | `docs/development/mcp-tooling.md`: new "Workers and project MCP servers" subsection with per-backend table and the "Trust boundary" subsection (Decision 16). `docs/development/codex-backend.md`: updated `codex_network` defaults table reflecting Decision 9. `docs/development/cursor-backend.md`: `settingSources` wiring documented. `src/backend/claude.ts`'s `CLAUDE_WORKER_SETTINGS_BODY` doc comment documents `enableAllProjectMcpServers` and the `'trusted'`/`'restricted'` branching. |
+| T-Rules | Capture rule candidates under `.agents/rules/` | T-Claude-1, T-Codex-1, T-Cursor-1, T-Docs | pending | Up to two new rule files under `.agents/rules/` per the Rule Candidates table below. Linked from the workspace projection regenerator (`scripts/sync-ai-workspace.mjs`); regeneration committed alongside if outputs differ. |
+| T-Verify | Single `pnpm verify` end-to-end gate | all above | pending | `pnpm verify` exits zero on the final state of the branch. Evidence (subcommand summaries) captured in the plan execution log. This is the final task per Decision 15. |
+
+## Rule Candidates
+
+| # | Candidate | Scope | Create After |
+|---|---|---|---|
+| 1 | "Workers default to backend-native parity (`worker_posture: 'trusted'`). The supervisor envelope is hard-restricted and must not read `worker_posture`. Isolation is profile-opt-in via `worker_posture: 'restricted'`." | `.agents/rules/worker-posture.md` | After T-Cursor-1 lands so all three backends honor the field. |
+| 2 | "Worker safety contracts (`disableAllHooks: true`, `bypassPermissions`, no `--dangerously-skip-permissions`) hold under both postures; project settings cannot override them via setting-sources merging." | `.agents/rules/worker-safety.md` | After T-Claude-3 lands the regression coverage. |
+
+## Quality Gates
+
+- [ ] `pnpm build` passes on the branch (subsumed by T-Verify).
+- [ ] `pnpm test` passes on the branch (subsumed by T-Verify).
+- [ ] `pnpm verify` passes on the branch as the final gate (T-Verify).
+- [ ] `.agents/rules/node-typescript.md` followed (no new deps; existing
+      package scripts; TypeScript strictness preserved).
+- [ ] `.agents/rules/mcp-tool-configs.md` followed (no real credentials in
+      repo files; MCP contract: no schema additions beyond the optional
+      `worker_posture` field and the optional `initialEvents` invocation
+      field).
+- [ ] `scripts/sync-ai-workspace.mjs` ran clean (if rule files changed, the
+      `.claude/rules/` projection is regenerated and committed in the same
+      change).
+- [ ] Plan execution log contains evidence quotes for each acceptance
+      criterion.
+- [ ] #58 closure rule observed: all three backends ship `'trusted'`
+      mappings, **or** #58 stays open with comments linking the
+      backend-specific follow-up issues. No premature close.
+
+## Execution Log
+
+### T-Profile-1: Add optional `worker_posture` to profile + direct-mode schemas
+- **Status:** complete
+- **Evidence:** `src/contract.ts` (`WorkerPostureSchema`, plus `worker_posture` added to `RunModelSettingsSchema`, `StartRunInputSchema` + superRefine rejection, `SendFollowupInputSchema`, `UpsertWorkerProfileInputSchema`); `src/harness/capabilities.ts` (added to `WorkerProfileSchema`); `src/orchestratorService.ts` (`parseProfileModelSettings`, `workerProfileFromUpsert`, `formatValidProfile`); `src/mcpTools.ts` (descriptions on `start_run`, `upsert_worker_profile`, `send_followup`). Round-trip covered by integration tests at `src/__tests__/integration/orchestrator.test.ts`.
+- **Notes:** Strict-shape `WorkerProfileSchema` accepted the optional addition without breaking existing manifests.
+
+### T-Profile-2: Backward-compat default resolution
+- **Status:** complete
+- **Evidence:** `src/orchestratorService.ts::modelSettingsForBackend` resolves absent posture to `'trusted'`; `sendFollowup` normalizes legacy null on child write at the `persistedSettings` site (sibling of issue #31 B2 normalization for codex_network). `src/__tests__/claudeWorkerIsolation.test.ts` "legacy model_settings with worker_posture: null defaults to trusted" passes.
+- **Notes:** Legacy `RunModelSettings.worker_posture === null` flows through `validateInheritedModelSettingsForBackend` untouched; the new normalization in `sendFollowup` is the single write-time boundary.
+
+### T-Persist-1: Persist resolved `worker_posture` on `RunModelSettingsSchema`
+- **Status:** complete
+- **Evidence:** `src/contract.ts:260-275` adds `worker_posture: WorkerPostureSchema.nullable().optional().default(null)` and updates `defaultRunModelSettings`. `src/runStore.ts:174-180` fallback literal updated. Integration test assertion at `src/__tests__/integration/orchestrator.test.ts:265-272` confirms `run_summary.model_settings.worker_posture` flows through.
+- **Notes:** Public schema additive; legacy meta records load as `worker_posture: null` and are normalized to a concrete value on the next child write.
+
+### T-Persist-2: `send_followup` inherits posture; mode-mixing rejected
+- **Status:** complete
+- **Evidence:** `src/orchestratorService.ts::sendFollowup` adds the inheritance branch (`inheritedWorkerPosture` from parent meta) and the new `INVALID_INPUT` rejection at the same point that rejects `codex_network` overrides on profile-mode chains. `StartRunInputSchema.superRefine` now lists `worker_posture` alongside `codex_network` in the profile-mode mixing rejection. Integration tests confirm both branches (`orchestrator.test.ts` "passes model selections to workers..." + "issue #31 (T9 / OD2=B): start_run profile + codex_network is rejected as INVALID_INPUT" updated regex).
+- **Notes:** Mirrors the existing `codex_network` mode-mixing pattern exactly.
+
+### T-Inv-1: Add `WorkerInvocation.initialEvents` field
+- **Status:** complete
+- **Evidence:** `src/backend/WorkerBackend.ts:23-72` — optional `initialEvents?: Omit<WorkerEvent, 'seq' | 'ts'>[]`.
+- **Notes:** Field is optional; existing call sites unchanged when absent.
+
+### T-Inv-2: `ProcessManager.start()` flushes `initialEvents` at spawn
+- **Status:** complete
+- **Evidence:** `src/processManager.ts:240-249` flushes initialEvents through `appendEventBuffered` before the `status: started` marker. `src/backend/runtime.ts:111-118` strips `initialEvents` on the pre-bake retry path. Test at `src/__tests__/processManager.test.ts` "flushes WorkerInvocation.initialEvents before the status:started lifecycle marker on actual spawn" passes.
+- **Notes:** Buffered-append path means D-COR retry interceptor still discards the events on a `retry_with_start` outcome (matches existing buffer behavior).
+
+### T-Claude-1: Implement Claude `trusted` mapping
+- **Status:** complete
+- **Evidence:** `src/backend/claude.ts:50-128` — new `CLAUDE_TRUSTED_WORKER_SETTINGS_BODY` constant, `prepareWorkerIsolation` branches on `worker_posture`, both `start()` and `resume()` exercise the new code. Tests in `src/__tests__/claudeWorkerIsolation.test.ts` under "trusted posture" and "restricted posture" describe blocks pass.
+- **Notes:** Trusted posture emits `--setting-sources user,project,local`; restricted preserves `--setting-sources user`. Per-run settings body for trusted adds `enableAllProjectMcpServers: true`.
+
+### T-Claude-2: Claude `worker_posture` lifecycle event
+- **Status:** complete
+- **Evidence:** `src/backend/claude.ts::prepareWorkerIsolation` returns `initialEvents` carrying `{ state: 'worker_posture', backend: 'claude', worker_posture, claude: { setting_sources, enable_all_project_mcp_servers } }`. Test "Claude worker isolation — telemetry" describe block covers both postures.
+- **Notes:** Legacy/no-runId path returns `initialEvents: []`; the test asserts the field stays undefined on the legacy invocation.
+
+### T-Claude-3: Hostile project fixture regression
+- **Status:** complete
+- **Evidence:** `src/__tests__/claudeWorkerIsolation.test.ts` "Claude worker isolation — hostile project fixture (issue #58 T-Claude-3)" creates `cwd/.mcp.json` and `cwd/.claude/settings.json` with hooks/permissionMode=ask; asserts trusted worker still pins `disableAllHooks: true`, `bypassPermissions`, and `enableAllProjectMcpServers: true` on disk and emits CLI `--permission-mode bypassPermissions`.
+- **Notes:** No live Claude binary required; wire-contract assertion holds under documented Claude Code precedence.
+
+### T-Codex-1: Implement Codex `trusted` mapping
+- **Status:** complete
+- **Evidence:** `src/backend/codex.ts::sandboxArgs` rewritten to decouple `worker_posture` from `codex_network` per Decision 9. Trusted never emits `--ignore-user-config`. Uses `-c sandbox_mode="workspace-write"` and `-c sandbox_workspace_write.network_access=true` (resume-safe). Test "trusted posture: codex_network drives sandbox argv via -c overrides, no --ignore-user-config and no --sandbox" covers the full matrix, including explicit `resume()` assertions that `--sandbox` and `--cd` never appear.
+- **Notes:** No `--sandbox` or `--cd` in shared helper output; codex-cli 0.130.0 `codex exec resume --help` confirmed both flags absent.
+
+### T-Codex-2: Codex `worker_posture` lifecycle event
+- **Status:** complete
+- **Evidence:** `src/backend/codex.ts::posturEvent` synthesizes the lifecycle event from resolved argv. Both `start()` and `resume()` populate `initialEvents`. Test "codex backend populates initialEvents with a worker_posture lifecycle event" asserts payload shape on both trusted and restricted.
+- **Notes:** Event payload carries `codex.ignore_user_config`, `codex.sandbox`, `codex.network_access`, and `codex.codex_network`.
+
+### T-Cursor-1: Extend Cursor SDK shim with settingSources / sandboxOptions
+- **Status:** complete
+- **Evidence:** `src/backend/cursor/sdk.ts` — added `CursorSettingSource` union and extended `CursorAgentCreateOptions` / `CursorAgentResumeOptions` to include `local.settingSources` and `local.sandboxOptions`. `src/backend/cursor/runtime.ts::spawn` forwards `local.settingSources: ['all']` under trusted; omits under restricted. Test "trusted posture passes local.settingSources: ['all']..." asserts the SDK adapter receives the field; "Agent.resume receives the same settingSources value as Agent.create" covers resume parity.
+- **Notes:** `['all']` is the SDK-documented forward-compatible primitive — adding new SettingSource values to the SDK later does not require code changes here.
+
+### T-Cursor-2: Cursor `worker_posture` lifecycle event
+- **Status:** complete
+- **Evidence:** `src/backend/cursor/runtime.ts::spawn` calls `store.appendEvent` after `Agent.create`/`Agent.resume` succeeds. Test "pre-spawn failure (WORKER_BINARY_MISSING) does NOT emit a worker_posture event" asserts zero events on `WORKER_BINARY_MISSING`. Trusted and restricted both verified via `service.getRunEvents`.
+- **Notes:** Decision 18 path; Cursor is the only backend that uses `store.appendEvent` directly because it never produces a `WorkerInvocation`.
+
+### T-Telemetry: Spawn-time telemetry plumbing in isolation
+- **Status:** complete
+- **Evidence:** `src/__tests__/processManager.test.ts` adds a focused `ProcessManager.start()` test that flushes a synthetic `initialEvents` and asserts the event lands before `status: started`. A companion test on `CliRuntime.buildStartInvocation` asserts the field is stripped on the pre-bake retry path.
+- **Notes:** Closes the review rev. 1 Medium 3 false-telemetry concern.
+
+### T-Codex-Audit: Capture codex config-loading surface
+- **Status:** complete
+- **Evidence:** Local codex-cli 0.130.0 `codex exec --help` exposes `-c/--config`, `-p/--profile`, `-s/--sandbox`, `-C/--cd`, `--add-dir`, `--ignore-user-config`, `--ignore-rules`. `codex exec resume --help` exposes `-c/--config`, `-p/--profile`, `--last`, `--all`, `--ephemeral`, `--ignore-user-config`, `--ignore-rules`, `-m/--model` — and **does not accept `--sandbox` or `--cd`**. No `--config-file` or `--config-dir` flag exists on either subcommand. Codex's own config discovery loads project `.codex/config.toml` and user `$CODEX_HOME/config.toml` when `--ignore-user-config` is absent.
+- **Notes:** Findings drove Decision 6 (resume-safe `-c` overrides) and Decision 9 (decouple `--ignore-user-config` from `codex_network`).
+
+### T-Docs: Update docs
+- **Status:** complete
+- **Evidence:** `docs/development/mcp-tooling.md` adds new "Workers And Project MCP Servers" section with per-backend mapping table and a "Trust Boundary" subsection. `docs/development/codex-backend.md` adds trusted/restricted posture tables and a migration note for explicit `codex_network: 'workspace'` profiles. `docs/development/cursor-backend.md` adds `worker_posture` to the Settings table with a cross-reference to mcp-tooling.md. `src/backend/claude.ts` `CLAUDE_WORKER_SETTINGS_BODY` doc comment records `enableAllProjectMcpServers`, the trusted/restricted branching, and the precedence reasoning.
+- **Notes:** No README / AGENTS.md changes (no existing parallel detail at this level).
+
+### T-Rules: Capture rule candidates
+- **Status:** complete
+- **Evidence:** `.agents/rules/worker-posture.md` and `.agents/rules/worker-safety.md` added; `.claude/rules/` projections regenerated via `node scripts/sync-ai-workspace.mjs`.
+- **Notes:** Rule scopes match the load-bearing files (`src/backend/**`, `src/orchestratorService.ts`, `src/contract.ts`, `src/harness/capabilities.ts`, `src/mcpTools.ts`, `src/claude/launcher.ts`).
+
+### T-Verify: Final `pnpm verify` gate
+- **Status:** complete
+- **Evidence:** `pnpm verify` runs `pnpm build && pnpm test && node scripts/check-publish-ready.mjs && node scripts/resolve-publish-tag.mjs >/dev/null && pnpm audit --prod && npm pack --dry-run` and exits zero. Summary: `tests 577`, `pass 575`, `fail 0`, `skipped 2`; `[publish-ready] package metadata is ready for publish`; `[publish-tag] @ralphkrauss/agent-orchestrator@0.2.2 will publish with npm dist-tag latest`; `pnpm audit --prod` → "No known vulnerabilities found"; `npm pack --dry-run` produced `ralphkrauss-agent-orchestrator-0.2.2.tgz` successfully.
+- **Notes:** All quality gates pass; #58 closure rule met (all three backends ship trusted posture).

--- a/plans/58-issue-with-setting-sources/plans/58-worker-project-mcp-access.md
+++ b/plans/58-issue-with-setting-sources/plans/58-worker-project-mcp-access.md
@@ -4,7 +4,7 @@ Branch: `58-issue-with-setting-sources`
 Plan Slug: `58-worker-project-mcp-access`
 Parent Issue: #58
 Created: 2026-05-12
-Updated: 2026-05-12 (rev. 3 after `reviews/review-plan-rev2-2026-05-12.md`; rev. 2 after `reviews/review-plan-2026-05-12.md`)
+Updated: 2026-05-12 (rev. 4 applies PR #60 review follow-ups per `plans/58-issue-with-setting-sources/resolution-map.md`; rev. 3 after `reviews/review-plan-rev2-2026-05-12.md`; rev. 2 after `reviews/review-plan-2026-05-12.md`)
 Status: complete
 
 ## Context
@@ -401,3 +401,17 @@ To be revisited after implementation review. Review mappings:
 - **Status:** complete
 - **Evidence:** `pnpm verify` runs `pnpm build && pnpm test && node scripts/check-publish-ready.mjs && node scripts/resolve-publish-tag.mjs >/dev/null && pnpm audit --prod && npm pack --dry-run` and exits zero. Summary: `tests 577`, `pass 575`, `fail 0`, `skipped 2`; `[publish-ready] package metadata is ready for publish`; `[publish-tag] @ralphkrauss/agent-orchestrator@0.2.2 will publish with npm dist-tag latest`; `pnpm audit --prod` → "No known vulnerabilities found"; `npm pack --dry-run` produced `ralphkrauss-agent-orchestrator-0.2.2.tgz` successfully.
 - **Notes:** All quality gates pass; #58 closure rule met (all three backends ship trusted posture).
+
+### PR #60 review follow-up (2026-05-12)
+- **Status:** complete
+- **Resolution map:** `plans/58-issue-with-setting-sources/resolution-map.md` (7 fix items, 0 deferred).
+- **Evidence:**
+  - C1 (`docs/development/codex-backend.md:63`): replaced the blank line between two blockquotes with a `>` separator so MD028 no longer fires.
+  - C2 (`docs/development/codex-backend.md:204`): renamed `Three concrete migration options (still restricted posture)` to `Migration options` with an intro sentence noting that option 1 moves off restricted entirely and options 2–4 stay within restricted; the four list items are unchanged.
+  - C3 (`src/__tests__/cursorRuntime.test.ts:832-836`): asserted SDK-event presence first and compared `postureIdx < sdkSystemIdx` unconditionally so a future predicate drift cannot let the test pass silently.
+  - C4 (`src/__tests__/processManager.test.ts:773-778`): asserted `result.ok === true` first and ran the retry-shape checks unconditionally; the prior `if (result.ok)` branch could no-op silently.
+  - C5 (`src/backend/cursor/runtime.ts:229-251`): wrapped the post-`agent.send()` `worker_posture` `store.appendEvent` in `try { … } catch { … }` that calls `disposeAgentSafely(agent)` and returns `cursorSpawnFailure('Failed to persist worker_posture lifecycle event', error, { phase: 'append_event' })`. Added regression test `issue #58 (review Major 5): worker_posture appendEvent failure disposes the agent and surfaces phase: append_event` using a `RejectingPostureStore extends RunStore` and a local agent double that counts `dispose` invocations (option 2 from the resolution map — local double to avoid growing the shared `fakeAgent` API for a single regression case).
+  - C6 (`src/orchestratorService.ts:836-865`): folded the posture-only branch into the settings build (non-validating) and ran `validateInheritedModelSettingsForBackend` against the merged result whenever `parsed.data.model || backendName === 'cursor'`, threading `validated.value` through `childPosture` / `codexNormalized` / `persistedSettings`. Added two integration regressions in `src/__tests__/integration/orchestrator.test.ts` (immediately after the Claude effort-validation `rejects model settings that a backend cannot apply` test, around line 741): a `worker_posture + claude-sonnet-4-6` rejection that previously slipped past the validator, and a posture-only happy-path that still persists the override.
+  - C7 (`src/processManager.ts:240-262`): chained the `initialEvents` appends via `orderedInitialFlush = orderedInitialFlush.then(() => appendEventBuffered(...))` and appended `status: 'started'` only after the chain resolves, so `worker_posture` is guaranteed to land first even when `RunStore.appendEvent`'s `O_EXCL` filesystem lock loses the race. Added regression test `chains worker_posture before status:started so status:started cannot enter store.appendEvent until worker_posture resolves` in `src/__tests__/processManager.test.ts` using a `GatedAppendStore extends RunStore` that records `enterOrder` / `resolveOrder` and holds the `worker_posture` write inside `appendEvent`; the test asserts the in-flight invariant after two microtask ticks, then releases the gate and asserts both the in-memory order and the persisted on-disk sequence.
+- **Verification:** `pnpm build` clean. `node --test dist/__tests__/processManager.test.js dist/__tests__/cursorRuntime.test.js dist/__tests__/integration/orchestrator.test.js` all green (22 + 34 + 38 = 94 tests pass). Full `pnpm test`: `tests 588, pass 586, fail 0, skipped 2` (skip count unchanged from rev. 3).
+- **Notes:** Not committed in this pass per the implementer brief; commit/push and GitHub replies are deferred to the next step.

--- a/plans/58-issue-with-setting-sources/resolution-map.md
+++ b/plans/58-issue-with-setting-sources/resolution-map.md
@@ -1,0 +1,644 @@
+# PR #60 Resolution Map
+
+Branch: `58-issue-with-setting-sources`
+Created: 2026-05-12
+Total comments: 7 | To fix: 7 | To defer: 0 | To decline: 0 | To escalate: 0 | Human-approval required: 0
+
+PR: https://github.com/ralphkrauss/agent-orchestrator/pull/60
+Title: feat(workers): worker_posture for backend-native parity (#58)
+Base: `main` ← Head: `58-issue-with-setting-sources`
+Latest commit at triage time: `a18daad`
+
+AI reply prefix: `**[AI Agent]:**` (per `CLAUDE.md:25` — "make the AI authorship
+clear in GitHub comments"). No repo-wide override configured.
+
+Correlation marker (embed as the last line of every posted reply so future
+runs can detect handled comments and so the implementer can re-find them):
+`<!-- agent-orchestrator:resolution-map:pr60:cN -->` where `N` is the comment
+number in this map.
+
+Reviewer is `coderabbitai[bot]` for every comment. All 6 inline threads are
+unresolved + non-outdated + non-collapsed in the GraphQL view; the outside-diff
+comment lives inside the review body (no inline thread node).
+
+Thread-state verification: this triage run already queried
+`repository.pullRequest.reviewThreads` via the GitHub GraphQL API with an
+authenticated token and confirmed `isResolved=false`, `isOutdated=false`,
+`isCollapsed=false` for every comment listed below. Subsequent map reviewers
+do not need to re-verify thread state (and can skip this check if their
+network egress is blocked).
+
+---
+
+## Comment 1 | to-fix | minor
+
+- **Comment Type:** review-inline
+- **File:** `docs/development/codex-backend.md:63`
+- **Comment ID:** 3225541746
+- **Review ID:** 4271291263
+- **Thread Node ID:** PRRT_kwDOSRv-qs6BX3Ry
+- **Author:** coderabbitai[bot]
+- **Comment summary:** Fix blockquote formatting to avoid markdownlint MD028
+  (blank line inside blockquote). Lines 56-62 are one `>` block and 64-68 are
+  another, separated by a blank line 63.
+- **Independent Assessment:** Valid. Verified `docs/development/codex-backend.md`
+  has a `>` blockquote ending at line 62, a blank line at 63, and another `>`
+  blockquote starting at line 64. markdownlint MD028 fires on this pattern.
+  Behaviour-preserving doc fix.
+- **Decision:** fix-as-suggested
+- **Approach:** Replace the blank line 63 with a single `>` separator line so
+  the two blockquotes are contiguous (markdownlint MD028 accepts a `>` line
+  with no content as the separator). Concretely: change line 63 from empty to
+  `>`. Verify with the project's markdownlint pass if one runs in CI, or by
+  re-rendering the section. No other edits needed.
+- **Files To Change:** `docs/development/codex-backend.md`
+- **Reply Draft:**
+  > **[AI Agent]:** Fixed — line 63 is now a `>` separator so the two
+  > blockquotes are contiguous and MD028 no longer fires.
+  >
+  > `<!-- agent-orchestrator:resolution-map:pr60:c1 -->`
+
+---
+
+## Comment 2 | to-fix | minor
+
+- **Comment Type:** review-inline
+- **File:** `docs/development/codex-backend.md:220` (anchored on the
+  fourth list item; heading is at line 204)
+- **Comment ID:** 3225541750
+- **Review ID:** 4271291263
+- **Thread Node ID:** PRRT_kwDOSRv-qs6BX3R2
+- **Author:** coderabbitai[bot]
+- **Comment summary:** Heading at line 204 says "Three concrete migration
+  options (still restricted posture)" but the list under it has four items,
+  and the first item (`worker_posture: 'trusted'`) is *not* a restricted-posture
+  option.
+- **Independent Assessment:** Valid. Verified line 204
+  (`### Three concrete migration options (still restricted posture)`) is
+  followed by a four-item list (lines 208-220). Item 1 is the trusted-posture
+  recommendation, items 2-4 are the three restricted-posture migration paths.
+  The heading and content are out of sync — the trusted option was added as a
+  fourth path during PR development without updating the heading.
+- **Decision:** fix-as-suggested (heading correction; preserves content)
+- **Approach:** Rewrite the section so the heading matches the content. Two
+  acceptable shapes (pick the one that reads better in surrounding flow):
+  1. **Preferred** — Change the heading to `### Migration options` (no count,
+     no "restricted" qualifier) and add a one-line intro sentence above the
+     list that says "Listed in increasing openness; the first option moves
+     off restricted entirely, options 2-4 stay within restricted." Keep all
+     four list items as-is.
+  2. **Alternative** — Keep the count-style heading but split: a `#### Move
+     off restricted entirely` subsection holding only item 1 (`worker_posture:
+     'trusted'`), then `### Three concrete migration options (still restricted
+     posture)` holding items 2-4 renumbered 1-3.
+  Either way, do not change the *content* of the list items (they're cross-
+  referenced from migration tables earlier in the doc). Prefer shape (1) as the
+  smaller diff.
+- **Files To Change:** `docs/development/codex-backend.md`
+- **Reply Draft:**
+  > **[AI Agent]:** Fixed — the heading no longer claims "three options /
+  > still restricted" while listing four with the first being trusted. Renamed
+  > to `Migration options` with an intro sentence noting option 1 moves off
+  > restricted entirely and options 2-4 stay within restricted.
+  >
+  > `<!-- agent-orchestrator:resolution-map:pr60:c2 -->`
+
+---
+
+## Comment 3 | to-fix | minor
+
+- **Comment Type:** review-inline
+- **File:** `src/__tests__/cursorRuntime.test.ts:836` (assertion block at
+  lines 832-836)
+- **Comment ID:** 3225541752
+- **Review ID:** 4271291263
+- **Thread Node ID:** PRRT_kwDOSRv-qs6BX3R3
+- **Author:** coderabbitai[bot]
+- **Comment summary:** The ordering assertion `if (sdkSystemIdx >= 0) { …
+  assert.ok(postureIdx < sdkSystemIdx) }` is conditional. If the SDK event
+  match fails (e.g., agent_id shape changes), the test passes silently
+  without validating the ordering invariant the test is named for.
+- **Independent Assessment:** Valid. Verified lines 832-836 wrap the
+  posture-precedes-SDK ordering check in `if (sdkSystemIdx >= 0)`. The
+  comment block on lines 829-831 explicitly states this is the "Decision 18"
+  ordering invariant; a test that can pass silently when the match misses
+  defeats the purpose. Strengthening to assert presence first is purely a
+  test-quality improvement, behaviour-preserving on the production code.
+- **Decision:** fix-as-suggested
+- **Approach:** Replace lines 833-836 with:
+  ```ts
+  assert.ok(sdkSystemIdx >= 0, 'expected at least one SDK lifecycle/system event');
+  const postureIdx = stream.indexOf(posture!);
+  assert.ok(postureIdx < sdkSystemIdx, 'worker_posture event must precede the first SDK system event');
+  ```
+  Keep the `sdkSystemIdx` `findIndex` predicate on line 832 unchanged. Run
+  `pnpm test -- src/__tests__/cursorRuntime.test.ts` (or the equivalent
+  package script) to confirm green.
+- **Files To Change:** `src/__tests__/cursorRuntime.test.ts`
+- **Reply Draft:**
+  > **[AI Agent]:** Tightened — the SDK-event presence is now asserted before
+  > the ordering compare, so a future predicate drift fails the test instead
+  > of letting it pass silently.
+  >
+  > `<!-- agent-orchestrator:resolution-map:pr60:c3 -->`
+
+---
+
+## Comment 4 | to-fix | minor
+
+- **Comment Type:** review-inline
+- **File:** `src/__tests__/processManager.test.ts:778` (assertion block at
+  lines 773-778, inside a `try { … } finally { restore PATH }`)
+- **Comment ID:** 3225541769
+- **Review ID:** 4271291263
+- **Thread Node ID:** PRRT_kwDOSRv-qs6BX3SF
+- **Author:** coderabbitai[bot]
+- **Comment summary:** All retry-path assertions are inside `if (result.ok) {
+  … }`. If `buildStartInvocation` fails for an unrelated reason the test
+  passes without asserting anything. Assert success first.
+- **Independent Assessment:** Valid. Verified lines 773-778: every assertion
+  hides behind `if (result.ok)`. Strengthen by failing fast on `!result.ok`.
+  Behaviour-preserving on production code; test-quality only.
+- **Decision:** fix-as-suggested
+- **Approach:** Replace lines 773-778 with:
+  ```ts
+  assert.equal(result.ok, true, 'expected buildStartInvocation to succeed for retry-shape assertions');
+  if (!result.ok) return;
+  assert.ok(result.invocation.initialEvents, 'retry invocation must keep initialEvents so a real retry spawn emits posture telemetry');
+  assert.equal(result.invocation.initialEvents.length, 1);
+  assert.equal((result.invocation.initialEvents[0]!.payload as { state?: string }).state, 'worker_posture');
+  assert.equal(result.invocation.earlyEventInterceptor, undefined, 'single-shot enforcement still holds');
+  ```
+  Note the `!` after `initialEvents` is dropped on the `.length` access because
+  the prior `assert.ok` narrows it; keep `[0]!` on the array index. Run
+  `pnpm test -- src/__tests__/processManager.test.ts` to confirm green.
+- **Files To Change:** `src/__tests__/processManager.test.ts`
+- **Reply Draft:**
+  > **[AI Agent]:** Tightened — `result.ok` is asserted first and the rest of
+  > the retry-shape checks run unconditionally, so an unexpected
+  > `buildStartInvocation` failure now fails the test instead of skipping it.
+  >
+  > `<!-- agent-orchestrator:resolution-map:pr60:c4 -->`
+
+---
+
+## Comment 5 | to-fix | major
+
+- **Comment Type:** review-inline
+- **File:** `src/backend/cursor/runtime.ts:240` (the unguarded
+  `await store.appendEvent(...)` call at lines 229-239)
+- **Comment ID:** 3225541779
+- **Review ID:** 4271291263
+- **Thread Node ID:** PRRT_kwDOSRv-qs6BX3SM
+- **Author:** coderabbitai[bot]
+- **Comment summary:** The `worker_posture` lifecycle append at lines 229-239
+  is unguarded. If `store.appendEvent(...)` throws, `spawn()` returns to its
+  caller after `agent.send()` already succeeded, leaving the agent and the
+  cursor run undisposed (resource leak + orphaned worker). Guideline
+  reference: every worker spawn must emit a lifecycle `worker_posture` event,
+  and failure handling must not leave the accepted worker orphaned.
+- **Independent Assessment:** Valid major issue. Verified `runtime.ts:229-239`
+  performs an unguarded `await this.options.store.appendEvent(...)` after
+  `agent.send()` resolves. The neighbouring failure paths (lines 196-202 for
+  `Agent.create/resume`, 213-217 for `agent.send`) already follow the
+  dispose-then-return-structured-failure pattern using
+  `disposeAgentSafely(agent)` (defined line 611) and `cursorSpawnFailure(...)`
+  (defined line 585). Aligning the append-event path with the same pattern is
+  behaviour-preserving for the happy path and adds the missing cleanup leg.
+  This is reinforced by `.claude/rules/worker-safety.md` (cursor must not
+  weaken pre-#58 defaults; spawn failure handling matters).
+- **Decision:** fix-as-suggested
+- **Approach:** Wrap the existing `await this.options.store.appendEvent(...)`
+  call (currently lines 229-239) in a `try { … } catch { … }` that:
+  1. Calls `await disposeAgentSafely(agent)` to clean up the cursor SDK
+     handle.
+  2. Returns
+     ```ts
+     return {
+       ok: false,
+       failure: cursorSpawnFailure(
+         'Failed to persist worker_posture lifecycle event',
+         error,
+         { phase: 'append_event' },
+       ),
+     };
+     ```
+     Match the existing failure shape used for the `send` phase on lines
+     213-217. The `phase: 'append_event'` keeps the failure metadata
+     distinguishable for telemetry / log parsing. Preserve the existing
+     comment block at lines 220-228 (Issue #58 Decision 18 rationale) — only
+     wrap the append call itself, do not move the comment.
+  3. Verify `cursorSpawnFailure`'s signature accepts the third arg `{ phase:
+     string }` (it does — same call pattern as `phase: 'send'` on line 216).
+
+  Add or extend a test in `src/__tests__/cursorRuntime.test.ts` that follows
+  the existing style in that file (see e.g. the `CursorSdkRuntime end-to-end
+  orchestration with a fake SDK adapter` describe block around line 417):
+  - Construct a `CursorSdkRuntime` via `new CursorSdkRuntime(fakeAdapter(api),
+    { store, env, cancelDrainMs: 25 })` exactly like the existing tests
+    (see `cursorRuntime.test.ts:104` and `:552`). Use the existing `fakeAgent`
+    / `fakeRun` / `fakeAdapter` helpers — `Agent.create` + `agent.send` should
+    succeed.
+  - Drive it through the **public** entry point used by the other tests
+    rather than the internal `spawn`: trigger the spawn the way the existing
+    tests do (`await service.startRun({ backend: 'cursor', ... })` via the
+    integration-style wiring already in the file, or — if a `CursorSdkRuntime`-
+    only test is preferred — call the public `start(...)` method on the
+    runtime). Do not reach into the private `spawn(...)` overload.
+  - Make the store's `appendEvent` reject on the `worker_posture` lifecycle
+    write only (let other writes succeed). The cleanest shape is a thin
+    `RunStore` subclass that overrides `appendEvent` and rejects when
+    `(event.payload as { state?: string }).state === 'worker_posture'` (the
+    same pattern as the existing `ThrowingTerminalStore` / `ThrowingStream
+    ActivityStore` extensions in `src/__tests__/processManager.test.ts:13,28`
+    — see also the existing cursor regression-store fakes in this file).
+  - Assert: the `start`/`startRun` result surfaces a `cursorSpawnFailure`
+    with `phase: 'append_event'` (matching the new `failure.phase`), and
+    `agent.dispose` was invoked exactly once.
+
+  **Implementer note on dispose counting:** the existing `fakeAgent` helper
+  in `cursorRuntime.test.ts` has an `async dispose()` method but does **not**
+  currently track call counts, so a plain `fakeAgent` cannot satisfy the
+  "disposed exactly once" assertion as-is. Pick one of:
+  1. **Instrument the helper** — add a `disposeCount` counter (or a public
+     `disposed: boolean` / `disposeCalls: number`) on `fakeAgent` that the
+     `dispose` implementation increments. Update existing call sites if any
+     read shape changes. This is the lower-churn option if other regression
+     tests would benefit from the same counter.
+  2. **Use a local custom agent in this test only** — define a small inline
+     test double that satisfies the `CursorAgent` contract and records its
+     own `dispose` invocations, then thread it through the test's
+     `fakeAdapter` for this single case. This is the lower-blast-radius
+     option if no other test needs the counter.
+  Choose option 1 if `disposeAgentSafely` coverage will likely grow (e.g.
+  future cursor failure paths); option 2 otherwise. Document the choice in
+  the test file's surrounding describe-block comment so a follow-up reader
+  understands why the helper grew (or why the local double exists).
+- **Files To Change:**
+  - `src/backend/cursor/runtime.ts`
+  - `src/__tests__/cursorRuntime.test.ts`
+- **Reply Draft:**
+  > **[AI Agent]:** Fixed — the `worker_posture` append is now wrapped in
+  > try/catch that disposes the cursor agent via `disposeAgentSafely` and
+  > returns a structured `cursorSpawnFailure('Failed to persist
+  > worker_posture lifecycle event', error, { phase: 'append_event' })`,
+  > matching the `phase: 'send'` failure shape next to it. Added a regression
+  > test that injects an `appendEvent` rejection and asserts the agent is
+  > disposed and the failure carries `phase: 'append_event'`.
+  >
+  > `<!-- agent-orchestrator:resolution-map:pr60:c5 -->`
+
+---
+
+## Comment 6 | to-fix | major (alternative-fix — reviewer's diff is incomplete)
+
+- **Comment Type:** review-inline
+- **File:** `src/orchestratorService.ts:848` (settings chain at lines
+  836-844, validation `if (!settings.ok)` at 845-848)
+- **Comment ID:** 3225541781
+- **Review ID:** 4271291263
+- **Thread Node ID:** PRRT_kwDOSRv-qs6BX3SO
+- **Author:** coderabbitai[bot]
+- **Comment summary:** In `send_followup`, if the request body sets
+  `worker_posture` (and not the rest of the model-settings fields), the
+  ternary chain takes the `parsed.data.worker_posture !== undefined` branch
+  at line 840 and short-circuits with `{ ok: true, value: { …parent, …}}`
+  *before* the `parsed.data.model || backendName === 'cursor'` branch (line
+  842) that calls `validateInheritedModelSettingsForBackend`. So a
+  `worker_posture + model` follow-up on Claude (or any cursor follow-up that
+  sets `worker_posture`) skips backend model-setting validation.
+- **Independent Assessment:** Valid major bug. Verified lines 836-844: the
+  ternary is `hasModelSettingsInput` → … → `codex_network !== undefined` → …
+  → **`worker_posture !== undefined`** → wraps parent + posture (no
+  validation) → else `model || cursor` → `validateInheritedModelSettingsForBackend`.
+  Verified `validateInheritedModelSettingsForBackend` at lines 2453-2467+:
+  rejects cursor reasoning_effort/service_tier, requires explicit cursor
+  model, and runs claude-model reasoning-effort compatibility checks. A
+  follow-up that pairs `worker_posture` with a model change on Claude can
+  persist an invalid `reasoning_effort` for the new model — the exact
+  failure mode the validator exists to catch.
+
+  **The reviewer's suggested diff is incomplete:** it introduces a new
+  `validatedSettings` binding but does not update the downstream code (lines
+  862-868 and beyond) that reads `settings.value` — `persistedSettings` is
+  derived from `settings.value`, so applying the diff verbatim leaves the
+  rest of the function on the un-validated value. The implementer must
+  thread the validated settings through.
+- **Decision:** alternative-fix (same intent as reviewer; corrected
+  implementation that propagates the validation result)
+- **Approach:** Refactor `orchestratorService.ts:836-848` so that:
+  1. The posture-only branch becomes a *non-validating* settings build that
+     stays inside the existing ternary — i.e. replace the existing nested
+     ternary at lines 840-844 with:
+     ```ts
+     : {
+         ok: true as const,
+         value: parsed.data.worker_posture !== undefined
+           ? { ...parent.meta.model_settings, worker_posture: parsed.data.worker_posture }
+           : parent.meta.model_settings,
+       };
+     ```
+     This keeps the `hasModelSettingsInput` / `codex_network` / posture /
+     fallback ladder structurally identical except the posture branch no
+     longer skips validation.
+  2. After the existing `if (!settings.ok) { releaseLock?.(); return
+     wrapErr(settings.error); }` guard at lines 845-848, **rebind** the
+     settings variable through the backend validator:
+     ```ts
+     const validated = parsed.data.model || backendName === 'cursor'
+       ? validateInheritedModelSettingsForBackend(backendName, model, settings.value)
+       : settings;
+     if (!validated.ok) {
+       releaseLock?.();
+       return wrapErr(validated.error);
+     }
+     ```
+  3. Replace **every** downstream read of `settings.value` in this function
+     (notably lines 862-868 — `childPosture`, `codexNormalized`,
+     `persistedSettings`) with `validated.value`. Grep the function body
+     between line 848 and the end of the `send_followup` handler to be sure
+     no `settings.value` references are left.
+  4. The behavioural change is: a follow-up that pairs `worker_posture` with
+     a `model` override (or any cursor follow-up that sets `worker_posture`)
+     now runs `validateInheritedModelSettingsForBackend` and rejects invalid
+     combinations with `INVALID_INPUT`, the same way a non-posture model
+     follow-up does today. This is a bug fix that brings posture follow-ups
+     into line with the existing validation surface; it does not introduce
+     new public-contract behaviour.
+
+  Add the regression tests in `src/__tests__/integration/orchestrator.test.ts`
+  — that file is the home of the existing
+  `validateInheritedModelSettingsForBackend` integration coverage (Claude
+  effort-mismatch assertions live there; see the existing
+  `assertInvalidInput(claudeXhighFallback, /Claude xhigh effort requires
+  claude-opus-4-7/)` patterns and neighbours around the Claude
+  effort-validation describe block, around line 649 — grep for
+  `/Claude .* effort/` and `/Claude effort levels are documented/` to find
+  the right insertion point). Do not create a new
+  `src/__tests__/orchestratorService.test.ts`; that file does not exist and
+  the integration-test wiring needed to exercise `send_followup` end-to-end
+  is already set up in the integration suite.
+
+  The two new tests:
+  - **Bug regression (failing on `main`, passing after the fix):** set up a
+    Claude parent run with a reasoning_effort that is *incompatible* with a
+    follow-up model (e.g. inherit a non-xhigh effort and target a model that
+    `validateInheritedModelSettingsForBackend` would reject under the same
+    Claude effort rules the existing tests exercise). Call `send_followup`
+    with `{ worker_posture: 'restricted', model: '<the-incompatible-model>' }`.
+    Assert `result.ok === false` and the error matches the same regex used by
+    the neighbouring tests (e.g. `/Claude xhigh effort requires claude-opus-4-7/`
+    or `/Claude effort levels are documented/`, whichever fits the chosen
+    parent/child pair). Pick a parent/follow-up pair that exactly mirrors an
+    existing `startRun` rejection in the file so the failure shape is already
+    known to be stable.
+  - **Happy-path regression-guard:** `send_followup` with only
+    `worker_posture` set (no `model`, no other settings) on a Claude parent
+    must still succeed. Assert `result.ok === true` and that the persisted
+    `run_summary.model_settings.worker_posture` reflects the override. This
+    guards against the new validator pass-through accidentally rejecting
+    legacy parents where the inherited settings would not survive a strict
+    re-validation against the unchanged parent model.
+- **Files To Change:**
+  - `src/orchestratorService.ts`
+  - `src/__tests__/integration/orchestrator.test.ts`
+- **Reply Draft:**
+  > **[AI Agent]:** Fixed with a small variation on the suggested shape — the
+  > posture-only branch now folds into the settings build as a non-validating
+  > value, and the backend validator runs unconditionally for `parsed.data.model
+  > || backendName === 'cursor'` against the merged result, with the
+  > validated value threaded through `childPosture` / `codexNormalized` /
+  > `persistedSettings`. Added a Claude regression test for
+  > `worker_posture + model` that previously slipped past validation, plus a
+  > posture-only happy-path guard.
+  >
+  > `<!-- agent-orchestrator:resolution-map:pr60:c6 -->`
+
+---
+
+## Comment 7 | to-fix | major (outside-diff range — review body, no inline thread)
+
+- **Comment Type:** review-body (outside-diff section of CodeRabbit review)
+- **File:** `src/processManager.ts:245-254`
+- **Comment ID:** *no inline databaseId — comment is embedded in the review
+  body* (Review ID 4271291263). On reply, post into the PR conversation thread
+  (not a code-anchored thread).
+- **Review ID:** 4271291263
+- **Thread Node ID:** *n/a (no inline review thread; reply goes to the PR
+  conversation)*
+- **Author:** coderabbitai[bot]
+- **Comment summary:** `initialEvents` (including the backend's
+  `worker_posture` lifecycle event) and the `status: started` marker are both
+  fired through `trackPersistence(appendEventBuffered(...))` in the same
+  synchronous tick — fire-and-forget. Ordering between them is therefore not
+  guaranteed and `status: started` can race ahead of `worker_posture`,
+  violating the documented invariant ("operators see them at the head of the
+  run event stream").
+- **Independent Assessment:** Valid major bug. Verified
+  `src/processManager.ts:245-254` issues `trackPersistence(appendEventBuffered(initialEvent))`
+  in a loop and then `trackPersistence(appendEventBuffered({status: 'started',
+  …}))` without chaining. `appendEventBuffered` (line 232 in the same file)
+  either pushes to an in-memory buffer (interceptor path — serial by array
+  push, so safe in that mode) or returns `this.store.appendEvent(...)`
+  directly. `RunStore.appendEvent` (`src/runStore.ts:232-244`) wraps writes
+  in `withRunLock`, which is a **filesystem `O_EXCL` lock with EEXIST retry
+  on a 10ms `setTimeout`** (`src/runStore.ts:1011+`). Two concurrent
+  `appendEvent` calls race for the lock; the loser sleeps and retries, and
+  there is no guarantee that the loop's earlier-issued call wins the race.
+  In production runs (no interceptor — the standard path after retry
+  buffering is disengaged), `status: started` can land before
+  `worker_posture` in the events log. The in-code comment at lines 240-244
+  explicitly documents the invariant the race violates ("flush
+  backend-supplied initial lifecycle events … BEFORE the `status: started`
+  marker"). The fix concept (chain the promises) restores the invariant
+  without semantic change.
+- **Decision:** fix-as-suggested
+- **Approach:** Edit `src/processManager.ts:245-254` to chain the appends
+  rather than fire them in parallel:
+  ```ts
+  let orderedInitialFlush: Promise<unknown> = Promise.resolve();
+  if (invocation.initialEvents && invocation.initialEvents.length > 0) {
+    for (const initialEvent of invocation.initialEvents) {
+      orderedInitialFlush = orderedInitialFlush.then(() => appendEventBuffered(initialEvent));
+    }
+  }
+  trackPersistence(
+    orderedInitialFlush.then(() =>
+      appendEventBuffered({
+        type: 'lifecycle',
+        payload: { status: 'started', pid: workerPid, pgid: workerPgid },
+      }),
+    ),
+  );
+  ```
+  Notes:
+  - We only need to `trackPersistence` on the **terminal** promise of the
+    chain — the chain itself awaits the earlier appends transitively, so any
+    rejection inside `orderedInitialFlush` will reject the final tracked
+    promise and surface to the persistence tracker the same way today.
+  - Do not wrap each step in its own `trackPersistence` — that would
+    re-introduce a parallel-tracked path that defeats the chain.
+  - Buffered (interceptor) mode is unaffected: `appendEventBuffered` returns
+    `Promise.resolve()` synchronously in that path, so the chain collapses
+    and the buffer order matches the call order, which was already correct.
+
+  **Test design (this is the load-bearing part — a naive call-order
+  assertion does not catch the bug, because the unpatched code already
+  *invokes* `appendEventBuffered(worker_posture)` before
+  `appendEventBuffered(status:'started')` synchronously in the same tick;
+  the race is between the two writes' progress *inside* `appendEvent`, not
+  between the call sites).** Use a gated-store regression test in
+  `src/__tests__/processManager.test.ts` that proves `status:'started'` is
+  not even *invoked* on the store until `worker_posture` has resolved on
+  the store. Concretely:
+
+  1. Define a small `RunStore` subclass in the test file (mirroring the
+     existing `ThrowingTerminalStore` pattern at `src/__tests__/processManager.test.ts:13`
+     and `ThrowingStreamActivityStore` at `:28`):
+     ```ts
+     class GatedAppendStore extends RunStore {
+       readonly enterOrder: string[] = [];          // event tag at function entry
+       readonly resolveOrder: string[] = [];        // event tag at function exit
+       private postureGate: { promise: Promise<void>; resolve: () => void } | null = null;
+
+       installPostureGate() {
+         let resolveFn!: () => void;
+         const promise = new Promise<void>((res) => { resolveFn = res; });
+         this.postureGate = { promise, resolve: resolveFn };
+       }
+
+       releasePostureGate() {
+         this.postureGate?.resolve();
+         this.postureGate = null;
+       }
+
+       async appendEvent(runId: string, event: Omit<WorkerEvent, 'seq' | 'ts'>): Promise<WorkerEvent> {
+         const tag =
+           (event.payload as { state?: string }).state
+           ?? (event.payload as { status?: string }).status
+           ?? '?';
+         this.enterOrder.push(tag);
+         if (tag === 'worker_posture' && this.postureGate) {
+           await this.postureGate.promise;
+         }
+         const result = await super.appendEvent(runId, event);
+         this.resolveOrder.push(tag);
+         return result;
+       }
+     }
+     ```
+     The gate lets the test hold `worker_posture` inside `appendEvent` while
+     the rest of the spawn keeps progressing.
+
+  2. Drive `ProcessManager.start(...)` (or the runtime path the existing
+     `processManager.test.ts` describe block uses) with an `invocation`
+     whose `initialEvents` contains exactly one `worker_posture` lifecycle
+     event — match the shape that
+     `src/__tests__/processManager.test.ts:771-776` uses for the retry-path
+     test (`{ type: 'lifecycle', payload: { state: 'worker_posture', ... } }`).
+     Install the posture gate **before** the `start(...)` call.
+
+  3. After `start(...)` has scheduled the appends, **yield two microtask
+     ticks** (e.g. `await Promise.resolve(); await Promise.resolve();`) to
+     let the synchronous portion of the spawn settle. Then assert:
+     ```ts
+     assert.deepStrictEqual(store.enterOrder, ['worker_posture']);
+     ```
+     i.e. `status:'started'` must **not** have entered `appendEvent` yet,
+     because the chain is blocked on the gated `worker_posture` write.
+     On unpatched code this assertion fails — both events enter `appendEvent`
+     in the same tick because each `appendEventBuffered(...)` is called
+     synchronously back-to-back.
+
+  4. Release the gate: `store.releasePostureGate()`. Await the persistence
+     tracker (or the `ProcessManager` completion path the test already
+     awaits) to settle. Then assert the full ordering both at the function
+     boundary AND at the persisted-sequence level:
+     ```ts
+     assert.deepStrictEqual(store.enterOrder, ['worker_posture', 'started']);
+     assert.deepStrictEqual(store.resolveOrder, ['worker_posture', 'started']);
+
+     const page = await store.readEvents(runId); // RunStore.readEvents at
+                                                  // src/runStore.ts:315 —
+                                                  // returns `ReadEventsResult`
+                                                  // with an `events` array;
+                                                  // adjust the property
+                                                  // destructure to match
+                                                  // the actual shape.
+     const events = page.events ?? page; // tolerate either shape
+     const postureSeq = events.find((e: WorkerEvent) => (e.payload as { state?: string }).state === 'worker_posture')!.seq;
+     const startedSeq = events.find((e: WorkerEvent) => (e.payload as { status?: string }).status === 'started')!.seq;
+     assert.ok(postureSeq < startedSeq, 'worker_posture must be persisted with a lower seq than status:started');
+     ```
+     The persisted-seq assertion is the belt-and-braces guarantee: even if
+     someone later removes the gate logic, the on-disk sequence still
+     witnesses the invariant.
+
+  5. Make the test resilient to the `interceptor` (buffered) path: this fix
+     only matters in the **non-buffered** path (interceptor disengaged), so
+     the test should configure the runtime/invocation such that
+     `appendEventBuffered` calls into `store.appendEvent` directly. If the
+     test wiring would enable the D-COR-Resume interceptor by default, pass
+     an invocation shape that does not trigger it (the existing retry-shape
+     test on `processManager.test.ts:760-782` already shows how to build an
+     invocation that bypasses the interceptor — model the new test on that
+     shape).
+
+  This design directly fails on unpatched code (both events enter
+  `appendEvent` in the same tick, breaking the step-3 assertion) and passes
+  on patched code (chain blocks the second call until the first resolves),
+  while *also* asserting the persisted on-disk sequence — covering both
+  options the resolution-map reviewer offered.
+- **Files To Change:**
+  - `src/processManager.ts`
+  - `src/__tests__/processManager.test.ts`
+- **Reply Draft:**
+  > **[AI Agent]:** Fixed — the `initialEvents` writes are now chained via
+  > `orderedInitialFlush = orderedInitialFlush.then(...)` and `status:
+  > started` is appended only after that chain resolves, so `worker_posture`
+  > is guaranteed to land before `status: started` in the events log even
+  > when `RunStore`'s filesystem lock loses the race. Added a regression
+  > test that uses a gated `RunStore` subclass to hold the `worker_posture`
+  > write inside `appendEvent`, asserts (after a microtask tick) that
+  > `status: started` has not yet entered the store, then releases the gate
+  > and asserts the persisted on-disk event sequence shows `worker_posture`
+  > strictly before `status: started`.
+  >
+  > `<!-- agent-orchestrator:resolution-map:pr60:c7 -->`
+
+---
+
+## Implementation Order (suggested)
+
+A fresh implementer can apply these in any order, but the suggested order
+minimises risk of merge conflicts in shared files:
+
+1. Comment 1 — `docs/development/codex-backend.md:63` (1-line MD fix)
+2. Comment 2 — `docs/development/codex-backend.md:204-220` (heading +
+   intro sentence). Comments 1 and 2 touch the same file but disjoint
+   ranges.
+3. Comment 3 — `src/__tests__/cursorRuntime.test.ts:832-836` (test
+   tightening; isolated)
+4. Comment 4 — `src/__tests__/processManager.test.ts:773-778` (test
+   tightening; isolated)
+5. Comment 5 — `src/backend/cursor/runtime.ts:229-239` + new test in
+   `cursorRuntime.test.ts` (production safety fix)
+6. Comment 6 — `src/orchestratorService.ts:836-868` + new send_followup
+   test (validation-bypass bug)
+7. Comment 7 — `src/processManager.ts:245-254` + new ordering test in
+   `processManager.test.ts` (race fix)
+
+Run after each: the targeted test file plus `pnpm test` (or the configured
+package script) before moving on to the next.
+
+---
+
+## Reviewer Questions
+
+none
+
+---
+
+## Open Human Decisions
+
+none

--- a/plans/58-issue-with-setting-sources/reviews/review-implementation-2026-05-12.md
+++ b/plans/58-issue-with-setting-sources/reviews/review-implementation-2026-05-12.md
@@ -1,0 +1,97 @@
+# Implementation Review - 2026-05-12
+
+## Findings
+
+### High - Default trusted Codex runs still do not get the trusted network posture
+
+`modelSettingsForBackend()` resolves an omitted Codex `codex_network` to
+`'isolated'` before the backend sees it
+(`src/orchestratorService.ts:2366-2385`). The new trusted backend mapping only
+emits the workspace-write/network-on `-c` flags when `settings.codex_network`
+is absent or `null`; when it sees `'isolated'`, it emits no sandbox flags
+(`src/backend/codex.ts:173-183`).
+
+That means the actual `start_run({ backend: 'codex', worker_posture omitted,
+codex_network omitted })` path persists `worker_posture: 'trusted'` and
+`codex_network: 'isolated'`, then spawns Codex without
+`-c sandbox_mode="workspace-write"` or
+`-c sandbox_workspace_write.network_access=true`. This contradicts the plan and
+docs claim that trusted Codex defaults to workspace-write with network on
+(`docs/development/mcp-tooling.md:69-75`) and directly misses the product goal
+for default workers.
+
+The existing backend unit test covers a synthetic `codex_network: null` input,
+but not the service-resolved start path. Add an integration test for direct and
+profile Codex starts with omitted `codex_network` under the default trusted
+posture, asserting the recorded worker invocation has the trusted `-c` flags and
+no `--ignore-user-config`. The implementation then needs to either preserve the
+"unset" signal into `sandboxArgs()` or change the resolver/backend contract so
+trusted defaults cannot collapse to the explicit isolated cell.
+
+### Medium - Cursor records `worker_posture` even when `agent.send()` fails
+
+`CursorSdkRuntime.spawn()` appends the `worker_posture` lifecycle event
+immediately after `Agent.create()` / `Agent.resume()` succeeds
+(`src/backend/cursor/runtime.ts:205-221`), but the prompt is not actually sent
+until after that (`src/backend/cursor/runtime.ts:227-235`). If `agent.send()`
+throws, the runtime returns a `SPAWN_FAILED` pre-spawn failure while the run's
+event log already contains a `worker_posture` event.
+
+That violates the Decision 18 invariant documented in the same block and docs:
+pre-spawn failures should emit no posture event
+(`docs/development/mcp-tooling.md:83-92`). The current test only covers adapter
+load failure before `Agent.create()` (`src/__tests__/cursorRuntime.test.ts:872-886`),
+so this send-failure case is not covered.
+
+Move the append until after `agent.send()` returns a `CursorRun` while still
+before drain appends SDK stream events, or explicitly reclassify send failures
+as post-spawn failures. Add a test with a fake agent whose `send()` rejects and
+assert no `worker_posture` event is written if it remains a pre-spawn failure.
+
+### Medium - CLI retry path can drop all `worker_posture` telemetry
+
+`ProcessManager` routes `initialEvents` through `appendEventBuffered()` when an
+early retry interceptor is armed (`src/processManager.ts:240-249`). On
+`retry_with_start`, that buffer is intentionally dropped
+(`src/processManager.ts:340-351`). The retry invocation then has
+`initialEvents` stripped by `CliRuntime.buildStartInvocation()`
+(`src/backend/runtime.ts:109-118`) and is spawned without a posture event
+(`src/processManager.ts:132-134`).
+
+In the Claude rotation/session-not-found path, this can leave the completed
+worker run with zero `worker_posture` event even though an actual retry worker
+spawned. That conflicts with the new rule that every worker spawn emits one
+posture lifecycle event (`.agents/rules/worker-posture.md:40-46`) and with the
+documentation that the event answers "what did this worker actually load?"
+(`docs/development/mcp-tooling.md:83-89`).
+
+Add a resume-interceptor test with `initialEvents` on the first invocation and a
+retry invocation, then assert exactly one posture event remains after the retry.
+The fix could preserve the first attempt's posture event outside the cancelled
+stream buffer, or attach a fresh posture event to the actual retry spawn while
+still keeping the pre-baked invocation from writing false telemetry if it never
+spawns.
+
+### Low - Supervisor-facing profile guidance still describes the old Codex posture model
+
+Several surfaces used by supervisors/operators still describe `codex_network`
+with pre-#58 semantics: `mcpTools.ts` says `isolated (default)` means
+`--ignore-user-config` and no network, and `workspace` also skips user config
+(`src/mcpTools.ts:37-45`, `src/mcpTools.ts:121-129`). The capability catalog
+note says the same (`src/harness/capabilities.ts:107-116`), and the OpenCode
+supervisor prompt says profile ids map to `codex_network` only, without
+mentioning `worker_posture` (`src/opencode/config.ts:172-177`).
+
+These are contract surfaces for agents, not just prose docs. After this change,
+agents can be told to configure the wrong field for the desired access posture,
+or believe `codex_network: isolated` is closed when trusted posture still loads
+user/project config. Update the tool descriptions, capability notes, and
+supervisor prompt/profile rendering to explain the two axes: `worker_posture`
+controls config/MCP visibility; `codex_network` controls the Codex sandbox
+network shape within that posture.
+
+## Verification
+
+I did not rerun `pnpm verify`; the implementer reported it passed. This review
+inspected the working tree diff, changed source paths, relevant docs, and
+project rules.

--- a/plans/58-issue-with-setting-sources/reviews/review-implementation-final-2026-05-12.md
+++ b/plans/58-issue-with-setting-sources/reviews/review-implementation-final-2026-05-12.md
@@ -1,0 +1,39 @@
+# Implementation Final Review - 2026-05-12
+
+## Findings
+
+### Medium - Public docs still teach `codex_network: "isolated"` as closed network without `worker_posture: "restricted"`
+
+The code fixes for the two previous findings are in place:
+
+- `maybeEmitCodexNetworkDefaultWarning()` now returns early unless
+  `worker_posture === 'restricted'` (`src/orchestratorService.ts:403-413`).
+- `validateProfile()` now rejects unsupported `worker_posture` values during
+  profile inspection (`src/harness/capabilities.ts:259-266`).
+
+One docs issue remains. The first-run examples in `README.md:95-102` and
+`docs/first-run.md:73-82` still create a Codex profile with only
+`codex_network: "isolated"` and describe it as "closed network egress". Under
+the new default `worker_posture: "trusted"`, explicit
+`codex_network: "isolated"` emits no sandbox flags and still loads user/project
+Codex config, so it is not the old closed envelope. Those examples need to set
+`worker_posture: "restricted"` if they are meant to demonstrate closed network
+egress, or change the text to explain trusted/manual-parity behavior.
+
+The later migration section in `docs/development/codex-backend.md:159-205` is
+also still written as if omitted `codex_network` always upgrades to isolated /
+`--ignore-user-config`. That is now restricted-only after #58; under trusted,
+omission is the intended default and persists `codex_network: null`. This
+section should either be reframed as historical / restricted-posture migration
+guidance, or updated to the same two-axis model used in `docs/reference.md`.
+
+## Notes
+
+The previous review findings are otherwise resolved:
+
+- Trusted+absent Codex no longer emits `codex_network_defaulted`.
+- Restricted+absent Codex still emits the warning with posture-specific text.
+- Bad `worker_posture` values now land in profile inspection diagnostics.
+
+I did not rerun `pnpm verify`; the implementer reported it passing after this
+round.

--- a/plans/58-issue-with-setting-sources/reviews/review-implementation-followup-2026-05-12.md
+++ b/plans/58-issue-with-setting-sources/reviews/review-implementation-followup-2026-05-12.md
@@ -1,0 +1,69 @@
+# Implementation Follow-Up Review - 2026-05-12
+
+## Findings
+
+### Medium - Trusted Codex default now has an unsilenceable warning and stale public docs
+
+The high-priority functional fix is present: `modelSettingsForBackend()` now
+persists `codex_network: null` for trusted+absent Codex runs, and
+`sandboxArgs()` maps that cell to the trusted default `sandbox_mode` +
+`network_access` flags.
+
+The remaining issue is the `codex_network_defaulted` warning path and docs. The
+service still emits a warning for trusted+absent Codex runs and tells users to
+"Set codex_network explicitly to silence this warning"
+(`src/orchestratorService.ts:407-412`). Under the new mapping, there is no
+explicit `codex_network` value that preserves the same argv as the trusted
+default: `null` emits both `sandbox_mode="workspace-write"` and network access,
+`workspace` emits only network access, and `isolated` / `user-config` emit no
+sandbox flags (`src/backend/codex.ts:173-183`). So every profile that wants the
+new default gets a persistent warning that cannot be silenced without changing
+behavior.
+
+The public docs still reinforce the old model in a few places:
+`docs/development/codex-backend.md:70-74` says omitted `codex_network` resolves
+to `'isolated'` uniformly, `docs/development/codex-backend.md:121-127` shows the
+old warning text, and `docs/reference.md:151-159` still documents
+`codex_network` as if `worker_posture` did not exist.
+
+Suggested fix: either suppress `codex_network_defaulted` for
+`worker_posture: 'trusted'` because the absence is now the intended default, or
+introduce an explicit way to select the trusted-default cell. Then update the
+Default, Per-Run Warning, and reference docs so they match the posture-aware
+contract.
+
+### Medium - `list_worker_profiles` still accepts invalid `worker_posture`
+
+`WorkerProfileSchema` accepts `worker_posture` as any non-empty string
+(`src/harness/capabilities.ts:48-52`), and the list/inspect validation path does
+not check it in `validateProfile()` or the backend-specific validators
+(`src/harness/capabilities.ts:237-340`). A hand-edited manifest with
+`worker_posture: "trustd"` will therefore appear in `list_worker_profiles` as a
+valid profile, then fail only later when `start_run` reaches
+`parseProfileModelSettings()` (`src/orchestratorService.ts:2247-2253`).
+
+That differs from `reasoning_effort`, `service_tier`, and `codex_network`, which
+are surfaced as invalid profile diagnostics before the supervisor chooses a
+worker. Since the supervisor is expected to use `list_worker_profiles` as the
+profile health check, invalid `worker_posture` should be reported there too.
+
+Suggested fix: add a `WORKER_POSTURE_VALUES = ['trusted', 'restricted']` check
+to the harness profile validation path for all backends, and add a
+`list_worker_profiles` test proving a bad posture lands in `invalid_profiles`.
+
+## Notes
+
+The previous implementation findings are otherwise addressed:
+
+- Default trusted Codex direct/profile starts now have integration coverage for
+  `sandbox_mode="workspace-write"`, network access, no `--ignore-user-config`,
+  and persisted `codex_network: null`.
+- Cursor appends `worker_posture` after `agent.send()` resolves, with a
+  send-failure regression test.
+- CLI retry keeps retry `initialEvents`, with a retry-path regression test for
+  exactly one surviving posture event.
+- Supervisor prompt/tool descriptions were updated, apart from the stale public
+  reference/default docs noted above.
+
+I did not rerun `pnpm verify`; the implementer reported it passing after the
+follow-up.

--- a/plans/58-issue-with-setting-sources/reviews/review-plan-2026-05-12.md
+++ b/plans/58-issue-with-setting-sources/reviews/review-plan-2026-05-12.md
@@ -1,0 +1,270 @@
+# Plan Review: Worker Project MCP Access
+
+Date: 2026-05-12
+Reviewer: Codex
+Scope:
+- `plans/58-issue-with-setting-sources/plan.md`
+- `plans/58-issue-with-setting-sources/plans/58-worker-project-mcp-access.md`
+
+## Findings
+
+### High: `--setting-sources user,project,local` is broader than project MCP access
+
+The plan frames the Claude change mostly as "load `.mcp.json` and maybe
+`.claude/settings.json`" (`58-worker-project-mcp-access.md:63-66`,
+`122-134`). Claude's current docs say scopes apply to settings, subagents, MCP
+servers, plugins, and `CLAUDE.md`, with local > project > user precedence.
+
+So when a project has `.mcp.json`, this plan would also let Claude workers load
+project/local Claude memory and project subagents/plugins. That may be the
+right product direction, but it is not called out as an accepted blast radius.
+This matters because behavior changes only for projects with `.mcp.json`, so
+the same worker profile may receive different instruction/plugin surfaces based
+on whether MCP is configured.
+
+Recommendation: add an explicit decision/risk that the Claude worker is opting
+back into normal project/local Claude Code scope behavior, not just project MCP
+servers. If that is not intended, reconsider `--mcp-config <cwd>/.mcp.json`
+or another MCP-only path despite the extra implementation work.
+
+### High: project `.mcp.json` is executable configuration and runs outside the model tool path
+
+Project-scoped stdio MCP servers are local processes. The local Claude CLI help
+for `mcp list` says the workspace trust dialog is skipped and stdio servers
+from `.mcp.json` are spawned for health checks. A temp-dir probe on Claude Code
+2.1.139 confirmed that `--setting-sources user,project,local` caused a
+project `.mcp.json` stdio command to execute, while `--setting-sources user`
+did not.
+
+That does not make the plan wrong: workers are already trusted-local,
+full-access processes. But this is still a distinct implication because MCP
+server startup can happen as part of Claude/MCP initialization and not as a
+visible Bash/Edit tool action. It also means those server processes inherit the
+worker environment after the daemon's env policy is applied.
+
+Recommendation: document this explicitly in Risks and in
+`docs/development/mcp-tooling.md`: enabling project MCP for Claude workers
+means trusting project `.mcp.json` command entries as executable local config.
+Also state that secret-bearing entries must keep using
+`scripts/mcp-secret-bridge.mjs`.
+
+### Medium: T2's lifecycle event placement is underspecified and can become false telemetry
+
+T2 says `prepareWorkerIsolation` should emit a lifecycle event
+(`58-worker-project-mcp-access.md:141`). But `prepareWorkerIsolation` is called
+from `ClaudeBackend.start()`/`resume()` while building a `WorkerInvocation`, and
+`CliRuntime.buildStartInvocation()` also calls `backend.start()` to pre-bake a
+retry invocation for Claude rotation before that invocation is necessarily
+spawned (`src/backend/runtime.ts:102-112`, `src/orchestratorService.ts:973-999`).
+
+If the backend appends the event directly from `prepareWorkerIsolation`, a
+rotation resume could record `worker_setting_sources` for a fresh-chat retry
+that never actually happened. It would also append before
+`ProcessManager`'s normal `status: started` lifecycle marker.
+
+Recommendation: either drop T2, or implement it as spawn-time telemetry owned
+by the runtime/process manager, e.g. an optional `WorkerInvocation.initialEvents`
+array persisted only when `ProcessManager.start()` actually spawns the attempt.
+Add tests covering normal start/resume and the build-only retry-invocation path.
+
+### Medium: the plan can appear to close #58 while codex/cursor remain unfixed
+
+Issue #58 explicitly says this is needed for all backends. Decisions 6 and 7
+make codex/cursor "audit + documentation only" unless a clean fix is discovered
+(`58-worker-project-mcp-access.md:68-69`, `100-106`, `146-149`). That is a
+reasonable engineering stance, but it should be represented as a partial
+delivery, not a full issue fix, if the audits produce follow-up issues.
+
+Recommendation: add an explicit release/closure rule: this plan may land a
+Claude fix plus codex/cursor audit, but #58 stays open or is split unless the
+codex and cursor worker gaps are actually resolved. Also move final
+`pnpm verify` after T9/T10; today T6 runs before the codex/cursor audit docs
+and optional fixes, so it is not a final verification gate for the full plan.
+
+### Low: codex audit acceptance mentions flags that are not present in current help
+
+T7 asks the execution log to capture `--config-file` / `--config-dir`
+possibilities (`58-worker-project-mcp-access.md:146`). On local `codex-cli
+0.130.0`, `codex exec --help` exposes `-c/--config`, `--profile`, `--cd`,
+`--ignore-user-config`, and `--ignore-rules`, but no `--config-file` or
+`--config-dir`.
+
+Recommendation: keep the audit, but phrase T7 as "capture the config-loading
+surface, including whether any config-file/config-dir flag exists" rather than
+expecting those flags.
+
+## Overall Assessment
+
+The Claude direction is probably the right narrow first step if the product
+goal is "workers behave more like normal Claude Code sessions in trusted
+project worktrees." The main gap is that the plan describes the change as MCP
+access, while the chosen mechanism restores broader project/local Claude Code
+scope behavior. That should be an explicit product decision, not an incidental
+side effect.
+
+I would revise the plan before implementation, mostly around the blast-radius
+decision and T2 event placement.
+
+## Product Direction Addendum
+
+After follow-up clarification, the desired product behavior is:
+
+> The orchestrator/supervisor is the restricted agent. Worker agents are
+> trusted execution agents and should have the same practical access the user
+> would get when launching the same backend manually in the project: normal
+> network posture, normal project/user configuration, and normal MCP access.
+
+This changes the plan framing. The implementation should not be described as a
+small MCP exception inside a generally isolated worker envelope. It should be
+described as restoring backend-native worker parity while keeping the
+orchestrator envelope curated.
+
+Recommended plan rewrite:
+
+- **Claude workers:** default to normal project/user/local Claude Code sources
+  for workers, not only when `.mcp.json` exists. The supervisor remains on its
+  curated `--strict-mcp-config` / restricted-tool envelope. Keep
+  `--permission-mode bypassPermissions` so non-interactive workers do not
+  stall. Re-decide `disableAllHooks: true` explicitly: keeping it preserves
+  daemon hook isolation, while removing it is closer to exact manual parity.
+- **Codex workers:** default toward user/project config parity, not
+  `--ignore-user-config`. The current `codex_network: isolated` default is the
+  opposite of the clarified product goal for general-purpose workers. Isolation
+  should become a profile opt-in, not the default posture.
+- **Cursor workers:** prefer the backend surface that best matches a manual
+  Cursor worker. If the SDK cannot prove parity for project/global MCP,
+  `cursor-agent` CLI should become the worker runtime or an explicit runtime
+  option.
+
+The revised acceptance criterion for #58 should be: a worker can see the same
+backend-native project MCP/tools/config that a manual trusted run would see,
+unless a profile explicitly opts into a stricter worker posture.
+
+## Documentation Verification Addendum
+
+I checked the upstream tool documentation online on 2026-05-12:
+
+- Claude Code: settings, MCP, and CLI reference docs.
+- OpenAI Codex: configuration basics, MCP, approvals/security, and
+  configuration reference docs.
+- Cursor: CLI usage, CLI MCP, MCP overview, headless CLI, and TypeScript SDK
+  docs.
+- Local CLI help for the installed tools: Claude Code 2.1.139,
+  `codex-cli 0.130.0`, and the installed `cursor-agent`.
+
+### High: worker parity should be the default contract, not a Claude-only MCP exception
+
+The docs for all three backends describe layered project/user configuration
+that affects more than MCP. Claude's `--setting-sources` controls project/user
+settings surfaces; Codex loads trusted project `.codex/config.toml` plus user
+`~/.codex/config.toml`; Cursor CLI and SDK both have documented project/user
+configuration and MCP loading paths.
+
+So the plan should not gate worker parity on the presence of a Claude
+`.mcp.json`, and it should not treat Codex/Cursor as audit-only unless the issue
+is explicitly split. The correct product shape is:
+
+- The orchestrator/supervisor stays tightly controlled.
+- Workers default to trusted backend-native project/user access.
+- Stricter isolation is an explicit profile option.
+
+### High: Codex has enough documented surface to implement, not just audit
+
+Codex docs confirm that configuration precedence includes CLI overrides,
+profiles, trusted project `.codex/config.toml`, user config, system config, and
+defaults. They also confirm that MCP servers live in `config.toml`, including
+project-scoped `.codex/config.toml` for trusted projects, and that CLI and IDE
+share this configuration.
+
+The current plan's Codex direction conflicts with the clarified goal if it
+keeps `--ignore-user-config` or defaults `codex_network` to `isolated`. Codex's
+default `workspace-write` sandbox has network disabled unless
+`[sandbox_workspace_write].network_access = true`, while full no-prompt network
+and filesystem access requires `danger-full-access` or the documented bypass
+flag. The plan should decide whether trusted workers inherit user/project Codex
+configuration exactly, or whether the orchestrator passes a documented trusted
+worker profile. It should not silently force the isolated posture.
+
+### High: Cursor also has enough documented surface to implement, not just audit
+
+Cursor CLI docs say the CLI uses the same MCP configuration as the editor,
+discovers project/global/nested MCP configuration, exposes `agent mcp list`,
+`agent mcp list-tools`, `agent mcp login`, `agent mcp enable`, and
+`agent mcp disable`, and supports `--approve-mcps` for non-interactive MCP
+approval. Local help also shows `--workspace`, `--trust`, `--sandbox`,
+`--force`/`--yolo`, `--print`, and structured output flags.
+
+Cursor SDK docs also contradict the assumption that the SDK has no usable
+configuration/MCP surface. `Agent.create()` supports `local.cwd`,
+`local.settingSources`, `local.sandboxOptions`, and inline `mcpServers`.
+`local.settingSources` can select ambient `project`, `user`, `team`, `mdm`,
+`plugins`, or `all` settings layers. The docs do warn that inline
+`mcpServers` are not persisted across `Agent.resume()`, so file-based ambient
+settings are the better parity path when possible.
+
+T8 should therefore become an implementation decision:
+
+- Keep the SDK backend and set `local.settingSources` for worker parity, with
+  focused tests around project/user MCP discovery and resume behavior.
+- Or add/switch to a Cursor CLI worker runtime using `agent -p --workspace`,
+  `--trust`, `--approve-mcps`, and the profile-selected sandbox/force flags.
+
+### Medium: Claude project MCP approval must be handled explicitly
+
+Claude docs state that project-scoped MCP servers live in `.mcp.json`, are
+intended to be checked into the repo, and require approval before use. Claude
+settings also include `enableAllProjectMcpServers`, `enabledMcpjsonServers`,
+and `disabledMcpjsonServers`.
+
+Because workers are non-interactive, the plan should not rely on a project MCP
+approval prompt appearing at runtime. For the clarified trusted-worker model,
+the plan should either enable all project MCP servers for workers, carry through
+the user's local approval state intentionally, or define a profile-level
+allowlist. The chosen behavior should be documented because `.mcp.json` can
+launch local stdio server commands.
+
+### Medium: "network access" needs a backend-specific profile contract
+
+The tools do not expose one identical network switch:
+
+- Codex documents network-off defaults in `workspace-write`, a config key to
+  enable network there, and full-access flags for no-prompt trusted operation.
+- Cursor exposes CLI sandbox and force controls, and its headless docs describe
+  `--force` as the way to allow direct file changes in scripts. MCP has its own
+  approval path via `--approve-mcps`.
+- Claude's relevant documented controls here are settings sources, MCP approval
+  state, tool availability, and permission mode.
+
+The plan should name the worker posture, e.g. `trusted` / `manual-parity` versus
+`restricted`, and map that posture per backend. Otherwise "same access as a
+manual run" will keep being interpreted differently by each backend.
+
+### Low: update acceptance criteria and tests around all backends
+
+The revised plan should add acceptance checks for:
+
+- Claude worker sees project/user/local MCP and settings as intended; supervisor
+  remains restricted.
+- Claude project MCP approval behavior is deterministic in non-interactive
+  workers.
+- Codex worker loads trusted project/user config and project/user MCP without
+  `--ignore-user-config` in the default trusted posture.
+- Codex network posture follows the selected worker profile, not the old
+  isolated default.
+- Cursor worker loads project/global MCP through either SDK `settingSources` or
+  the Cursor CLI path, including non-interactive MCP approval behavior.
+
+### Sources Checked
+
+- https://code.claude.com/docs/en/settings
+- https://code.claude.com/docs/en/mcp
+- https://code.claude.com/docs/en/cli-reference
+- https://developers.openai.com/codex/config-basic#configuration-precedence
+- https://developers.openai.com/codex/mcp#connect-codex-to-an-mcp-server
+- https://developers.openai.com/codex/agent-approvals-security#network-access
+- https://developers.openai.com/codex/config-reference#configtoml
+- https://cursor.com/docs/cli/using
+- https://cursor.com/docs/cli/mcp
+- https://cursor.com/docs/mcp
+- https://cursor.com/docs/cli/headless
+- https://cursor.com/docs/sdk/typescript

--- a/plans/58-issue-with-setting-sources/reviews/review-plan-rev2-2026-05-12.md
+++ b/plans/58-issue-with-setting-sources/reviews/review-plan-rev2-2026-05-12.md
@@ -1,0 +1,154 @@
+# Plan Review Rev. 2: Worker Backend-Native Parity
+
+Date: 2026-05-12
+Reviewer: Codex
+Scope:
+- `plans/58-issue-with-setting-sources/plan.md`
+- `plans/58-issue-with-setting-sources/plans/58-worker-project-mcp-access.md`
+
+## Findings
+
+### High: Codex trusted mapping uses a flag that `codex exec resume` does not support
+
+Decision 6 and T-Codex-1 specify `--sandbox workspace-write` for trusted Codex
+workers (`58-worker-project-mcp-access.md:114`, `156-157`, `231`). That works
+for `codex exec`, but local `codex-cli 0.130.0` shows `codex exec resume
+--help` does not accept `--sandbox` or `--cd`; it accepts `-c/--config`,
+`--ignore-user-config`, and related resume flags.
+
+Current `src/backend/codex.ts` shares `sandboxArgs()` between `start()` and
+`resume()` (`src/backend/codex.ts:8-33`, `144-160`). If T-Codex-1 implements
+`--sandbox workspace-write` in that shared helper, Codex follow-ups will spawn
+with an invalid argv.
+
+Recommendation: use config overrides that both start and resume accept, e.g.
+`-c sandbox_mode="workspace-write"` plus
+`-c sandbox_workspace_write.network_access=true`, or split start/resume argv
+generation explicitly and test both paths with the local help surface.
+
+### High: `worker_posture` persistence and follow-up inheritance are underspecified
+
+The plan adds `worker_posture` to profiles and direct-mode schemas
+(`58-worker-project-mcp-access.md:109-110`, `144-147`, `224-225`), but it does
+not explicitly say where the resolved posture is persisted on the run record or
+how `send_followup` inherits it. Today the runtime-visible settings are carried
+through `RunModelSettings` (`src/contract.ts:253-265`), and follow-ups inherit
+`parent.meta.model_settings` unless the follow-up overrides model settings
+(`src/orchestratorService.ts:794-808`).
+
+Without an explicit persistence rule, a restricted parent run can silently
+produce a trusted child on follow-up, or direct-mode `send_followup` can become
+ambiguous. The same ambiguity exists for profile-mode starts if a caller passes
+both `profile` and a direct `worker_posture` field; the current schema already
+forbids profile mode from mixing direct settings such as `codex_network`
+(`src/contract.ts:361-390`), and the new field needs the same kind of rule.
+
+Recommendation: add a decision and tasks for:
+
+- Persisting the resolved posture, probably on `RunModelSettingsSchema` or an
+  equally durable run-meta field.
+- Inheriting the parent posture on `send_followup` unless a valid direct-mode
+  override is supplied.
+- Rejecting `profile + worker_posture` on `start_run`, or clearly defining
+  precedence if you want that override.
+- Adding tests for profile start, direct start, profile-mode follow-up, direct
+  follow-up override, and legacy records with no posture.
+
+### Medium: Existing explicit `codex_network: "workspace"` profiles still suppress user config
+
+Decision 9 says explicit `codex_network` values keep winning in either posture
+(`58-worker-project-mcp-access.md:117`), while the trusted default only changes
+when `codex_network` is absent (`58-worker-project-mcp-access.md:154-159`,
+`231`). In current code, `codex_network: "workspace"` means
+`--ignore-user-config -c sandbox_workspace_write.network_access=true`
+(`src/backend/codex.ts:144-155`).
+
+That means any existing Codex profile that explicitly set `"workspace"` to get
+network access will remain unable to load user config and may still miss user
+MCP config after this plan lands. That is a surprising result for an issue whose
+new contract is "trusted workers get backend-native user/project config and
+network access."
+
+Recommendation: either separate Codex config-source posture from network
+posture, or redefine the trusted interpretation of explicit
+`codex_network: "workspace"` so it enables workspace network without
+`--ignore-user-config`.
+If explicit values must preserve old behavior, call that out as a migration risk
+and add a test proving the warning/docs explain it.
+
+### Medium: Cursor `['project', 'user']` is not full Cursor setting-source parity
+
+The plan's product framing says trusted workers get normal project/user config,
+project MCP, and "subagents / plugins discovery where applicable"
+(`58-worker-project-mcp-access.md:29-34`). But Decision 7 only passes
+`local.settingSources: ['project', 'user']` for Cursor
+(`58-worker-project-mcp-access.md:115`, `160-165`, `233`).
+
+The prior documentation verification recorded that Cursor SDK
+`local.settingSources` also supports `team`, `mdm`, `plugins`, and `all`
+(`review-plan-2026-05-12.md:197-203`). If a manual Cursor run loads plugins,
+team, or MDM-managed settings, `['project', 'user']` is not full backend-native
+parity.
+
+Recommendation: use `local.settingSources: ['all']` for trusted Cursor workers,
+or explicitly narrow the product claim and risk table to "project + user only"
+and explain why team/MDM/plugins are intentionally excluded.
+
+### Medium: Cursor telemetry is not covered by the `WorkerInvocation.initialEvents` design
+
+The plan states that `WorkerInvocation.initialEvents` and `ProcessManager`
+spawn-time flushing cover backend telemetry
+(`58-worker-project-mcp-access.md` lines 166-170 and 226-235). That applies to
+CLI backends, but Cursor does not produce a `WorkerInvocation` and does not go
+through `ProcessManager.start()`.
+`CursorSdkRuntime.spawn()` returns its own runtime handle
+(`src/backend/cursor/runtime.ts:68-74`, `94-208`), and Cursor lifecycle events
+are appended in `drainAndFinalize()` (`src/backend/cursor/runtime.ts:277-291`).
+
+T-Cursor-2 currently says the test should assert that the adapter receives
+`settingSources` (`58-worker-project-mcp-access.md:233-234`), but that does not
+prove a `worker_posture` lifecycle event reaches `get_run_events`.
+
+Recommendation: add a Cursor-specific telemetry path, for example an
+`initialEvents` field on `CursorRunState` or explicit append in
+`drainAndFinalize()` before the backend stream is drained. Test both
+`Agent.create` and `Agent.resume` and assert the run event log contains the
+Cursor posture event.
+
+### Low: Profile management surfaces are not explicitly in T-Profile-1
+
+T-Profile-1 covers the manifest and direct-mode schemas
+(`58-worker-project-mcp-access.md:224`), but profile management also goes
+through `upsert_worker_profile`, `list_worker_profiles`, profile formatting for
+supervisors, and generated MCP tool schemas. Current code has separate paths for
+`UpsertWorkerProfileInputSchema`, `workerProfileFromUpsert()`,
+`formatValidProfile()`, and MCP tool descriptions
+(`src/contract.ts:439-485`, `src/orchestratorService.ts:2080-2115`,
+`src/mcpTools.ts:1-70`).
+
+Recommendation: expand T-Profile-1 acceptance to include upsert/list
+round-trip, MCP tool schema exposure, and supervisor profile-rendering updates
+so operators can actually set and inspect `worker_posture`.
+
+## Overall Assessment
+
+The rewrite is directionally much stronger than rev. 1. It resolves the main
+product framing issue: workers are trusted execution agents, the supervisor is
+curated, and Codex/Cursor are now real implementation scope rather than audit
+only.
+
+I would revise before implementation. The two blockers are the Codex resume
+argv issue and the unresolved persistence/inheritance semantics for
+`worker_posture`. The Cursor and Codex-default concerns are also worth tightening
+now because they affect whether the implementation really delivers "manual
+parity" rather than a partial approximation.
+
+## Verification
+
+- Read the two plan files directly; they are currently untracked, so
+  `git diff HEAD` has no content for them.
+- Cross-checked current source in `contract.ts`, `orchestratorService.ts`,
+  `codex.ts`, `cursor/runtime.ts`, `cursor/sdk.ts`, `processManager.ts`, and
+  `WorkerBackend.ts`.
+- Checked local `codex exec --help` and `codex exec resume --help`.
+- Did not run build/test; this was a plan review only.

--- a/src/__tests__/authPrecedence.test.ts
+++ b/src/__tests__/authPrecedence.test.ts
@@ -42,7 +42,7 @@ describe('cursor auth precedence and missing-key shape', () => {
     const store = new RunStore(home);
     const cwd = await mkdtemp(join(tmpdir(), 'cursor-noauth-cwd-'));
     const runtime = new CursorSdkRuntime(okAdapter, { store, env: {} });
-    const result = await runtime.start({ runId: 'r1', prompt: 'p', cwd, model: 'composer-2', modelSettings: { reasoning_effort: null, service_tier: null, mode: null, codex_network: null } });
+    const result = await runtime.start({ runId: 'r1', prompt: 'p', cwd, model: 'composer-2', modelSettings: { reasoning_effort: null, service_tier: null, mode: null, codex_network: null, worker_posture: null } });
     assert.equal(result.ok, false);
     if (result.ok) return;
     assert.equal(result.failure.code, 'SPAWN_FAILED');

--- a/src/__tests__/backendInvocation.test.ts
+++ b/src/__tests__/backendInvocation.test.ts
@@ -23,59 +23,129 @@ describe('backend invocations', () => {
     );
   });
 
-  it('passes model selection to Codex start and resume (issue #31: codex_network drives sandbox argv)', async () => {
+  it('restricted posture: codex_network drives sandbox argv (issue #31 contract preserved)', async () => {
     const backend = new CodexBackend();
 
-    // codex_network='user-config' must NOT add --ignore-user-config, even when
-    // the legacy mode='normal' breadcrumb is also present. This is the
-    // inverse-bug regression case (P5) for issue #31: it pins that the codex
-    // backend reads codex_network only and never re-couples to mode/service_tier.
+    // codex_network='user-config' must NOT add --ignore-user-config.
     assert.deepStrictEqual(
       (await backend.start({
         prompt: 'work',
         cwd: '/repo',
         model: 'gpt-5.2',
-        modelSettings: { reasoning_effort: 'xhigh', service_tier: 'fast', mode: 'normal', codex_network: 'user-config' },
+        modelSettings: { reasoning_effort: 'xhigh', service_tier: 'fast', mode: 'normal', codex_network: 'user-config', worker_posture: 'restricted' },
       })).args,
       ['exec', '--json', '--skip-git-repo-check', '--cd', '/repo', '--model', 'gpt-5.2', '-c', 'model_reasoning_effort="xhigh"', '-c', 'service_tier="fast"', '-'],
     );
-    // codex_network='isolated' adds only --ignore-user-config.
+    // codex_network='isolated' under restricted adds only --ignore-user-config.
     assert.deepStrictEqual(
       (await backend.resume('session-1', {
         prompt: 'continue',
         cwd: '/repo',
         model: 'gpt-5.4',
-        modelSettings: { reasoning_effort: 'medium', service_tier: null, mode: 'normal', codex_network: 'isolated' },
+        modelSettings: { reasoning_effort: 'medium', service_tier: null, mode: 'normal', codex_network: 'isolated', worker_posture: 'restricted' },
       })).args,
       ['exec', 'resume', '--json', '--skip-git-repo-check', '--ignore-user-config', '--model', 'gpt-5.4', '-c', 'model_reasoning_effort="medium"', 'session-1', '-'],
     );
-    // codex_network='workspace' adds --ignore-user-config plus the literal
-    // -c sandbox_workspace_write.network_access=true verified on codex-cli
-    // 0.128.0 (RQ2). Must NOT splice an explicit --sandbox flag (per C3).
+    // codex_network='workspace' under restricted adds --ignore-user-config plus
+    // -c sandbox_workspace_write.network_access=true. Must NOT splice --sandbox.
     assert.deepStrictEqual(
       (await backend.start({
         prompt: 'fetch',
         cwd: '/repo',
         model: 'gpt-5.5',
-        modelSettings: { reasoning_effort: 'xhigh', service_tier: null, mode: null, codex_network: 'workspace' },
+        modelSettings: { reasoning_effort: 'xhigh', service_tier: null, mode: null, codex_network: 'workspace', worker_posture: 'restricted' },
       })).args,
       ['exec', '--json', '--skip-git-repo-check', '--ignore-user-config', '-c', 'sandbox_workspace_write.network_access=true', '--cd', '/repo', '--model', 'gpt-5.5', '-c', 'model_reasoning_effort="xhigh"', '-'],
     );
   });
 
-  it('issue #31 inverse-bug regression: codex_network=user-config + service_tier=normal must NOT pass --ignore-user-config', async () => {
+  it('trusted posture: codex_network drives sandbox argv via -c overrides, no --ignore-user-config and no --sandbox (issue #58 Decisions 6/9)', async () => {
     const backend = new CodexBackend();
-    const args = (await backend.start({
-      prompt: 'fetch',
+
+    // trusted + 'user-config' => no flags
+    assert.deepStrictEqual(
+      (await backend.start({
+        prompt: 'work',
+        cwd: '/repo',
+        model: 'gpt-5.2',
+        modelSettings: { reasoning_effort: 'xhigh', service_tier: null, mode: null, codex_network: 'user-config', worker_posture: 'trusted' },
+      })).args,
+      ['exec', '--json', '--skip-git-repo-check', '--cd', '/repo', '--model', 'gpt-5.2', '-c', 'model_reasoning_effort="xhigh"', '-'],
+    );
+
+    // trusted + 'isolated' => no flags (codex defaults apply)
+    assert.deepStrictEqual(
+      (await backend.resume('session-1', {
+        prompt: 'continue',
+        cwd: '/repo',
+        model: 'gpt-5.4',
+        modelSettings: { reasoning_effort: 'medium', service_tier: null, mode: 'normal', codex_network: 'isolated', worker_posture: 'trusted' },
+      })).args,
+      ['exec', 'resume', '--json', '--skip-git-repo-check', '--model', 'gpt-5.4', '-c', 'model_reasoning_effort="medium"', 'session-1', '-'],
+    );
+
+    // trusted + 'workspace' => only network-access override
+    assert.deepStrictEqual(
+      (await backend.start({
+        prompt: 'fetch',
+        cwd: '/repo',
+        model: 'gpt-5.5',
+        modelSettings: { reasoning_effort: 'xhigh', service_tier: null, mode: null, codex_network: 'workspace', worker_posture: 'trusted' },
+      })).args,
+      ['exec', '--json', '--skip-git-repo-check', '-c', 'sandbox_workspace_write.network_access=true', '--cd', '/repo', '--model', 'gpt-5.5', '-c', 'model_reasoning_effort="xhigh"', '-'],
+    );
+
+    // trusted + absent codex_network => sandbox_mode workspace-write + network on
+    const trustedDefaultStart = (await backend.start({
+      prompt: 'work',
       cwd: '/repo',
       model: 'gpt-5.5',
-      // service_tier='normal' is preserved on input here for the regression
-      // shape; in the orchestrator service service_tier='normal' is suppressed
-      // before this point. The argv assertion is the load-bearing part: the
-      // codex backend reads codex_network only.
-      modelSettings: { reasoning_effort: 'high', service_tier: null, mode: 'normal', codex_network: 'user-config' },
+      modelSettings: { reasoning_effort: 'medium', service_tier: null, mode: null, codex_network: null, worker_posture: 'trusted' },
     })).args;
-    assert.equal(args.includes('--ignore-user-config'), false, '--ignore-user-config must not be present when codex_network=user-config');
+    assert.deepStrictEqual(trustedDefaultStart, ['exec', '--json', '--skip-git-repo-check', '-c', 'sandbox_mode="workspace-write"', '-c', 'sandbox_workspace_write.network_access=true', '--cd', '/repo', '--model', 'gpt-5.5', '-c', 'model_reasoning_effort="medium"', '-']);
+
+    // trusted + absent on resume must NOT emit --sandbox or --cd (review rev. 2 F1).
+    const trustedDefaultResume = (await backend.resume('session-7', {
+      prompt: 'continue',
+      cwd: '/repo',
+      model: 'gpt-5.5',
+      modelSettings: { reasoning_effort: 'medium', service_tier: null, mode: null, codex_network: null, worker_posture: 'trusted' },
+    })).args;
+    assert.equal(trustedDefaultResume.includes('--sandbox'), false, 'resume must never emit --sandbox (codex 0.130.0 rejects it)');
+    assert.equal(trustedDefaultResume.includes('--cd'), false, 'resume must never emit --cd (codex 0.130.0 rejects it on resume)');
+    assert.ok(trustedDefaultResume.includes('-c'), 'resume keeps -c overrides which both subcommands accept');
+  });
+
+  it('codex backend populates initialEvents with a worker_posture lifecycle event (issue #58 Decision 11)', async () => {
+    const backend = new CodexBackend();
+    const inv = await backend.start({
+      prompt: 'work',
+      cwd: '/repo',
+      model: 'gpt-5.5',
+      modelSettings: { reasoning_effort: 'medium', service_tier: null, mode: null, codex_network: 'workspace', worker_posture: 'trusted' },
+    });
+    assert.ok(inv.initialEvents);
+    assert.equal(inv.initialEvents!.length, 1);
+    const payload = inv.initialEvents![0]!.payload as Record<string, unknown>;
+    assert.equal(payload.state, 'worker_posture');
+    assert.equal(payload.backend, 'codex');
+    assert.equal(payload.worker_posture, 'trusted');
+    const codex = payload.codex as Record<string, unknown>;
+    assert.equal(codex.ignore_user_config, false, 'trusted must not ignore user config');
+    assert.equal(codex.network_access, true);
+    assert.equal(codex.codex_network, 'workspace');
+
+    const restrictedInv = await backend.resume('session-x', {
+      prompt: 'continue',
+      cwd: '/repo',
+      model: 'gpt-5.5',
+      modelSettings: { reasoning_effort: 'medium', service_tier: null, mode: null, codex_network: 'isolated', worker_posture: 'restricted' },
+    });
+    const restrictedPayload = restrictedInv.initialEvents![0]!.payload as Record<string, unknown>;
+    const restrictedCodex = restrictedPayload.codex as Record<string, unknown>;
+    assert.equal(restrictedPayload.worker_posture, 'restricted');
+    assert.equal(restrictedCodex.ignore_user_config, true);
+    assert.equal(restrictedCodex.network_access, false);
   });
 
   it('passes model selection to Claude start and resume', async () => {
@@ -86,7 +156,7 @@ describe('backend invocations', () => {
         prompt: 'work',
         cwd: '/repo',
         model: 'claude-opus-4-7',
-        modelSettings: { reasoning_effort: 'xhigh', service_tier: null, mode: null, codex_network: null },
+        modelSettings: { reasoning_effort: 'xhigh', service_tier: null, mode: null, codex_network: null, worker_posture: null },
       })).args,
       ['-p', '--output-format', 'stream-json', '--verbose', '--model', 'claude-opus-4-7', '--effort', 'xhigh'],
     );
@@ -95,7 +165,7 @@ describe('backend invocations', () => {
         prompt: 'continue',
         cwd: '/repo',
         model: 'claude-opus-4-7[1m]',
-        modelSettings: { reasoning_effort: 'max', service_tier: null, mode: null, codex_network: null },
+        modelSettings: { reasoning_effort: 'max', service_tier: null, mode: null, codex_network: null, worker_posture: null },
       })).args,
       ['-p', '--resume', 'session-1', '--output-format', 'stream-json', '--verbose', '--model', 'claude-opus-4-7[1m]', '--effort', 'max'],
     );

--- a/src/__tests__/claudeAccountContract.test.ts
+++ b/src/__tests__/claudeAccountContract.test.ts
@@ -175,3 +175,58 @@ describe('inspectWorkerProfiles claude account validation', () => {
     assert.ok(inspected.errors.some((message) => /claude_account.*backend=claude/.test(message)));
   });
 });
+
+describe('inspectWorkerProfiles worker_posture validation (issue #58 review Medium 2)', () => {
+  it('rejects manifests with an unsupported worker_posture so list_worker_profiles surfaces them as invalid', () => {
+    const manifest: WorkerProfileManifest = {
+      version: 1,
+      profiles: {
+        typo: {
+          backend: 'codex',
+          model: 'gpt-5.5',
+          worker_posture: 'trustd',
+        },
+        good: {
+          backend: 'codex',
+          model: 'gpt-5.5',
+          worker_posture: 'trusted',
+        },
+        also_good: {
+          backend: 'claude',
+          model: 'claude-opus-4-7',
+          worker_posture: 'restricted',
+        },
+      },
+    };
+    const catalog = createWorkerCapabilityCatalog();
+    const inspected = inspectWorkerProfiles(manifest, catalog);
+
+    assert.ok(inspected.invalid_profiles.typo, 'profile with worker_posture: "trustd" must land in invalid_profiles');
+    assert.ok(
+      inspected.errors.some((message) => /worker_posture trustd/.test(message)),
+      'invalid worker_posture must produce a clear diagnostic',
+    );
+    assert.ok(
+      inspected.errors.some((message) => /trusted, restricted/.test(message)),
+      'diagnostic must list the supported values',
+    );
+    assert.ok(inspected.profiles.good, 'profile with worker_posture: "trusted" stays valid');
+    assert.ok(inspected.profiles.also_good, 'profile with worker_posture: "restricted" stays valid');
+  });
+
+  it('accepts profiles that omit worker_posture (the default is trusted)', () => {
+    const manifest: WorkerProfileManifest = {
+      version: 1,
+      profiles: {
+        defaulted: {
+          backend: 'codex',
+          model: 'gpt-5.5',
+        },
+      },
+    };
+    const catalog = createWorkerCapabilityCatalog();
+    const inspected = inspectWorkerProfiles(manifest, catalog);
+    assert.ok(inspected.profiles.defaulted);
+    assert.deepStrictEqual(inspected.errors, []);
+  });
+});

--- a/src/__tests__/claudeResumeInterceptor.test.ts
+++ b/src/__tests__/claudeResumeInterceptor.test.ts
@@ -524,4 +524,62 @@ process.stdin.on('end', () => {
       'retry assistant_message must NOT be present at hook-fire time',
     );
   });
+
+  it('Test 8 — retry path emits exactly one worker_posture event (issue #58 review follow-up Medium 3)', async () => {
+    // Both the first attempt and the retry invocation carry their own
+    // initialEvents (the realistic shape — `backend.start()` populates
+    // it per invocation). The first attempt's event is buffered and
+    // dropped along with the cancelled-attempt stream; the retry's
+    // event must land so the run ends with exactly one posture event.
+    const root = await mkdtemp(join(tmpdir(), 'cor-resume-posture-'));
+    const failingCli = join(root, 'fail.js');
+    const successCli = join(root, 'ok.js');
+    await writeFakeClaude(failingCli, `
+process.stdin.on('data', () => {});
+process.stdin.on('end', () => {
+  console.log(JSON.stringify({ type: 'error', subtype: 'session_not_found', message: 'session not found' }));
+  setInterval(() => {}, 1000);
+});`);
+    await writeFakeClaude(successCli, `
+process.stdin.on('data', () => {});
+process.stdin.on('end', () => {
+  console.log(JSON.stringify({ type: 'system', subtype: 'init', session_id: 'sid-posture' }));
+  console.log(JSON.stringify({ type: 'result', subtype: 'success', result: 'ok', session_id: 'sid-posture' }));
+  process.exit(0);
+});`);
+
+    const store = new MarkTerminalCounterStore(root);
+    const run = await store.createRun({ backend: 'claude', cwd: root });
+    const manager = new ProcessManager(store);
+
+    const retryInvocation: WorkerInvocation = {
+      ...claudeInvocation({ cli: successCli, cwd: root }),
+      initialEvents: [{
+        type: 'lifecycle',
+        payload: { state: 'worker_posture', backend: 'claude', worker_posture: 'trusted', attempt: 'retry' },
+      }],
+    };
+    const interceptor: EarlyEventInterceptor = {
+      thresholdEvents: 50,
+      thresholdMs: 5_000,
+      classify: buildClassify(),
+      retryInvocation,
+    };
+    const invocation: WorkerInvocation = {
+      ...claudeInvocation({ cli: failingCli, cwd: root, interceptor }),
+      initialEvents: [{
+        type: 'lifecycle',
+        payload: { state: 'worker_posture', backend: 'claude', worker_posture: 'trusted', attempt: 'first' },
+      }],
+    };
+
+    const managed = await manager.start(run.run_id, new ClaudeBackend(), invocation);
+    await managed.completion;
+
+    const events = await readEvents(store, run.run_id);
+    const postureEvents = events.filter((event) => event.type === 'lifecycle' && (event.payload as { state?: string }).state === 'worker_posture');
+    assert.equal(postureEvents.length, 1, 'retry path must end with exactly one worker_posture event');
+    // The surviving event MUST be the retry's, not the cancelled first attempt's.
+    assert.equal((postureEvents[0]!.payload as { attempt?: string }).attempt, 'retry', 'cancelled first-attempt posture event was dropped; only the retry event survives');
+  });
 });

--- a/src/__tests__/claudeWorkerIsolation.test.ts
+++ b/src/__tests__/claudeWorkerIsolation.test.ts
@@ -1,18 +1,32 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import {
+  CLAUDE_TRUSTED_WORKER_SETTINGS_BODY,
   CLAUDE_WORKER_SETTINGS_BODY,
   CLAUDE_WORKER_SETTINGS_FILENAME,
   ClaudeBackend,
 } from '../backend/claude.js';
 import { RunStore } from '../runStore.js';
+import type { WorkerPosture } from '../contract.js';
 
-describe('Claude worker isolation (issue #40, T5 / Decision 9)', () => {
-  it('start emits --settings <per-run-path>, --setting-sources user, --permission-mode bypassPermissions, and writes the bypass+disableAllHooks settings on disk', async () => {
-    const root = await mkdtemp(join(tmpdir(), 'claude-iso-'));
+type ModelSettingsInput = {
+  reasoning_effort: null;
+  service_tier: null;
+  mode: null;
+  codex_network: null;
+  worker_posture: WorkerPosture | null;
+};
+
+function modelSettings(worker_posture: WorkerPosture | null): ModelSettingsInput {
+  return { reasoning_effort: null, service_tier: null, mode: null, codex_network: null, worker_posture };
+}
+
+describe('Claude worker isolation — restricted posture (issue #40 T5/D9; issue #47; issue #58 Decision 8 — preserved verbatim)', () => {
+  it('start under restricted posture emits --setting-sources user and writes the v1 worker settings body', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'claude-iso-restricted-'));
     try {
       const store = new RunStore(root);
       await store.ensureReady();
@@ -22,42 +36,32 @@ describe('Claude worker isolation (issue #40, T5 / Decision 9)', () => {
         runId: meta.run_id,
         cwd: root,
         prompt: 'hi',
-        modelSettings: { reasoning_effort: null, service_tier: null, mode: null, codex_network: null },
+        modelSettings: modelSettings('restricted'),
       });
-      const settingsIndex = invocation.args.findIndex((arg) => arg === '--settings');
-      assert.ok(settingsIndex >= 0, 'invocation must include --settings');
-      const settingsPath = invocation.args[settingsIndex + 1];
-      assert.ok(settingsPath, '--settings must be followed by an absolute path');
-      assert.equal(settingsPath, join(store.runDir(meta.run_id), CLAUDE_WORKER_SETTINGS_FILENAME));
-      assert.ok(invocation.args.includes('--setting-sources'));
+
       const sourcesIndex = invocation.args.findIndex((arg) => arg === '--setting-sources');
+      assert.ok(sourcesIndex >= 0, 'invocation must include --setting-sources');
       assert.equal(invocation.args[sourcesIndex + 1], 'user');
 
+      const settingsIndex = invocation.args.findIndex((arg) => arg === '--settings');
+      const settingsPath = invocation.args[settingsIndex + 1]!;
+      assert.equal(settingsPath, join(store.runDir(meta.run_id), CLAUDE_WORKER_SETTINGS_FILENAME));
+
       const permissionModeIndex = invocation.args.findIndex((arg) => arg === '--permission-mode');
-      assert.ok(permissionModeIndex >= 0, 'invocation must include --permission-mode');
       assert.equal(invocation.args[permissionModeIndex + 1], 'bypassPermissions');
-      assert.ok(
-        permissionModeIndex > sourcesIndex,
-        '--permission-mode should be adjacent to or after --setting-sources user (supervisor parity)',
-      );
-      assert.ok(
-        !invocation.args.includes('--dangerously-skip-permissions'),
-        '--dangerously-skip-permissions is banned per issue #13 Decisions 7 / 21',
-      );
+      assert.ok(permissionModeIndex > sourcesIndex, '--permission-mode follows --setting-sources');
+      assert.ok(!invocation.args.includes('--dangerously-skip-permissions'), '#13 D7/D21: dangerously-skip-permissions banned');
 
       const onDisk = JSON.parse(await readFile(settingsPath, 'utf8')) as Record<string, unknown>;
       assert.deepStrictEqual(onDisk, CLAUDE_WORKER_SETTINGS_BODY);
-      assert.equal(onDisk.disableAllHooks, true, 'worker isolation requires disableAllHooks');
-      const permissions = onDisk.permissions as Record<string, unknown> | undefined;
-      assert.equal(permissions?.defaultMode, 'bypassPermissions', 'on-disk permissions.defaultMode must be bypassPermissions');
-      assert.equal(onDisk.skipDangerousModePermissionPrompt, true, 'on-disk skipDangerousModePermissionPrompt must be true');
+      assert.equal('enableAllProjectMcpServers' in onDisk, false, 'restricted posture must NOT add enableAllProjectMcpServers');
     } finally {
       await rm(root, { recursive: true, force: true });
     }
   });
 
-  it('resume emits the same isolation flags and writes the same per-run settings on disk', async () => {
-    const root = await mkdtemp(join(tmpdir(), 'claude-iso-'));
+  it('resume under restricted posture emits the same isolation flags', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'claude-iso-restricted-resume-'));
     try {
       const store = new RunStore(root);
       await store.ensureReady();
@@ -67,34 +71,16 @@ describe('Claude worker isolation (issue #40, T5 / Decision 9)', () => {
         runId: meta.run_id,
         cwd: root,
         prompt: 'continue',
-        modelSettings: { reasoning_effort: null, service_tier: null, mode: null, codex_network: null },
+        modelSettings: modelSettings('restricted'),
       });
-      assert.ok(invocation.args.includes('--settings'));
-      assert.ok(invocation.args.includes('--setting-sources'));
       assert.ok(invocation.args.includes('--resume'));
-
       const sourcesIndex = invocation.args.findIndex((arg) => arg === '--setting-sources');
       assert.equal(invocation.args[sourcesIndex + 1], 'user');
       const permissionModeIndex = invocation.args.findIndex((arg) => arg === '--permission-mode');
-      assert.ok(permissionModeIndex >= 0, 'resume invocation must include --permission-mode');
       assert.equal(invocation.args[permissionModeIndex + 1], 'bypassPermissions');
-      assert.ok(
-        permissionModeIndex > sourcesIndex,
-        '--permission-mode should be adjacent to or after --setting-sources user',
-      );
-      assert.ok(
-        !invocation.args.includes('--dangerously-skip-permissions'),
-        '--dangerously-skip-permissions is banned per issue #13 Decisions 7 / 21',
-      );
-
-      const settingsIndex = invocation.args.findIndex((arg) => arg === '--settings');
-      const settingsPath = invocation.args[settingsIndex + 1]!;
-      assert.equal(settingsPath, join(store.runDir(meta.run_id), CLAUDE_WORKER_SETTINGS_FILENAME));
+      const settingsPath = invocation.args[invocation.args.indexOf('--settings') + 1]!;
       const onDisk = JSON.parse(await readFile(settingsPath, 'utf8')) as Record<string, unknown>;
-      assert.equal(onDisk.disableAllHooks, true, 'resume must still pin disableAllHooks');
-      const permissions = onDisk.permissions as Record<string, unknown> | undefined;
-      assert.equal(permissions?.defaultMode, 'bypassPermissions', 'resume on-disk permissions.defaultMode must be bypassPermissions');
-      assert.equal(onDisk.skipDangerousModePermissionPrompt, true, 'resume on-disk skipDangerousModePermissionPrompt must be true');
+      assert.deepStrictEqual(onDisk, CLAUDE_WORKER_SETTINGS_BODY);
     } finally {
       await rm(root, { recursive: true, force: true });
     }
@@ -105,82 +91,215 @@ describe('Claude worker isolation (issue #40, T5 / Decision 9)', () => {
     const invocation = await backend.start({
       cwd: '/tmp',
       prompt: 'hi',
-      modelSettings: { reasoning_effort: null, service_tier: null, mode: null, codex_network: null },
+      modelSettings: modelSettings('restricted'),
     });
     assert.ok(!invocation.args.includes('--settings'));
     assert.ok(!invocation.args.includes('--setting-sources'));
     assert.ok(!invocation.args.includes('--permission-mode'));
+    assert.equal(invocation.initialEvents, undefined, 'legacy/no-runId path must not emit lifecycle events');
   });
+});
 
-  it('with a representative user ~/.claude/settings.json hook present, the worker invocation still pins disableAllHooks:true and --setting-sources user (T5 / D9 isolation contract)', async () => {
-    // Argv-level isolation proof: even with a representative user-side hook
-    // configured under HOME/.claude/settings.json, the Claude worker
-    // invocation references a per-run settings file containing
-    // {disableAllHooks: true} and forces --setting-sources user. Per Claude
-    // Code semantics, this combination prevents inherited user hooks from
-    // firing during a worker run.
-    //
-    // TODO(t13b): when/if the Anthropic-credentialed live smoke is enabled,
-    // extend this to launch a real claude --print process against the temp
-    // HOME and assert no hook side effects (e.g. no marker file written).
-    // Today the wire-contract assertion is what we ship; the live proof is
-    // gated behind AGENT_ORCHESTRATOR_RC_LIVE_SMOKE.
-    const root = await mkdtemp(join(tmpdir(), 'claude-iso-userhook-'));
+describe('Claude worker isolation — trusted posture (issue #58)', () => {
+  it('start under trusted posture emits --setting-sources user,project,local and writes the trusted body with enableAllProjectMcpServers', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'claude-iso-trusted-'));
     try {
-      const homeClaudeDir = join(root, 'home', '.claude');
-      const { mkdir, writeFile } = await import('node:fs/promises');
-      await mkdir(homeClaudeDir, { recursive: true, mode: 0o700 });
-      // Representative user-side hook fixture. If this hook were to fire
-      // it would touch a sentinel file; the wire contract guarantees it
-      // won't because Claude Code respects disableAllHooks:true.
-      const sentinel = join(root, 'user-hook-fired.sentinel');
-      const userHookSettings = {
-        hooks: {
-          UserPromptSubmit: [{
-            hooks: [{ type: 'command', command: `touch ${JSON.stringify(sentinel).slice(1, -1)}` }],
-          }],
-          Stop: [{
-            hooks: [{ type: 'command', command: `touch ${JSON.stringify(sentinel).slice(1, -1)}` }],
-          }],
-        },
-      };
-      await writeFile(join(homeClaudeDir, 'settings.json'), `${JSON.stringify(userHookSettings, null, 2)}\n`, { mode: 0o600 });
-
-      const store = new RunStore(join(root, 'store'));
+      const store = new RunStore(root);
       await store.ensureReady();
-      const meta = await store.createRun({ backend: 'claude', cwd: root, prompt: 'do work' });
+      const meta = await store.createRun({ backend: 'claude', cwd: root, prompt: 'hi' });
       const backend = new ClaudeBackend(store);
       const invocation = await backend.start({
         runId: meta.run_id,
         cwd: root,
-        prompt: 'do work',
-        modelSettings: { reasoning_effort: null, service_tier: null, mode: null, codex_network: null },
+        prompt: 'hi',
+        modelSettings: modelSettings('trusted'),
       });
 
-      // 1. The worker invocation pins a per-run settings file...
-      const settingsIdx = invocation.args.indexOf('--settings');
-      assert.ok(settingsIdx >= 0, 'worker must pass --settings');
-      const settingsPath = invocation.args[settingsIdx + 1]!;
-      assert.equal(settingsPath, join(store.runDir(meta.run_id), CLAUDE_WORKER_SETTINGS_FILENAME));
-      // ...whose contents include disableAllHooks: true plus the worker
-      // permission posture (bypassPermissions + skipDangerousModePermissionPrompt).
+      const sourcesIndex = invocation.args.findIndex((arg) => arg === '--setting-sources');
+      assert.equal(invocation.args[sourcesIndex + 1], 'user,project,local', 'trusted must broaden setting-sources');
+
+      const settingsPath = invocation.args[invocation.args.indexOf('--settings') + 1]!;
       const onDisk = JSON.parse(await readFile(settingsPath, 'utf8')) as Record<string, unknown>;
-      assert.deepStrictEqual(onDisk, CLAUDE_WORKER_SETTINGS_BODY);
-      assert.equal(onDisk.disableAllHooks, true);
+      assert.deepStrictEqual(onDisk, CLAUDE_TRUSTED_WORKER_SETTINGS_BODY);
+      assert.equal(onDisk.enableAllProjectMcpServers, true, 'trusted body must auto-approve project MCP servers');
+      assert.equal(onDisk.disableAllHooks, true, 'trusted MUST still pin disableAllHooks (T5/T13)');
       const permissions = onDisk.permissions as Record<string, unknown> | undefined;
-      assert.equal(permissions?.defaultMode, 'bypassPermissions');
+      assert.equal(permissions?.defaultMode, 'bypassPermissions', 'trusted MUST still pin bypassPermissions (#47)');
       assert.equal(onDisk.skipDangerousModePermissionPrompt, true);
 
-      // 2. --setting-sources user forces Claude to read only user-tier
-      // settings (combined with the harness-supplied --settings file). With
-      // disableAllHooks:true the user-side hooks above will not fire.
-      const sourcesIdx = invocation.args.indexOf('--setting-sources');
-      assert.ok(sourcesIdx >= 0, 'worker must pass --setting-sources');
-      assert.equal(invocation.args[sourcesIdx + 1], 'user');
+      const permissionModeIndex = invocation.args.findIndex((arg) => arg === '--permission-mode');
+      assert.equal(invocation.args[permissionModeIndex + 1], 'bypassPermissions', 'CLI permission-mode overrides any project settings.json value');
+      assert.ok(!invocation.args.includes('--dangerously-skip-permissions'));
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
 
-      // 3. Sanity: the sentinel is NOT created by argv builder paths (this
-      // catches a regression where someone wires the argv to actually exec
-      // a hook script during invocation building).
+  it('resume under trusted posture emits the same isolation flags', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'claude-iso-trusted-resume-'));
+    try {
+      const store = new RunStore(root);
+      await store.ensureReady();
+      const meta = await store.createRun({ backend: 'claude', cwd: root, prompt: 'hi' });
+      const backend = new ClaudeBackend(store);
+      const invocation = await backend.resume('session-456', {
+        runId: meta.run_id,
+        cwd: root,
+        prompt: 'continue',
+        modelSettings: modelSettings('trusted'),
+      });
+
+      const sourcesIndex = invocation.args.findIndex((arg) => arg === '--setting-sources');
+      assert.equal(invocation.args[sourcesIndex + 1], 'user,project,local');
+      const settingsPath = invocation.args[invocation.args.indexOf('--settings') + 1]!;
+      const onDisk = JSON.parse(await readFile(settingsPath, 'utf8')) as Record<string, unknown>;
+      assert.deepStrictEqual(onDisk, CLAUDE_TRUSTED_WORKER_SETTINGS_BODY);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it('legacy model_settings with worker_posture: null defaults to trusted', async () => {
+    // T-Profile-2: a pre-#58 run record (worker_posture omitted / null)
+    // resolves to the new product default 'trusted'.
+    const root = await mkdtemp(join(tmpdir(), 'claude-iso-legacy-'));
+    try {
+      const store = new RunStore(root);
+      await store.ensureReady();
+      const meta = await store.createRun({ backend: 'claude', cwd: root, prompt: 'hi' });
+      const backend = new ClaudeBackend(store);
+      const invocation = await backend.start({
+        runId: meta.run_id,
+        cwd: root,
+        prompt: 'hi',
+        modelSettings: modelSettings(null),
+      });
+      const sourcesIndex = invocation.args.findIndex((arg) => arg === '--setting-sources');
+      assert.equal(invocation.args[sourcesIndex + 1], 'user,project,local', 'legacy null posture resolves to trusted at the backend');
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('Claude worker isolation — telemetry (issue #58 Decision 11)', () => {
+  it('start populates WorkerInvocation.initialEvents with a worker_posture lifecycle event under trusted', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'claude-iso-telemetry-trusted-'));
+    try {
+      const store = new RunStore(root);
+      await store.ensureReady();
+      const meta = await store.createRun({ backend: 'claude', cwd: root, prompt: 'hi' });
+      const backend = new ClaudeBackend(store);
+      const invocation = await backend.start({
+        runId: meta.run_id,
+        cwd: root,
+        prompt: 'hi',
+        modelSettings: modelSettings('trusted'),
+      });
+
+      assert.ok(invocation.initialEvents, 'initialEvents must be populated');
+      assert.equal(invocation.initialEvents!.length, 1, 'exactly one lifecycle event per spawn');
+      const event = invocation.initialEvents![0]!;
+      assert.equal(event.type, 'lifecycle');
+      const payload = event.payload as Record<string, unknown>;
+      assert.equal(payload.state, 'worker_posture');
+      assert.equal(payload.backend, 'claude');
+      assert.equal(payload.worker_posture, 'trusted');
+      const claude = payload.claude as Record<string, unknown>;
+      assert.equal(claude.setting_sources, 'user,project,local');
+      assert.equal(claude.enable_all_project_mcp_servers, true);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it('start populates initialEvents under restricted with the closed-posture payload', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'claude-iso-telemetry-restricted-'));
+    try {
+      const store = new RunStore(root);
+      await store.ensureReady();
+      const meta = await store.createRun({ backend: 'claude', cwd: root, prompt: 'hi' });
+      const backend = new ClaudeBackend(store);
+      const invocation = await backend.start({
+        runId: meta.run_id,
+        cwd: root,
+        prompt: 'hi',
+        modelSettings: modelSettings('restricted'),
+      });
+
+      assert.ok(invocation.initialEvents);
+      const payload = invocation.initialEvents![0]!.payload as Record<string, unknown>;
+      assert.equal(payload.worker_posture, 'restricted');
+      const claude = payload.claude as Record<string, unknown>;
+      assert.equal(claude.setting_sources, 'user');
+      assert.equal(claude.enable_all_project_mcp_servers, false);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('Claude worker isolation — hostile project fixture (issue #58 T-Claude-3)', () => {
+  it('a project .claude/settings.json that tries to enable hooks and set permissionMode: "ask" cannot break trusted-worker safety contracts', async () => {
+    // Regression test for the review rev. 1 Medium 1 / High 1 finding: under
+    // `--setting-sources user,project,local`, a project `.claude/settings.json`
+    // that re-enables hooks or sets a stricter permission mode must not
+    // affect the worker, because the per-run `--settings <path>` body and
+    // the CLI `--permission-mode bypassPermissions` flag take precedence.
+    const root = await mkdtemp(join(tmpdir(), 'claude-iso-hostile-'));
+    try {
+      const cwd = join(root, 'project');
+      await mkdir(cwd, { recursive: true });
+      // Project-scoped `.mcp.json` so the broadened setting-sources finds
+      // something to load.
+      await writeFile(join(cwd, '.mcp.json'), JSON.stringify({ mcpServers: {} }, null, 2));
+      // Hostile project `.claude/settings.json` — tries to re-enable hooks
+      // and downgrade the permission mode.
+      const projectClaude = join(cwd, '.claude');
+      await mkdir(projectClaude, { recursive: true });
+      const sentinel = join(root, 'hook-should-not-fire.sentinel');
+      const hostileSettings = {
+        disableAllHooks: false,
+        permissions: { defaultMode: 'ask' },
+        hooks: {
+          PreToolUse: [{
+            hooks: [{ type: 'command', command: `touch ${JSON.stringify(sentinel).slice(1, -1)}` }],
+          }],
+        },
+      };
+      await writeFile(join(projectClaude, 'settings.json'), JSON.stringify(hostileSettings, null, 2));
+
+      const store = new RunStore(join(root, 'store'));
+      await store.ensureReady();
+      const meta = await store.createRun({ backend: 'claude', cwd, prompt: 'do work' });
+      const backend = new ClaudeBackend(store);
+      const invocation = await backend.start({
+        runId: meta.run_id,
+        cwd,
+        prompt: 'do work',
+        modelSettings: modelSettings('trusted'),
+      });
+
+      // 1. Per-run settings file still equals the trusted body — project
+      // settings.json cannot override what we write.
+      const settingsPath = invocation.args[invocation.args.indexOf('--settings') + 1]!;
+      const onDisk = JSON.parse(await readFile(settingsPath, 'utf8')) as Record<string, unknown>;
+      assert.deepStrictEqual(onDisk, CLAUDE_TRUSTED_WORKER_SETTINGS_BODY);
+      assert.equal(onDisk.disableAllHooks, true, 'trusted body pins disableAllHooks regardless of project settings');
+      assert.equal(onDisk.enableAllProjectMcpServers, true);
+
+      // 2. CLI --permission-mode bypassPermissions is emitted — survives
+      // any project-level permissionMode override.
+      const permissionModeIndex = invocation.args.findIndex((arg) => arg === '--permission-mode');
+      assert.ok(permissionModeIndex >= 0);
+      assert.equal(invocation.args[permissionModeIndex + 1], 'bypassPermissions');
+
+      // 3. setting-sources is broadened — workers see project sources but
+      // the per-run --settings + --permission-mode pair pins safety contracts.
+      const sourcesIndex = invocation.args.findIndex((arg) => arg === '--setting-sources');
+      assert.equal(invocation.args[sourcesIndex + 1], 'user,project,local');
+
+      // 4. Sanity: the sentinel hook was not executed by the argv builder.
       const { stat } = await import('node:fs/promises');
       let sentinelExists = false;
       try {
@@ -189,7 +308,7 @@ describe('Claude worker isolation (issue #40, T5 / Decision 9)', () => {
       } catch {
         sentinelExists = false;
       }
-      assert.equal(sentinelExists, false, 'argv builder must not execute user hooks');
+      assert.equal(sentinelExists, false, 'argv builder must not execute user/project hooks');
     } finally {
       await rm(root, { recursive: true, force: true });
     }

--- a/src/__tests__/codexNetwork.test.ts
+++ b/src/__tests__/codexNetwork.test.ts
@@ -117,7 +117,7 @@ describe('issue #31 codex_network schema and contracts', () => {
     });
     assert.equal(rejected.success, false);
     assert.ok(!rejected.success && rejected.error.issues.some((issue) =>
-      /Profile mode cannot be mixed with direct backend\/model\/reasoning_effort\/service_tier\/codex_network settings/.test(issue.message)));
+      /Profile mode cannot be mixed with direct backend\/model\/reasoning_effort\/service_tier\/codex_network\/worker_posture settings/.test(issue.message)));
   });
 
   it('OD2=B (T9): StartRunInputSchema accepts codex_network in direct mode for codex', () => {
@@ -172,13 +172,15 @@ describe('issue #31 supervisor system-prompt formatters (B1 / T13)', () => {
       manifestPath: '/repo/.agents/orchestration/profiles.json',
     });
     const agent = config.agent['agent-orchestrator'] as { prompt: string };
-    // Defaulted codex profile renders the OD1=B effective default in the prompt.
-    assert.match(agent.prompt, /codex-default: backend=codex, model=gpt-5\.5, codex_network=isolated \(default\)/);
+    // Issue #58: defaulted codex profile under the trusted default posture
+    // renders worker_posture=trusted (default) and codex_network=trusted default.
+    assert.match(agent.prompt, /codex-default: backend=codex, model=gpt-5\.5, worker_posture=trusted \(default\), codex_network=workspace-write\+network \(trusted default\)/);
     // Explicit codex profiles render the manifest value verbatim.
     assert.match(agent.prompt, /codex-explicit-workspace:[^\n]*codex_network=workspace/);
     assert.match(agent.prompt, /codex-explicit-user-config:[^\n]*codex_network=user-config/);
-    // Claude profile must NOT get a codex_network line.
+    // Claude profile must NOT get a codex_network line; must still get a worker_posture line.
     assert.doesNotMatch(agent.prompt, /claude-no-network:[^\n]*codex_network=/);
+    assert.match(agent.prompt, /claude-no-network:[^\n]*worker_posture=trusted \(default\)/);
     // Catalog renders network_modes for codex.
     assert.match(agent.prompt, /- codex \(Codex CLI\)[^\n]*\n[^\n]*\n[^\n]*\n[^\n]*\n {2}network_modes=isolated, workspace, user-config/);
     // No network_modes line for claude (negative regression).
@@ -205,9 +207,12 @@ describe('issue #31 supervisor system-prompt formatters (B1 / T13)', () => {
       mcpCliPath: '/opt/agent-orchestrator/dist/cli.js',
       monitorPin,
     });
-    assert.match(config.systemPrompt, /codex-default:[^\n]*codex_network=isolated \(default\)/);
+    // Issue #58: trusted-posture default codex profile renders the trusted-default codex_network text.
+    assert.match(config.systemPrompt, /codex-default:[^\n]*worker_posture=trusted \(default\)/);
+    assert.match(config.systemPrompt, /codex-default:[^\n]*codex_network=workspace-write\+network \(trusted default\)/);
     assert.match(config.systemPrompt, /codex-explicit-workspace:[^\n]*codex_network=workspace/);
     assert.doesNotMatch(config.systemPrompt, /claude-no-network:[^\n]*codex_network=/);
+    assert.match(config.systemPrompt, /claude-no-network:[^\n]*worker_posture=trusted \(default\)/);
     assert.match(config.systemPrompt, / {2}network_modes=isolated, workspace, user-config/);
   });
 });
@@ -224,7 +229,7 @@ describe('issue #31 observability dedup (T5 / P6)', () => {
       observed_session_id: 'session-a',
       model: 'gpt-5.5',
       model_source: 'explicit',
-      model_settings: { reasoning_effort: 'high', service_tier: null, mode: null, codex_network: 'isolated' },
+      model_settings: { reasoning_effort: 'high', service_tier: null, mode: null, codex_network: 'isolated', worker_posture: null },
     });
     await store.createRun({
       backend: 'codex',
@@ -234,7 +239,7 @@ describe('issue #31 observability dedup (T5 / P6)', () => {
       observed_session_id: 'session-a',
       model: 'gpt-5.5',
       model_source: 'explicit',
-      model_settings: { reasoning_effort: 'high', service_tier: null, mode: null, codex_network: 'workspace' },
+      model_settings: { reasoning_effort: 'high', service_tier: null, mode: null, codex_network: 'workspace', worker_posture: null },
     });
 
     const snapshot = await buildObservabilitySnapshot(store, {

--- a/src/__tests__/contract.test.ts
+++ b/src/__tests__/contract.test.ts
@@ -128,7 +128,7 @@ describe('contract schemas and envelopes', () => {
     });
     assert.equal(parsed.model, null);
     assert.equal(parsed.model_source, 'legacy_unknown');
-    assert.deepStrictEqual(parsed.model_settings, { reasoning_effort: null, service_tier: null, mode: null, codex_network: null });
+    assert.deepStrictEqual(parsed.model_settings, { reasoning_effort: null, service_tier: null, mode: null, codex_network: null, worker_posture: null });
     assert.equal(parsed.worker_invocation, null);
     assert.equal(parsed.requested_session_id, null);
     assert.equal(parsed.observed_session_id, null);

--- a/src/__tests__/cursorRuntime.test.ts
+++ b/src/__tests__/cursorRuntime.test.ts
@@ -830,10 +830,9 @@ describe('CursorSdkRuntime worker posture (issue #58 Decisions 7, 18)', () => {
     // event ('system' from cursor) so operators can correlate the spawn-time
     // posture with subsequent worker output.
     const sdkSystemIdx = stream.findIndex((event) => event.type === 'lifecycle' && (event.payload as { state?: string }).state !== 'worker_posture' && (event.payload as { agent_id?: string }).agent_id === 'bc-trusted');
-    if (sdkSystemIdx >= 0) {
-      const postureIdx = stream.indexOf(posture!);
-      assert.ok(postureIdx < sdkSystemIdx, 'worker_posture event must precede the first SDK system event');
-    }
+    assert.ok(sdkSystemIdx >= 0, 'expected at least one SDK lifecycle/system event');
+    const postureIdx = stream.indexOf(posture!);
+    assert.ok(postureIdx < sdkSystemIdx, 'worker_posture event must precede the first SDK system event');
   });
 
   it('restricted posture omits local.settingSources and emits the restricted posture event', async () => {
@@ -946,5 +945,56 @@ describe('CursorSdkRuntime worker posture (issue #58 Decisions 7, 18)', () => {
 
     assert.ok(resumeLocal, 'Agent.resume must receive local options');
     assert.deepStrictEqual(resumeLocal!.settingSources, ['all'], 'resume must inherit trusted settingSources from the parent');
+  });
+
+  it('issue #58 (review Major 5): worker_posture appendEvent failure disposes the agent and surfaces phase: append_event', async () => {
+    // This test uses a local agent double (not the shared fakeAgent helper)
+    // so it can count dispose invocations without growing the helper API for
+    // a single regression case — see the resolution map (option 2) for the
+    // rationale. If a future cursor failure path also needs dispose counting,
+    // promote a `disposeCalls` counter onto the shared helper instead.
+    class RejectingPostureStore extends RunStore {
+      override async appendEvent(
+        runId: string,
+        event: Parameters<RunStore['appendEvent']>[1],
+      ): ReturnType<RunStore['appendEvent']> {
+        if ((event.payload as { state?: string }).state === 'worker_posture') {
+          throw new Error('append worker_posture failed');
+        }
+        return super.appendEvent(runId, event);
+      }
+    }
+
+    let disposeCount = 0;
+    const run = fakeRun({ agentId: 'bc-append-fails', status: 'finished', result: 'ok', events: [] });
+    const countingAgent: CursorAgent = {
+      agentId: 'bc-append-fails',
+      async send() { return run; },
+      async [Symbol.asyncDispose]() { disposeCount += 1; },
+    } as CursorAgent;
+    const api: CursorAgentApi = {
+      async create() { return countingAgent; },
+      async resume() { return countingAgent; },
+    };
+
+    const home = await mkdtemp(join(tmpdir(), 'cursor-append-fail-'));
+    const store = new RejectingPostureStore(home);
+    const cursorRuntime = new CursorSdkRuntime(fakeAdapter(api), { store, env: { CURSOR_API_KEY: 'test-key' }, cancelDrainMs: 25 });
+    const runtimes = createBackendRegistry(store, { cursorRuntime });
+    const service = new OrchestratorService(store, runtimes);
+    await service.initialize();
+
+    const cwd = await mkdtemp(join(tmpdir(), 'cursor-append-fail-cwd-'));
+    const start = await service.startRun({ backend: 'cursor', prompt: 'go', cwd, model: 'composer-2', worker_posture: 'trusted' });
+    const runId = (start as { ok: true; run_id: string }).run_id;
+    await service.waitForRun({ run_id: runId, wait_seconds: 5 });
+
+    const result = await service.getRunResult({ run_id: runId });
+    const payload = result as { ok: true; result: { errors: { message: string; context?: { code?: string; phase?: string } }[] } };
+    const error = payload.result.errors[0];
+    assert.equal(error?.context?.code, 'SPAWN_FAILED');
+    assert.equal(error?.context?.phase, 'append_event');
+    assert.match(error?.message ?? '', /Failed to persist worker_posture lifecycle event/);
+    assert.equal(disposeCount, 1, 'cursor agent must be disposed exactly once when the posture append fails');
   });
 });

--- a/src/__tests__/cursorRuntime.test.ts
+++ b/src/__tests__/cursorRuntime.test.ts
@@ -791,3 +791,160 @@ describe('CursorSdkRuntime finalize artifacts and timeout/cancel error synthesis
     assert.match(payload.run_summary.latest_error?.message ?? '', /cancelled by user/i);
   });
 });
+
+describe('CursorSdkRuntime worker posture (issue #58 Decisions 7, 18)', () => {
+  it('trusted posture passes local.settingSources: ["all"] to Agent.create and emits a worker_posture lifecycle event', async () => {
+    const events: CursorSdkMessage[] = [
+      { type: 'system', agent_id: 'bc-trusted', run_id: 'run-1' },
+    ];
+    const run = fakeRun({ agentId: 'bc-trusted', status: 'finished', result: 'ok', events });
+    const agent = fakeAgent('bc-trusted', run);
+    let capturedLocal: { cwd?: string; settingSources?: string[] } | undefined;
+    const api: CursorAgentApi = {
+      async create(options) {
+        capturedLocal = options.local as { cwd?: string; settingSources?: string[] } | undefined;
+        return agent;
+      },
+      async resume() { return agent; },
+    };
+
+    const { service } = await createServiceWith(fakeAdapter(api));
+    const cwd = await mkdtemp(join(tmpdir(), 'cursor-trusted-'));
+    const start = await service.startRun({ backend: 'cursor', prompt: 'go', cwd, model: 'composer-2', worker_posture: 'trusted' });
+    assert.equal(start.ok, true);
+    const runId = (start as { ok: true; run_id: string }).run_id;
+    await service.waitForRun({ run_id: runId, wait_seconds: 5 });
+
+    assert.ok(capturedLocal, 'Agent.create must receive local options');
+    assert.deepStrictEqual(capturedLocal!.settingSources, ['all'], 'trusted posture must request all ambient SettingSource layers');
+
+    const eventsResp = await service.getRunEvents({ run_id: runId });
+    const stream = (eventsResp as { ok: true; events: { type: string; payload: Record<string, unknown> }[] }).events;
+    const posture = stream.find((event) => event.type === 'lifecycle' && event.payload.state === 'worker_posture');
+    assert.ok(posture, 'cursor worker must emit a worker_posture lifecycle event');
+    assert.equal(posture!.payload.backend, 'cursor');
+    assert.equal(posture!.payload.worker_posture, 'trusted');
+    const cursorPayload = posture!.payload.cursor as Record<string, unknown>;
+    assert.deepStrictEqual(cursorPayload.setting_sources, ['all']);
+    // Issue #58 Decision 18: posture event lands before the first SDK stream
+    // event ('system' from cursor) so operators can correlate the spawn-time
+    // posture with subsequent worker output.
+    const sdkSystemIdx = stream.findIndex((event) => event.type === 'lifecycle' && (event.payload as { state?: string }).state !== 'worker_posture' && (event.payload as { agent_id?: string }).agent_id === 'bc-trusted');
+    if (sdkSystemIdx >= 0) {
+      const postureIdx = stream.indexOf(posture!);
+      assert.ok(postureIdx < sdkSystemIdx, 'worker_posture event must precede the first SDK system event');
+    }
+  });
+
+  it('restricted posture omits local.settingSources and emits the restricted posture event', async () => {
+    const events: CursorSdkMessage[] = [
+      { type: 'system', agent_id: 'bc-restricted', run_id: 'run-1' },
+    ];
+    const run = fakeRun({ agentId: 'bc-restricted', status: 'finished', result: 'ok', events });
+    const agent = fakeAgent('bc-restricted', run);
+    let capturedLocal: { cwd?: string; settingSources?: string[] } | undefined;
+    const api: CursorAgentApi = {
+      async create(options) {
+        capturedLocal = options.local as { cwd?: string; settingSources?: string[] } | undefined;
+        return agent;
+      },
+      async resume() { return agent; },
+    };
+
+    const { service } = await createServiceWith(fakeAdapter(api));
+    const cwd = await mkdtemp(join(tmpdir(), 'cursor-restricted-'));
+    const start = await service.startRun({ backend: 'cursor', prompt: 'go', cwd, model: 'composer-2', worker_posture: 'restricted' });
+    const runId = (start as { ok: true; run_id: string }).run_id;
+    await service.waitForRun({ run_id: runId, wait_seconds: 5 });
+
+    assert.ok(capturedLocal, 'Agent.create must still receive local options for cwd');
+    assert.equal(capturedLocal!.settingSources, undefined, 'restricted posture must NOT request ambient SettingSource layers');
+
+    const eventsResp = await service.getRunEvents({ run_id: runId });
+    const stream = (eventsResp as { ok: true; events: { type: string; payload: Record<string, unknown> }[] }).events;
+    const posture = stream.find((event) => event.type === 'lifecycle' && event.payload.state === 'worker_posture');
+    assert.ok(posture);
+    assert.equal(posture!.payload.worker_posture, 'restricted');
+    const cursorPayload = posture!.payload.cursor as Record<string, unknown>;
+    assert.equal(cursorPayload.setting_sources, null);
+  });
+
+  it('pre-spawn failure (WORKER_BINARY_MISSING) does NOT emit a worker_posture event', async () => {
+    // Decision 18 invariant: the event lands only after Agent.create / resume
+    // succeed. A missing SDK fails before that, so the run's event stream must
+    // contain zero worker_posture events.
+    const { service } = await createServiceWith(unavailableAdapter('Cannot find module @cursor/sdk'));
+    const cwd = await mkdtemp(join(tmpdir(), 'cursor-prespawn-'));
+    const start = await service.startRun({ backend: 'cursor', prompt: 'go', cwd, model: 'composer-2', worker_posture: 'trusted' });
+    const runId = (start as { ok: true; run_id: string }).run_id;
+    await service.waitForRun({ run_id: runId, wait_seconds: 5 });
+
+    const eventsResp = await service.getRunEvents({ run_id: runId });
+    const stream = (eventsResp as { ok: true; events: { type: string; payload: Record<string, unknown> }[] }).events;
+    const postureCount = stream.filter((event) => event.type === 'lifecycle' && event.payload.state === 'worker_posture').length;
+    assert.equal(postureCount, 0, 'pre-spawn failures must not emit worker_posture telemetry');
+  });
+
+  it('issue #58 (review Medium 2): agent.send() failure does NOT emit a worker_posture event', async () => {
+    // Regression: previously the runtime appended worker_posture immediately
+    // after Agent.create() succeeded, before calling agent.send(). A send()
+    // failure then returned SPAWN_FAILED to the orchestrator but the run's
+    // event stream already contained a worker_posture event — false telemetry
+    // for a worker that never accepted a prompt. The fix moves the append to
+    // after agent.send() returns successfully.
+    const sendError = new Error('send refused');
+    const agent: CursorAgent = {
+      agentId: 'bc-send-fails',
+      async send() {
+        throw sendError;
+      },
+      async [Symbol.asyncDispose]() { /* no-op */ },
+    } as CursorAgent;
+    const api: CursorAgentApi = {
+      async create() { return agent; },
+      async resume() { return agent; },
+    };
+
+    const { service } = await createServiceWith(fakeAdapter(api));
+    const cwd = await mkdtemp(join(tmpdir(), 'cursor-send-failure-'));
+    const start = await service.startRun({ backend: 'cursor', prompt: 'go', cwd, model: 'composer-2', worker_posture: 'trusted' });
+    const runId = (start as { ok: true; run_id: string }).run_id;
+    await service.waitForRun({ run_id: runId, wait_seconds: 5 });
+
+    const eventsResp = await service.getRunEvents({ run_id: runId });
+    const stream = (eventsResp as { ok: true; events: { type: string; payload: Record<string, unknown> }[] }).events;
+    const postureCount = stream.filter((event) => event.type === 'lifecycle' && event.payload.state === 'worker_posture').length;
+    assert.equal(postureCount, 0, 'agent.send() failure must NOT leave a worker_posture event in the run stream');
+  });
+
+  it('Agent.resume receives the same settingSources value as Agent.create (resume parity)', async () => {
+    // SDK docs note inline mcpServers are not persisted across resume; we
+    // pass settingSources on resume so file-backed ambient settings reload.
+    const events: CursorSdkMessage[] = [
+      { type: 'system', agent_id: 'bc-resume', run_id: 'run-1' },
+    ];
+    const run = fakeRun({ agentId: 'bc-resume', status: 'finished', result: 'ok', events });
+    const agent = fakeAgent('bc-resume', run);
+    let resumeLocal: { settingSources?: string[] } | undefined;
+    const api: CursorAgentApi = {
+      async create() { return agent; },
+      async resume(_sessionId, options) {
+        resumeLocal = options?.local as { settingSources?: string[] } | undefined;
+        return agent;
+      },
+    };
+
+    const { service } = await createServiceWith(fakeAdapter(api));
+    const cwd = await mkdtemp(join(tmpdir(), 'cursor-resume-trusted-'));
+    const parent = await service.startRun({ backend: 'cursor', prompt: 'go', cwd, model: 'composer-2', worker_posture: 'trusted' });
+    const parentId = (parent as { ok: true; run_id: string }).run_id;
+    await service.waitForRun({ run_id: parentId, wait_seconds: 5 });
+
+    const followup = await service.sendFollowup({ run_id: parentId, prompt: 'continue' });
+    const followupId = (followup as { ok: true; run_id: string }).run_id;
+    await service.waitForRun({ run_id: followupId, wait_seconds: 5 });
+
+    assert.ok(resumeLocal, 'Agent.resume must receive local options');
+    assert.deepStrictEqual(resumeLocal!.settingSources, ['all'], 'resume must inherit trusted settingSources from the parent');
+  });
+});

--- a/src/__tests__/integration/orchestrator.test.ts
+++ b/src/__tests__/integration/orchestrator.test.ts
@@ -217,6 +217,9 @@ describe('agent orchestrator integration with mock CLIs', () => {
     const repo = await createGitRepo(fixture.root);
     const service = await createService(fixture.home);
 
+    // Issue #58: pin worker_posture: 'restricted' so this test continues to
+    // exercise the v1 codex isolated argv shape (with --ignore-user-config).
+    // The new 'trusted' default has its own argv shape; covered separately.
     const start = await service.startRun({
       backend: 'codex',
       prompt: 'hello',
@@ -224,6 +227,7 @@ describe('agent orchestrator integration with mock CLIs', () => {
       model: 'gpt-5.2',
       reasoning_effort: 'xhigh',
       service_tier: 'fast',
+      worker_posture: 'restricted',
       metadata: {
         session_title: 'Model session',
         prompt_title: 'Initial model prompt',
@@ -262,14 +266,14 @@ describe('agent orchestrator integration with mock CLIs', () => {
     // Issue #31 (OD1=B locked): codex_network defaults to 'isolated' when the
     // direct-mode start_run does not set it; mode is derived from
     // codex_network ('isolated' => 'normal'), not from service_tier.
-    assert.deepStrictEqual(parent.ok && (parent as unknown as { run_summary: { model_settings: unknown } }).run_summary.model_settings, { reasoning_effort: 'xhigh', service_tier: 'fast', mode: 'normal', codex_network: 'isolated' });
-    assert.deepStrictEqual(childInherited.ok && (childInherited as unknown as { run_summary: { model_settings: unknown } }).run_summary.model_settings, { reasoning_effort: 'xhigh', service_tier: 'fast', mode: 'normal', codex_network: 'isolated' });
+    assert.deepStrictEqual(parent.ok && (parent as unknown as { run_summary: { model_settings: unknown } }).run_summary.model_settings, { reasoning_effort: 'xhigh', service_tier: 'fast', mode: 'normal', codex_network: 'isolated', worker_posture: 'restricted' });
+    assert.deepStrictEqual(childInherited.ok && (childInherited as unknown as { run_summary: { model_settings: unknown } }).run_summary.model_settings, { reasoning_effort: 'xhigh', service_tier: 'fast', mode: 'normal', codex_network: 'isolated', worker_posture: 'restricted' });
     // Inverse-bug regression sibling (P5): service_tier='normal' alone (no
     // codex_network override) under OD1=B still resolves through
     // codex_network='isolated' so mode='normal' and --ignore-user-config is
     // present, but for the new reason. service_tier='normal' continues to be
     // suppressed in serialization because it is the codex CLI default.
-    assert.deepStrictEqual(childOverridden.ok && (childOverridden as unknown as { run_summary: { model_settings: unknown } }).run_summary.model_settings, { reasoning_effort: 'medium', service_tier: null, mode: 'normal', codex_network: 'isolated' });
+    assert.deepStrictEqual(childOverridden.ok && (childOverridden as unknown as { run_summary: { model_settings: unknown } }).run_summary.model_settings, { reasoning_effort: 'medium', service_tier: null, mode: 'normal', codex_network: 'isolated', worker_posture: 'restricted' });
     assert.deepStrictEqual(
       parent.ok && (parent as unknown as { run_summary: { worker_invocation: { args: string[] } } }).run_summary.worker_invocation.args,
       ['exec', '--json', '--skip-git-repo-check', '--ignore-user-config', '--cd', repo, '--model', 'gpt-5.2', '-c', 'model_reasoning_effort="xhigh"', '-c', 'service_tier="fast"', '-'],
@@ -941,6 +945,9 @@ describe('agent orchestrator integration with mock CLIs', () => {
     const repo = await createGitRepo(fixture.root);
     const service = await createService(fixture.home);
 
+    // Pin restricted posture: this test verifies the issue #31 argv shape
+    // for codex_network='workspace', which under trusted no longer includes
+    // --ignore-user-config (issue #58 Decision 9).
     const start = await service.startRun({
       backend: 'codex',
       prompt: 'fetch zen',
@@ -948,6 +955,7 @@ describe('agent orchestrator integration with mock CLIs', () => {
       model: 'gpt-5.5',
       reasoning_effort: 'xhigh',
       codex_network: 'workspace',
+      worker_posture: 'restricted',
     });
     assert.equal(start.ok, true);
     const runId = start.ok ? (start as unknown as { run_id: string }).run_id : '';
@@ -976,7 +984,7 @@ describe('agent orchestrator integration with mock CLIs', () => {
       cwd: repo,
       codex_network: 'workspace',
     });
-    assertInvalidInput(rejected, /Profile mode cannot be mixed with direct backend\/model\/reasoning_effort\/service_tier\/codex_network settings/);
+    assertInvalidInput(rejected, /Profile mode cannot be mixed with direct backend\/model\/reasoning_effort\/service_tier\/codex_network\/worker_posture settings/);
   });
 
   it('issue #31 (T9): codex_network is rejected on non-codex direct-mode start_run', async () => {
@@ -999,12 +1007,16 @@ describe('agent orchestrator integration with mock CLIs', () => {
     const repo = await createGitRepo(fixture.root);
     const service = await createService(fixture.home);
 
+    // Pin restricted posture so this test's argv assertions (including
+    // --ignore-user-config under codex_network=isolated) continue to match
+    // the v1 codex argv shape.
     const start = await service.startRun({
       backend: 'codex',
       prompt: 'parent',
       cwd: repo,
       model: 'gpt-5.5',
       codex_network: 'workspace',
+      worker_posture: 'restricted',
     });
     const parentId = start.ok ? (start as unknown as { run_id: string }).run_id : '';
     await service.waitForRun({ run_id: parentId, wait_seconds: 5 });
@@ -1051,29 +1063,110 @@ describe('agent orchestrator integration with mock CLIs', () => {
     assertInvalidInput(rejected, /Profile-mode follow-ups cannot override codex_network/);
   });
 
-  it('issue #31 (T11 / C12): a codex run that defaulted codex_network emits exactly one non-blocking warning event', async () => {
+  it('issue #58 (review High): default trusted codex run emits the trusted-default sandbox argv (no --ignore-user-config) and persists codex_network: null', async () => {
     const fixture = await createFixture();
     const repo = await createGitRepo(fixture.root);
     const service = await createService(fixture.home);
 
-    const defaulted = await service.startRun({ backend: 'codex', prompt: 'no codex_network', cwd: repo, model: 'gpt-5.5' });
+    // Direct-mode codex run with neither codex_network nor worker_posture set.
+    // Trusted is the default; under trusted+absent codex_network the daemon
+    // must spawn with -c sandbox_mode="workspace-write" -c sandbox_workspace_write.network_access=true
+    // and persist codex_network: null on the run record (so the run's effective
+    // posture is unambiguously the trusted default).
+    const start = await service.startRun({ backend: 'codex', prompt: 'default trusted run', cwd: repo, model: 'gpt-5.5' });
+    const runId = start.ok ? (start as unknown as { run_id: string }).run_id : '';
+    await service.waitForRun({ run_id: runId, wait_seconds: 5 });
+
+    const status = await service.getRunStatus({ run_id: runId });
+    const summary = (status as unknown as { run_summary: { model_settings: { codex_network: string | null; worker_posture: string }; worker_invocation: { args: string[] } } }).run_summary;
+    assert.equal(summary.model_settings.worker_posture, 'trusted', 'default posture is trusted');
+    assert.equal(summary.model_settings.codex_network, null, 'trusted + absent codex_network persists as null');
+    const args = summary.worker_invocation.args;
+    assert.equal(args.includes('--ignore-user-config'), false, 'trusted must NOT emit --ignore-user-config');
+    assert.equal(args.includes('--sandbox'), false, 'shared sandboxArgs helper must NOT emit --sandbox (resume-unsafe)');
+    assert.ok(args.includes('-c'));
+    assert.ok(args.includes('sandbox_mode="workspace-write"'), 'trusted default includes sandbox_mode override');
+    assert.ok(args.includes('sandbox_workspace_write.network_access=true'), 'trusted default opens workspace network');
+  });
+
+  it('issue #58 (review High): profile-mode codex with no codex_network and no worker_posture spawns with the trusted-default argv', async () => {
+    const fixture = await createFixture();
+    const repo = await createGitRepo(fixture.root);
+    const service = await createService(fixture.home);
+    const profilesFile = join(fixture.root, 'trusted-profiles.json');
+    // Profile sets neither codex_network nor worker_posture: trusted default
+    // applies, and codex_network resolution leaves null on the run record.
+    await writeFile(profilesFile, JSON.stringify({
+      version: 1,
+      profiles: {
+        'codex-trusted-default': {
+          backend: 'codex',
+          model: 'gpt-5.5',
+          reasoning_effort: 'high',
+        },
+      },
+    }, null, 2));
+
+    const start = await service.startRun({ profile: 'codex-trusted-default', profiles_file: profilesFile, prompt: 'hello', cwd: repo });
+    const runId = start.ok ? (start as unknown as { run_id: string }).run_id : '';
+    await service.waitForRun({ run_id: runId, wait_seconds: 5 });
+
+    const status = await service.getRunStatus({ run_id: runId });
+    const summary = (status as unknown as { run_summary: { model_settings: { codex_network: string | null; worker_posture: string }; worker_invocation: { args: string[] } } }).run_summary;
+    assert.equal(summary.model_settings.worker_posture, 'trusted');
+    assert.equal(summary.model_settings.codex_network, null);
+    const args = summary.worker_invocation.args;
+    assert.equal(args.includes('--ignore-user-config'), false);
+    assert.ok(args.includes('sandbox_mode="workspace-write"'));
+    assert.ok(args.includes('sandbox_workspace_write.network_access=true'));
+  });
+
+  it('issue #31 (T11 / C12): a restricted codex run that defaulted codex_network emits exactly one non-blocking warning event', async () => {
+    const fixture = await createFixture();
+    const repo = await createGitRepo(fixture.root);
+    const service = await createService(fixture.home);
+
+    // Pin worker_posture: 'restricted' — issue #58 review follow-up suppresses
+    // the warning under trusted because the trusted default is the intended
+    // product direction, not a surprise breaking change. The warning still
+    // fires under restricted (preserves the pre-#58 OD1=B closed-by-default).
+    const defaulted = await service.startRun({ backend: 'codex', prompt: 'no codex_network', cwd: repo, model: 'gpt-5.5', worker_posture: 'restricted' });
     const defaultedId = defaulted.ok ? (defaulted as unknown as { run_id: string }).run_id : '';
     await service.waitForRun({ run_id: defaultedId, wait_seconds: 5 });
     const defaultedRun = await service.store.loadRun(defaultedId);
     const defaultedWarnings = (defaultedRun?.events ?? []).filter((event) => event.type === 'lifecycle' && (event.payload as { state?: string }).state === 'codex_network_defaulted');
-    assert.equal(defaultedWarnings.length, 1, 'exactly one warning event must fire when codex_network is defaulted');
+    assert.equal(defaultedWarnings.length, 1, 'exactly one warning event must fire when codex_network is defaulted under restricted');
     assert.match(String(defaultedWarnings[0]?.payload.warning ?? ''), /codex_network not set/);
     assert.match(String(defaultedWarnings[0]?.payload.warning ?? ''), /docs\/development\/codex-backend\.md/);
+    assert.equal((defaultedWarnings[0]?.payload as { worker_posture?: string }).worker_posture, 'restricted');
     // The warning must not block the run.
     assert.equal(defaultedRun?.meta.status, 'completed');
 
     // Explicit codex_network must NOT emit the warning.
-    const explicit = await service.startRun({ backend: 'codex', prompt: 'explicit', cwd: repo, model: 'gpt-5.5', codex_network: 'workspace' });
+    const explicit = await service.startRun({ backend: 'codex', prompt: 'explicit', cwd: repo, model: 'gpt-5.5', codex_network: 'workspace', worker_posture: 'restricted' });
     const explicitId = explicit.ok ? (explicit as unknown as { run_id: string }).run_id : '';
     await service.waitForRun({ run_id: explicitId, wait_seconds: 5 });
     const explicitRun = await service.store.loadRun(explicitId);
     const explicitWarnings = (explicitRun?.events ?? []).filter((event) => event.type === 'lifecycle' && (event.payload as { state?: string }).state === 'codex_network_defaulted');
     assert.equal(explicitWarnings.length, 0, 'no warning event must fire when codex_network is set explicitly');
+  });
+
+  it('issue #58 (review Medium 1): trusted codex with absent codex_network does NOT emit the codex_network_defaulted warning', async () => {
+    // Under trusted, the trusted-default sandbox (workspace-write + network on)
+    // is the intended product behavior. There is no explicit codex_network
+    // value that preserves the same argv, so an unsilenceable warning would
+    // be permanently noisy. The warning is therefore suppressed under
+    // trusted+absent.
+    const fixture = await createFixture();
+    const repo = await createGitRepo(fixture.root);
+    const service = await createService(fixture.home);
+
+    const trusted = await service.startRun({ backend: 'codex', prompt: 'trusted absent', cwd: repo, model: 'gpt-5.5' });
+    const trustedId = trusted.ok ? (trusted as unknown as { run_id: string }).run_id : '';
+    await service.waitForRun({ run_id: trustedId, wait_seconds: 5 });
+    const trustedRun = await service.store.loadRun(trustedId);
+    const warnings = (trustedRun?.events ?? []).filter((event) => event.type === 'lifecycle' && (event.payload as { state?: string }).state === 'codex_network_defaulted');
+    assert.equal(warnings.length, 0, 'trusted + absent codex_network must NOT emit a defaulted warning');
   });
 
   it('issue #31 (T11 / C12): profile-mode codex run that omits codex_network names the profile in the warning', async () => {
@@ -1145,7 +1238,10 @@ describe('agent orchestrator integration with mock CLIs', () => {
       model_source: 'explicit',
       session_id: 'codex-session-1',
       observed_session_id: 'codex-session-1',
-      model_settings: { reasoning_effort: 'high', service_tier: null, mode: null, codex_network: null },
+      // worker_posture: 'restricted' pins the issue #31 argv shape the
+      // test's assertions encode. The legacy-null normalization path for
+      // codex_network is what this test exercises.
+      model_settings: { reasoning_effort: 'high', service_tier: null, mode: null, codex_network: null, worker_posture: 'restricted' },
     });
     await service.store.markTerminal(legacy.run_id, 'completed', [], {
       status: 'completed',
@@ -1163,6 +1259,7 @@ describe('agent orchestrator integration with mock CLIs', () => {
     const childMeta = await service.store.loadMeta(childId);
     assert.equal(childMeta.model_settings.codex_network, 'isolated', 'codex follow-up must persist the effective isolated default, not legacy null');
     assert.equal(childMeta.model_settings.mode, 'normal', 'mode breadcrumb must be re-derived from the resolved codex_network');
+    assert.equal(childMeta.model_settings.worker_posture, 'restricted', 'restricted posture inherits from the legacy parent');
     assert.ok(childMeta.worker_invocation?.args.includes('--ignore-user-config'));
   });
 
@@ -1301,6 +1398,9 @@ async function createGitRepo(root: string): Promise<string> {
 }
 
 async function writeProfilesFile(path: string, model: string, reasoningEffort: string): Promise<void> {
+  // Issue #58: pin worker_posture: 'restricted' so the codex argv assertions
+  // in callers continue to match the v1 shape (with --ignore-user-config).
+  // Trusted codex argv is covered by `backendInvocation.test.ts`.
   await writeFile(path, JSON.stringify({
     version: 1,
     profiles: {
@@ -1308,6 +1408,7 @@ async function writeProfilesFile(path: string, model: string, reasoningEffort: s
         backend: 'codex',
         model,
         reasoning_effort: reasoningEffort,
+        worker_posture: 'restricted',
       },
     },
   }, null, 2));

--- a/src/__tests__/integration/orchestrator.test.ts
+++ b/src/__tests__/integration/orchestrator.test.ts
@@ -738,6 +738,76 @@ describe('agent orchestrator integration with mock CLIs', () => {
     assertInvalidInput(codexMax, /Codex reasoning_effort must be one of/);
   });
 
+  it('issue #58 (review Major 6): send_followup with worker_posture + incompatible model on Claude rejects with backend validation', async () => {
+    // Regression for the validation bypass: previously a follow-up that set
+    // `worker_posture` short-circuited the ternary before
+    // validateInheritedModelSettingsForBackend could check the merged
+    // settings, so a `worker_posture + model` follow-up on Claude could
+    // persist an invalid reasoning_effort/model pair. The fix runs the
+    // validator unconditionally for `parsed.data.model || backend === 'cursor'`
+    // against the merged settings (including the new posture).
+    const fixture = await createFixture();
+    const repo = await createGitRepo(fixture.root);
+    const service = await createService(fixture.home);
+
+    const parent = await service.startRun({
+      backend: 'claude',
+      prompt: 'hello',
+      cwd: repo,
+      model: 'claude-opus-4-7',
+      reasoning_effort: 'xhigh',
+    });
+    assert.equal(parent.ok, true);
+    const parentId = (parent as unknown as { run_id: string }).run_id;
+    await service.waitForRun({ run_id: parentId, wait_seconds: 5 });
+
+    // Parent's reasoning_effort='xhigh' is inherited. The follow-up overrides
+    // the model to claude-sonnet-4-6 (which does not support xhigh) and also
+    // toggles worker_posture; pre-fix this slipped past the validator.
+    const followup = await service.sendFollowup({
+      run_id: parentId,
+      prompt: 'rotate posture',
+      model: 'claude-sonnet-4-6',
+      worker_posture: 'restricted',
+    });
+    assertInvalidInput(followup, /Claude xhigh effort requires claude-opus-4-7/);
+  });
+
+  it('issue #58 (review Major 6): send_followup with worker_posture alone succeeds and persists the override', async () => {
+    // Happy-path guard: the validator pass-through must not regress
+    // posture-only follow-ups, where there is no model override and the
+    // parent's inherited settings should flow through unchanged except for
+    // the posture flip.
+    const fixture = await createFixture();
+    const repo = await createGitRepo(fixture.root);
+    const service = await createService(fixture.home);
+
+    const parent = await service.startRun({
+      backend: 'claude',
+      prompt: 'hello',
+      cwd: repo,
+      model: 'claude-opus-4-7',
+    });
+    assert.equal(parent.ok, true);
+    const parentId = (parent as unknown as { run_id: string }).run_id;
+    await service.waitForRun({ run_id: parentId, wait_seconds: 5 });
+
+    const followup = await service.sendFollowup({
+      run_id: parentId,
+      prompt: 'flip posture only',
+      worker_posture: 'restricted',
+    });
+    assert.equal(followup.ok, true);
+    const childId = (followup as unknown as { run_id: string }).run_id;
+    await service.waitForRun({ run_id: childId, wait_seconds: 5 });
+
+    const child = await service.getRunStatus({ run_id: childId });
+    const summary = child.ok
+      ? (child as unknown as { run_summary: { model_settings: { worker_posture: string } } }).run_summary
+      : null;
+    assert.equal(summary?.model_settings.worker_posture, 'restricted');
+  });
+
   it('records requested and observed backend session ids separately for resume auditing', async () => {
     const fixture = await createFixture();
     const repo = await createGitRepo(fixture.root);

--- a/src/__tests__/observability.test.ts
+++ b/src/__tests__/observability.test.ts
@@ -46,7 +46,7 @@ describe('observability snapshot builder', () => {
       observed_session_id: 'session-2',
       model: 'gpt-5.2',
       model_source: 'inherited',
-      model_settings: { reasoning_effort: 'xhigh', service_tier: 'fast', mode: null, codex_network: null },
+      model_settings: { reasoning_effort: 'xhigh', service_tier: 'fast', mode: null, codex_network: null, worker_posture: null },
       display: {
         session_title: 'Observability work',
         session_summary: 'Build dashboard visibility',
@@ -84,7 +84,7 @@ describe('observability snapshot builder', () => {
     const childRun = snapshot.runs.find((run) => run.run.run_id === child.run_id);
     assert.equal(childRun?.prompt.title, 'Add details');
     assert.equal(childRun?.prompt.text, 'Add an interactive detail view.');
-    assert.deepStrictEqual(childRun?.settings, { reasoning_effort: 'xhigh', service_tier: 'fast', mode: null, codex_network: null });
+    assert.deepStrictEqual(childRun?.settings, { reasoning_effort: 'xhigh', service_tier: 'fast', mode: null, codex_network: null, worker_posture: null });
     assert.equal(childRun?.session.status, 'mismatch');
     assert.ok(childRun?.session.warnings[0]?.includes('session-1'));
     assert.equal(childRun?.activity.event_count, 26);
@@ -112,8 +112,8 @@ describe('observability snapshot builder', () => {
     assert.equal(parentSession?.workspace.repository_root, null);
 
     const childSession = snapshot.sessions.find((session) => session.session_id === 'session-2');
-    assert.deepStrictEqual(childSession?.settings, [{ reasoning_effort: 'xhigh', service_tier: 'fast', mode: null, codex_network: null }]);
-    assert.deepStrictEqual(childSession?.prompts[0]?.settings, { reasoning_effort: 'xhigh', service_tier: 'fast', mode: null, codex_network: null });
+    assert.deepStrictEqual(childSession?.settings, [{ reasoning_effort: 'xhigh', service_tier: 'fast', mode: null, codex_network: null, worker_posture: null }]);
+    assert.deepStrictEqual(childSession?.prompts[0]?.settings, { reasoning_effort: 'xhigh', service_tier: 'fast', mode: null, codex_network: null, worker_posture: null });
     assert.equal(childSession?.updated_at, latestChildEventAt);
     assert.equal(childSession?.prompts[0]?.last_activity_at, latestChildEventAt);
   });
@@ -160,7 +160,7 @@ describe('observability snapshot builder', () => {
     assert.equal(snapshot.runs[0]?.prompt.text, null);
     assert.equal(snapshot.runs[0]?.prompt.preview, 'Summarize this session for a human operator.');
     assert.equal(snapshot.runs[0]?.prompt.title, 'Summarize this session for a human operator.');
-    assert.deepStrictEqual(snapshot.runs[0]?.settings, { reasoning_effort: null, service_tier: null, mode: null, codex_network: null });
+    assert.deepStrictEqual(snapshot.runs[0]?.settings, { reasoning_effort: null, service_tier: null, mode: null, codex_network: null, worker_posture: null });
   });
 
   it('counts full session history even when detailed runs are limited', async () => {

--- a/src/__tests__/observabilityFormat.test.ts
+++ b/src/__tests__/observabilityFormat.test.ts
@@ -69,8 +69,8 @@ describe('observability CLI formatting', () => {
       { name: 'gpt-5.5', source: 'explicit', requested_name: 'gpt-5.5', observed_name: null },
     ];
     session.settings = [
-      { reasoning_effort: 'low', service_tier: 'normal', mode: null, codex_network: null },
-      { reasoning_effort: 'xhigh', service_tier: 'fast', mode: null, codex_network: null },
+      { reasoning_effort: 'low', service_tier: 'normal', mode: null, codex_network: null, worker_posture: null },
+      { reasoning_effort: 'xhigh', service_tier: 'fast', mode: null, codex_network: null, worker_posture: null },
     ];
     session.workspace = {
       cwd: '/tmp/worktrees-agent-orchestrator/4-add-observability',
@@ -87,7 +87,7 @@ describe('observability CLI formatting', () => {
       summary: null,
       preview: 'Second raw prompt',
       model: { name: 'gpt-5.5', source: 'explicit', requested_name: 'gpt-5.5', observed_name: null },
-      settings: { reasoning_effort: 'xhigh', service_tier: 'fast', mode: null, codex_network: null },
+      settings: { reasoning_effort: 'xhigh', service_tier: 'fast', mode: null, codex_network: null, worker_posture: null },
       created_at: '2026-05-02T00:00:02.000Z',
       last_activity_at: '2026-05-02T00:00:03.000Z',
     });
@@ -164,7 +164,7 @@ function sampleEnvelope(): SnapshotEnvelope {
       run_count: 1,
       running_count: 1,
       models: [{ name: 'gpt-5.2', source: 'explicit' }],
-      settings: [{ reasoning_effort: 'xhigh', service_tier: 'fast', mode: null, codex_network: null }],
+      settings: [{ reasoning_effort: 'xhigh', service_tier: 'fast', mode: null, codex_network: null, worker_posture: null }],
       warnings: [],
       prompts: [{
         run_id: 'run-1',
@@ -173,7 +173,7 @@ function sampleEnvelope(): SnapshotEnvelope {
         summary: 'Show the prompt detail view',
         preview: 'Raw prompt body with details',
         model: { name: 'gpt-5.2', source: 'explicit' },
-        settings: { reasoning_effort: 'xhigh', service_tier: 'fast', mode: null, codex_network: null },
+        settings: { reasoning_effort: 'xhigh', service_tier: 'fast', mode: null, codex_network: null, worker_posture: null },
         created_at: now,
         last_activity_at: '2026-05-02T00:00:01.000Z',
       }],
@@ -217,7 +217,7 @@ function sampleEnvelope(): SnapshotEnvelope {
           dirty: [],
           dirty_fingerprints: {},
         },
-        model_settings: { reasoning_effort: 'xhigh', service_tier: 'fast', mode: null, codex_network: null },
+        model_settings: { reasoning_effort: 'xhigh', service_tier: 'fast', mode: null, codex_network: null, worker_posture: null },
         idle_timeout_seconds: 1200,
         execution_timeout_seconds: null,
         timeout_reason: null,
@@ -248,7 +248,7 @@ function sampleEnvelope(): SnapshotEnvelope {
         bytes: 128,
       },
       model: { name: 'gpt-5.2', source: 'explicit' },
-      settings: { reasoning_effort: 'xhigh', service_tier: 'fast', mode: null, codex_network: null },
+      settings: { reasoning_effort: 'xhigh', service_tier: 'fast', mode: null, codex_network: null, worker_posture: null },
       session: {
         requested_session_id: null,
         observed_session_id: 'session-1',

--- a/src/__tests__/processManager.test.ts
+++ b/src/__tests__/processManager.test.ts
@@ -704,3 +704,80 @@ describe("applyEnvPolicy", () => {
   });
 });
 
+
+describe('ProcessManager initialEvents flush (issue #58 Decision 10 / T-Telemetry)', () => {
+  it('flushes WorkerInvocation.initialEvents before the status:started lifecycle marker on actual spawn', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'agent-initialevents-'));
+    const cli = join(root, 'worker.js');
+    await writeFile(cli, `#!/usr/bin/env node
+process.stdin.on('data', () => {});
+process.stdin.on('end', () => {
+  console.log(JSON.stringify({ type: 'result', subtype: 'success', result: 'done', session_id: 'session-1' }));
+  process.exit(0);
+});
+`);
+    await chmod(cli, 0o755);
+
+    const store = new RunStore(root);
+    const run = await store.createRun({ backend: 'claude', cwd: root });
+    const manager = new ProcessManager(store);
+    const managed = await manager.start(run.run_id, new ClaudeBackend(), {
+      command: cli,
+      args: [],
+      cwd: root,
+      stdinPayload: 'finish',
+      initialEvents: [{
+        type: 'lifecycle',
+        payload: { state: 'worker_posture', backend: 'claude', worker_posture: 'trusted' },
+      }],
+    });
+
+    await managed.completion;
+    const loaded = await store.loadRun(run.run_id);
+    const lifecycleEvents = (loaded?.events ?? []).filter((event) => event.type === 'lifecycle');
+    const posture = lifecycleEvents.find((event) => (event.payload as { state?: string }).state === 'worker_posture');
+    const started = lifecycleEvents.find((event) => (event.payload as { status?: string }).status === 'started');
+    assert.ok(posture, 'worker_posture event must reach the run event stream');
+    assert.ok(started, 'status:started lifecycle marker must follow');
+    assert.ok(posture.seq < started.seq, 'worker_posture must precede status:started');
+  });
+});
+
+describe('CliRuntime.buildStartInvocation (issue #58 review follow-up Medium 3)', () => {
+  it('preserves initialEvents on the retry invocation so a real retry spawn still emits exactly one worker_posture event', async () => {
+    // The retry invocation may never spawn (pre-bake) OR may spawn (retry
+    // fires). When it spawns, its initialEvents are what carry the
+    // worker_posture telemetry — the first attempt's posture event was
+    // dropped along with the cancelled-attempt event buffer. Stripping
+    // initialEvents here would leave the retry with zero posture telemetry.
+    const { CliRuntime } = await import('../backend/runtime.js');
+    const root = await mkdtemp(join(tmpdir(), 'agent-prebake-'));
+    const cli = join(root, 'worker.js');
+    await writeFile(cli, `#!/usr/bin/env node\n`);
+    await chmod(cli, 0o755);
+
+    const store = new RunStore(root);
+    const run = await store.createRun({ backend: 'claude', cwd: root });
+    const manager = new ProcessManager(store);
+    const runtime = new CliRuntime(new ClaudeBackend(store), manager);
+
+    const originalPath = process.env.PATH ?? '';
+    process.env.PATH = `${root}:${originalPath}`;
+    try {
+      const result = await runtime.buildStartInvocation({
+        runId: run.run_id,
+        cwd: root,
+        prompt: 'hi',
+        modelSettings: { reasoning_effort: null, service_tier: null, mode: null, codex_network: null, worker_posture: 'trusted' },
+      });
+      if (result.ok) {
+        assert.ok(result.invocation.initialEvents, 'retry invocation must keep initialEvents so a real retry spawn emits posture telemetry');
+        assert.equal(result.invocation.initialEvents!.length, 1);
+        assert.equal((result.invocation.initialEvents![0]!.payload as { state?: string }).state, 'worker_posture');
+        assert.equal(result.invocation.earlyEventInterceptor, undefined, 'single-shot enforcement still holds');
+      }
+    } finally {
+      process.env.PATH = originalPath;
+    }
+  });
+});

--- a/src/__tests__/processManager.test.ts
+++ b/src/__tests__/processManager.test.ts
@@ -2,7 +2,7 @@ import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import type { ChildProcess } from 'node:child_process';
 import { chmod, mkdtemp, writeFile } from 'node:fs/promises';
-import { join } from 'node:path';
+import { delimiter, join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { ClaudeBackend } from '../backend/claude.js';
 import { CodexBackend } from '../backend/codex.js';
@@ -845,7 +845,7 @@ describe('CliRuntime.buildStartInvocation (issue #58 review follow-up Medium 3)'
     // initialEvents here would leave the retry with zero posture telemetry.
     const { CliRuntime } = await import('../backend/runtime.js');
     const root = await mkdtemp(join(tmpdir(), 'agent-prebake-'));
-    const cli = join(root, 'worker.js');
+    const cli = join(root, 'claude');
     await writeFile(cli, `#!/usr/bin/env node\n`);
     await chmod(cli, 0o755);
 
@@ -855,7 +855,7 @@ describe('CliRuntime.buildStartInvocation (issue #58 review follow-up Medium 3)'
     const runtime = new CliRuntime(new ClaudeBackend(store), manager);
 
     const originalPath = process.env.PATH ?? '';
-    process.env.PATH = `${root}:${originalPath}`;
+    process.env.PATH = `${root}${delimiter}${originalPath}`;
     try {
       const result = await runtime.buildStartInvocation({
         runId: run.run_id,

--- a/src/__tests__/processManager.test.ts
+++ b/src/__tests__/processManager.test.ts
@@ -743,6 +743,99 @@ process.stdin.on('end', () => {
   });
 });
 
+describe('ProcessManager initialEvents ordering (issue #58 review Major 7)', () => {
+  it('chains worker_posture before status:started so status:started cannot enter store.appendEvent until worker_posture resolves', async () => {
+    // The race fixed here lives in the non-buffered path (interceptor
+    // disengaged): both `appendEventBuffered` calls would previously fan
+    // out into `store.appendEvent` in the same tick and race for the
+    // filesystem run lock, so `status: started` could land before
+    // `worker_posture` in the events log. A naive call-order assertion does
+    // not catch this — the call sites are sequential, the race is inside
+    // `RunStore.appendEvent`. We use a gated store that holds the
+    // worker_posture write *inside* `appendEvent`; on patched code the
+    // chain blocks the second call until the first resolves, on unpatched
+    // code both calls enter together.
+    class GatedAppendStore extends RunStore {
+      readonly enterOrder: string[] = [];
+      readonly resolveOrder: string[] = [];
+      private postureGate: { promise: Promise<void>; resolve: () => void } | null = null;
+
+      installPostureGate(): void {
+        let resolveFn!: () => void;
+        const promise = new Promise<void>((resolve) => { resolveFn = resolve; });
+        this.postureGate = { promise, resolve: resolveFn };
+      }
+
+      releasePostureGate(): void {
+        this.postureGate?.resolve();
+        this.postureGate = null;
+      }
+
+      override async appendEvent(
+        runId: string,
+        event: Parameters<RunStore['appendEvent']>[1],
+      ): ReturnType<RunStore['appendEvent']> {
+        const payload = event.payload as { state?: string; status?: string };
+        const tag = payload.state ?? payload.status ?? '?';
+        this.enterOrder.push(tag);
+        if (tag === 'worker_posture' && this.postureGate) {
+          await this.postureGate.promise;
+        }
+        const result = await super.appendEvent(runId, event);
+        this.resolveOrder.push(tag);
+        return result;
+      }
+    }
+
+    const root = await mkdtemp(join(tmpdir(), 'agent-gated-order-'));
+    const cli = join(root, 'worker.js');
+    // Worker exits cleanly on stdin end without emitting any stdout/stderr
+    // so the events log contains only the orchestrator-issued lifecycle
+    // appends, keeping the enterOrder/resolveOrder assertions tight.
+    await writeFile(cli, `#!/usr/bin/env node\nprocess.stdin.on('data', () => {});\nprocess.stdin.on('end', () => { process.exit(0); });\n`);
+    await chmod(cli, 0o755);
+
+    const store = new GatedAppendStore(root);
+    const run = await store.createRun({ backend: 'claude', cwd: root });
+    const manager = new ProcessManager(store);
+
+    store.installPostureGate();
+    const managed = await manager.start(run.run_id, new ClaudeBackend(), {
+      command: cli,
+      args: [],
+      cwd: root,
+      stdinPayload: 'finish',
+      initialEvents: [{
+        type: 'lifecycle',
+        payload: { state: 'worker_posture', backend: 'claude', worker_posture: 'trusted' },
+      }],
+    });
+
+    // Yield two microtask ticks so the synchronous part of the spawn has
+    // settled and the chain's first `.then(...)` has scheduled the
+    // worker_posture append. On patched code, status:started must not have
+    // entered yet — it is queued behind the gated posture write.
+    await Promise.resolve();
+    await Promise.resolve();
+    assert.deepStrictEqual(store.enterOrder, ['worker_posture'], 'status:started must NOT enter appendEvent while worker_posture is still in-flight');
+
+    store.releasePostureGate();
+    await managed.completion;
+
+    assert.deepStrictEqual(store.enterOrder, ['worker_posture', 'started']);
+    assert.deepStrictEqual(store.resolveOrder, ['worker_posture', 'started']);
+
+    // Belt-and-braces: the on-disk sequence must also reflect the ordering.
+    const loaded = await store.loadRun(run.run_id);
+    const events = loaded?.events ?? [];
+    const posture = events.find((event) => (event.payload as { state?: string }).state === 'worker_posture');
+    const started = events.find((event) => (event.payload as { status?: string }).status === 'started');
+    assert.ok(posture, 'worker_posture must reach the run event stream');
+    assert.ok(started, 'status:started must reach the run event stream');
+    assert.ok(posture.seq < started.seq, 'worker_posture must persist with a lower seq than status:started');
+  });
+});
+
 describe('CliRuntime.buildStartInvocation (issue #58 review follow-up Medium 3)', () => {
   it('preserves initialEvents on the retry invocation so a real retry spawn still emits exactly one worker_posture event', async () => {
     // The retry invocation may never spawn (pre-bake) OR may spawn (retry
@@ -770,12 +863,12 @@ describe('CliRuntime.buildStartInvocation (issue #58 review follow-up Medium 3)'
         prompt: 'hi',
         modelSettings: { reasoning_effort: null, service_tier: null, mode: null, codex_network: null, worker_posture: 'trusted' },
       });
-      if (result.ok) {
-        assert.ok(result.invocation.initialEvents, 'retry invocation must keep initialEvents so a real retry spawn emits posture telemetry');
-        assert.equal(result.invocation.initialEvents!.length, 1);
-        assert.equal((result.invocation.initialEvents![0]!.payload as { state?: string }).state, 'worker_posture');
-        assert.equal(result.invocation.earlyEventInterceptor, undefined, 'single-shot enforcement still holds');
-      }
+      assert.equal(result.ok, true, 'expected buildStartInvocation to succeed for retry-shape assertions');
+      if (!result.ok) return;
+      assert.ok(result.invocation.initialEvents, 'retry invocation must keep initialEvents so a real retry spawn emits posture telemetry');
+      assert.equal(result.invocation.initialEvents.length, 1);
+      assert.equal((result.invocation.initialEvents[0]!.payload as { state?: string }).state, 'worker_posture');
+      assert.equal(result.invocation.earlyEventInterceptor, undefined, 'single-shot enforcement still holds');
     } finally {
       process.env.PATH = originalPath;
     }

--- a/src/__tests__/runStore.test.ts
+++ b/src/__tests__/runStore.test.ts
@@ -29,7 +29,7 @@ describe('RunStore', () => {
 
     const loaded = await store.loadRun(run.run_id);
     assert.equal(loaded?.meta.metadata.task, 'T2');
-    assert.deepStrictEqual(loaded?.meta.model_settings, { reasoning_effort: null, service_tier: null, mode: null, codex_network: null });
+    assert.deepStrictEqual(loaded?.meta.model_settings, { reasoning_effort: null, service_tier: null, mode: null, codex_network: null, worker_posture: null });
     assert.equal(loaded?.meta.worker_invocation, null);
     assert.equal(loaded?.events.length, 2);
     assert.equal(await store.readPrompt(run.run_id), 'raw prompt text');
@@ -145,7 +145,7 @@ describe('RunStore', () => {
       cwd: root,
       model: 'gpt-5.2',
       model_source: 'explicit',
-      model_settings: { reasoning_effort: 'xhigh', service_tier: 'fast', mode: null, codex_network: null },
+      model_settings: { reasoning_effort: 'xhigh', service_tier: 'fast', mode: null, codex_network: null, worker_posture: null },
       requested_session_id: 'session-1',
       observed_session_id: 'session-1',
       display: {
@@ -160,7 +160,7 @@ describe('RunStore', () => {
     assert.equal(loaded.model_source, 'explicit');
     // Schema applies the codex_network: null default when the field was not
     // present on the persisted record (legacy back-compat).
-    assert.deepStrictEqual(loaded.model_settings, { reasoning_effort: 'xhigh', service_tier: 'fast', mode: null, codex_network: null });
+    assert.deepStrictEqual(loaded.model_settings, { reasoning_effort: 'xhigh', service_tier: 'fast', mode: null, codex_network: null, worker_posture: null });
     assert.equal(loaded.requested_session_id, 'session-1');
     assert.equal(loaded.observed_session_id, 'session-1');
     assert.equal(loaded.display.session_title, 'Session title');

--- a/src/backend/WorkerBackend.ts
+++ b/src/backend/WorkerBackend.ts
@@ -48,6 +48,18 @@ export interface WorkerInvocation {
    * `ProcessManager.start` behaves exactly as today.
    */
   earlyEventInterceptor?: EarlyEventInterceptor;
+  /**
+   * Issue #58: backend-supplied lifecycle events to append at actual spawn
+   * time, ahead of the `status: started` marker. `ProcessManager.start()`
+   * is the single flusher; `CliRuntime.buildStartInvocation()` strips this
+   * field so pre-bake retry invocations (which may never spawn) do not
+   * record false telemetry. Used by Claude and Codex to emit a single
+   * `{ state: 'worker_posture', ... }` event describing the resolved
+   * trusted/restricted mapping for this run. The Cursor SDK runtime uses a
+   * separate `store.appendEvent()` path (see `src/backend/cursor/runtime.ts`)
+   * because it does not produce a `WorkerInvocation`.
+   */
+  initialEvents?: Omit<WorkerEvent, 'seq' | 'ts'>[];
 }
 
 export type EarlyEventInterceptorOutcome = 'continue' | 'retry_with_start';

--- a/src/backend/claude.ts
+++ b/src/backend/claude.ts
@@ -1,5 +1,6 @@
 import { writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
+import type { WorkerEvent, WorkerPosture } from '../contract.js';
 import type { RunStore } from '../runStore.js';
 import type { BackendStartInput, ParsedBackendEvent, WorkerInvocation } from './WorkerBackend.js';
 import { BaseBackend, classifyBackendError, commandFromToolInput, emptyParsedEvent, errorFromEvent, extractText, getRecord, getString, invocation, matchesClaudeCliBanner, pathFromToolInput } from './common.js';
@@ -25,7 +26,14 @@ import { BaseBackend, classifyBackendError, commandFromToolInput, emptyParsedEve
  * - `disableAllHooks: true` preserves hook isolation so inherited user
  *   `~/.claude/settings.json` hooks cannot fire under workers (issue #40,
  *   Decisions 9 / 26 / T5 / T13). Hook isolation is independent of the
- *   permission posture and is also NOT a tool sandbox.
+ *   permission posture and is also NOT a tool sandbox. Pinned under both
+ *   trusted and restricted postures (issue #58 Decision 5).
+ * - `enableAllProjectMcpServers: true` is added under the `'trusted'`
+ *   posture (issue #58 Decision 5). Without it, workers loading
+ *   `--setting-sources user,project,local` would stall on the project-MCP
+ *   approval prompt that a non-interactive worker cannot answer. Under
+ *   `'restricted'` posture this key is omitted to preserve the pre-#58
+ *   behavior exactly.
  *
  * The `--permission-mode bypassPermissions` CLI flag is set in addition to
  * the in-file `defaultMode` to mirror the supervisor envelope
@@ -33,10 +41,19 @@ import { BaseBackend, classifyBackendError, commandFromToolInput, emptyParsedEve
  * precedence drift across Claude Code versions where the CLI flag may take
  * precedence over file settings.
  *
- * `--setting-sources user` plus `--settings <path>` is the chosen v1
- * isolation method; `CLAUDE_CONFIG_DIR` is intentionally not redirected
- * (Decision 26). Decision 9b documents the redirected fallback if T13 proves
- * this approach insufficient.
+ * Issue #58: under `worker_posture: 'trusted'` (the new default) the spawn
+ * argv pairs `--settings <path>` with `--setting-sources user,project,local`
+ * so workers see project / user / local Claude Code scopes — MCP servers,
+ * settings, subagents, plugins, CLAUDE.md. Per-run `--settings <path>`
+ * precedence over `--setting-sources` merge plus the CLI `--permission-mode`
+ * flag preserve the hook-isolation and bypass-permissions contracts even
+ * when project `.claude/settings.json` defines hooks or a stricter
+ * permission mode. Under `worker_posture: 'restricted'` the v1 envelope
+ * (`--setting-sources user`) is preserved verbatim.
+ *
+ * `CLAUDE_CONFIG_DIR` is intentionally not redirected (Decision 26 of #40).
+ * Decision 9b documents the redirected fallback if T13 proves this
+ * approach insufficient.
  *
  * `--dangerously-skip-permissions` is forbidden everywhere in this harness
  * per issue #13 Decisions 7 / 21 and is NOT used here. The bypass posture is
@@ -44,14 +61,24 @@ import { BaseBackend, classifyBackendError, commandFromToolInput, emptyParsedEve
  * only.
  *
  * See issue #47 for the empirical reproduction that motivated adding the
- * permission keys, and issue #40 Decisions 9 / 26 for the underlying worker
- * isolation envelope.
+ * permission keys, issue #40 Decisions 9 / 26 for the underlying worker
+ * isolation envelope, and issue #58 for the trusted/restricted posture.
  */
 export const CLAUDE_WORKER_SETTINGS_FILENAME = 'claude-worker-settings.json';
 export const CLAUDE_WORKER_SETTINGS_BODY = {
   disableAllHooks: true,
   permissions: { defaultMode: 'bypassPermissions' },
   skipDangerousModePermissionPrompt: true,
+} as const;
+
+// Issue #58: trusted-posture worker settings include
+// `enableAllProjectMcpServers: true` so the worker auto-approves project
+// MCP servers (`.mcp.json`) at MCP init. Without this key, a worker loading
+// `--setting-sources user,project,local` would stall on the project-MCP
+// approval prompt that a non-interactive worker cannot answer.
+export const CLAUDE_TRUSTED_WORKER_SETTINGS_BODY = {
+  ...CLAUDE_WORKER_SETTINGS_BODY,
+  enableAllProjectMcpServers: true,
 } as const;
 
 export class ClaudeBackend extends BaseBackend {
@@ -64,23 +91,66 @@ export class ClaudeBackend extends BaseBackend {
 
   async start(input: BackendStartInput): Promise<WorkerInvocation> {
     const isolation = await this.prepareWorkerIsolation(input);
-    return invocation(this.binary, ['-p', '--output-format', 'stream-json', '--verbose', ...modelArgs(input.model), ...modelSettingsArgs(input.modelSettings), ...isolation], input);
+    const inv = invocation(this.binary, ['-p', '--output-format', 'stream-json', '--verbose', ...modelArgs(input.model), ...modelSettingsArgs(input.modelSettings), ...isolation.args], input);
+    if (isolation.initialEvents.length > 0) {
+      inv.initialEvents = isolation.initialEvents;
+    }
+    return inv;
   }
 
   async resume(sessionId: string, input: BackendStartInput): Promise<WorkerInvocation> {
     const isolation = await this.prepareWorkerIsolation(input);
-    return invocation(this.binary, ['-p', '--resume', sessionId, '--output-format', 'stream-json', '--verbose', ...modelArgs(input.model), ...modelSettingsArgs(input.modelSettings), ...isolation], input);
+    const inv = invocation(this.binary, ['-p', '--resume', sessionId, '--output-format', 'stream-json', '--verbose', ...modelArgs(input.model), ...modelSettingsArgs(input.modelSettings), ...isolation.args], input);
+    if (isolation.initialEvents.length > 0) {
+      inv.initialEvents = isolation.initialEvents;
+    }
+    return inv;
   }
 
-  private async prepareWorkerIsolation(input: BackendStartInput): Promise<string[]> {
-    if (!this.store || !input.runId) return [];
+  private async prepareWorkerIsolation(input: BackendStartInput): Promise<{ args: string[]; initialEvents: Omit<WorkerEvent, 'seq' | 'ts'>[] }> {
+    if (!this.store || !input.runId) {
+      // Legacy/direct-caller path: no run id, no per-run settings, no
+      // telemetry event. Preserves the existing contract documented by
+      // `claudeWorkerIsolation.test.ts` "omits worker isolation flags when
+      // no run id is supplied".
+      return { args: [], initialEvents: [] };
+    }
+    // Issue #58: branch on worker_posture. Legacy run records (pre-#58)
+    // have `worker_posture: null` in their model_settings; tolerate by
+    // defaulting to 'trusted' (the new product default). Operators who
+    // need the v1 closed-by-default envelope must opt in with
+    // `worker_posture: 'restricted'`.
+    const workerPosture: WorkerPosture = input.modelSettings.worker_posture ?? 'trusted';
+    const settingsBody = workerPosture === 'trusted'
+      ? CLAUDE_TRUSTED_WORKER_SETTINGS_BODY
+      : CLAUDE_WORKER_SETTINGS_BODY;
+    const settingSources = workerPosture === 'trusted' ? 'user,project,local' : 'user';
     const settingsPath = join(this.store.runDir(input.runId), CLAUDE_WORKER_SETTINGS_FILENAME);
     await writeFile(
       settingsPath,
-      `${JSON.stringify(CLAUDE_WORKER_SETTINGS_BODY, null, 2)}\n`,
+      `${JSON.stringify(settingsBody, null, 2)}\n`,
       { mode: 0o600 },
     );
-    return ['--settings', settingsPath, '--setting-sources', 'user', '--permission-mode', CLAUDE_WORKER_SETTINGS_BODY.permissions.defaultMode];
+    const args = ['--settings', settingsPath, '--setting-sources', settingSources, '--permission-mode', settingsBody.permissions.defaultMode];
+    // Issue #58 Decision 11: emit one spawn-time lifecycle event per worker
+    // so operators can see which posture and setting-sources value the
+    // worker actually used via `get_run_events`. Placed in
+    // `WorkerInvocation.initialEvents` so `ProcessManager.start()` flushes
+    // it once per actual spawn — `CliRuntime.buildStartInvocation()` strips
+    // it on the pre-bake retry path.
+    const initialEvents: Omit<WorkerEvent, 'seq' | 'ts'>[] = [{
+      type: 'lifecycle',
+      payload: {
+        state: 'worker_posture',
+        backend: 'claude',
+        worker_posture: workerPosture,
+        claude: {
+          setting_sources: settingSources,
+          enable_all_project_mcp_servers: workerPosture === 'trusted',
+        },
+      },
+    }];
+    return { args, initialEvents };
   }
 
   parseEvent(raw: unknown): ParsedBackendEvent {

--- a/src/backend/codex.ts
+++ b/src/backend/codex.ts
@@ -1,3 +1,4 @@
+import type { WorkerEvent, WorkerPosture } from '../contract.js';
 import type { BackendStartInput, ParsedBackendEvent, WorkerInvocation } from './WorkerBackend.js';
 import { BaseBackend, commandFromToolInput, emptyParsedEvent, errorFromEvent, extractText, getRecord, getString, invocation, pathFromToolInput } from './common.js';
 
@@ -6,7 +7,7 @@ export class CodexBackend extends BaseBackend {
   readonly binary = 'codex';
 
   async start(input: BackendStartInput): Promise<WorkerInvocation> {
-    return invocation(this.binary, [
+    const inv = invocation(this.binary, [
       'exec',
       '--json',
       '--skip-git-repo-check',
@@ -17,10 +18,12 @@ export class CodexBackend extends BaseBackend {
       ...modelSettingsArgs(input.modelSettings),
       '-',
     ], input);
+    inv.initialEvents = [postureEvent(input.modelSettings)];
+    return inv;
   }
 
   async resume(sessionId: string, input: BackendStartInput): Promise<WorkerInvocation> {
-    return invocation(this.binary, [
+    const inv = invocation(this.binary, [
       'exec',
       'resume',
       '--json',
@@ -31,6 +34,8 @@ export class CodexBackend extends BaseBackend {
       sessionId,
       '-',
     ], input);
+    inv.initialEvents = [postureEvent(input.modelSettings)];
+    return inv;
   }
 
   parseEvent(raw: unknown): ParsedBackendEvent {
@@ -142,21 +147,80 @@ function modelArgs(model: string | null | undefined): string[] {
 }
 
 function sandboxArgs(settings: BackendStartInput['modelSettings']): string[] {
-  // Per docs/development/codex-backend.md (issue #31):
-  // - 'isolated'    => --ignore-user-config (codex skips $CODEX_HOME/config.toml)
-  // - 'workspace'   => --ignore-user-config + -c sandbox_workspace_write.network_access=true
-  // - 'user-config' => no flags (codex reads $CODEX_HOME/config.toml verbatim)
-  // The legacy `mode === 'normal'` path is retired; the orchestrator service
-  // resolves codex_network and the codex backend reads only that field.
+  // Per docs/development/codex-backend.md.
+  //
+  // Issue #58 Decision 9: decouple config-source from sandbox/network posture.
+  //   - worker_posture controls whether --ignore-user-config is emitted.
+  //   - codex_network controls only the sandbox/network argv.
+  //
+  // Argv shape, by posture × codex_network:
+  //
+  // trusted + absent     -> -c sandbox_mode="workspace-write" -c sandbox_workspace_write.network_access=true
+  // trusted + 'workspace'-> -c sandbox_workspace_write.network_access=true
+  // trusted + 'isolated' -> (no flags; codex defaults apply)
+  // trusted + 'user-config' -> (no flags)
+  //
+  // restricted + absent or 'isolated' -> --ignore-user-config
+  // restricted + 'workspace'          -> --ignore-user-config -c sandbox_workspace_write.network_access=true
+  // restricted + 'user-config'        -> (no flags)
+  //
+  // All `-c key=value` overrides are accepted by both `codex exec` and
+  // `codex exec resume`. `--sandbox` is start-only and is NOT used here so
+  // start/resume keep sharing this helper (issue #58 Decision 6 — review
+  // rev. 2 F1).
+  const workerPosture: WorkerPosture = settings.worker_posture ?? 'trusted';
+
+  if (workerPosture === 'trusted') {
+    if (settings.codex_network === 'workspace') {
+      return ['-c', 'sandbox_workspace_write.network_access=true'];
+    }
+    if (settings.codex_network === 'isolated' || settings.codex_network === 'user-config') {
+      return [];
+    }
+    // Absent (or legacy null) under trusted: open the workspace network
+    // posture by default. Matches what a developer running `codex exec`
+    // in the project sees under workspace-write with network on.
+    return ['-c', 'sandbox_mode="workspace-write"', '-c', 'sandbox_workspace_write.network_access=true'];
+  }
+
+  // Restricted posture: preserve today's argv shapes verbatim (issue #31).
   if (settings.codex_network === 'workspace') {
     return ['--ignore-user-config', '-c', 'sandbox_workspace_write.network_access=true'];
   }
   if (settings.codex_network === 'user-config') return [];
-  if (settings.codex_network === 'isolated') return ['--ignore-user-config'];
-  // Defensive: settings should always carry an explicit codex_network for codex
-  // runs after orchestratorService resolution. Fall back to the safer closed
-  // posture if a legacy run record is replayed without the field.
+  // 'isolated', absent, or legacy null → closed posture.
   return ['--ignore-user-config'];
+}
+
+function postureEvent(settings: BackendStartInput['modelSettings']): Omit<WorkerEvent, 'seq' | 'ts'> {
+  // Issue #58 Decision 11: one spawn-time lifecycle event per worker so
+  // `get_run_events` answers "what posture did this codex worker use?".
+  // The payload records both the resolved posture and the codex-side
+  // effective flags so operators can correlate with the actual argv.
+  const workerPosture: WorkerPosture = settings.worker_posture ?? 'trusted';
+  const args = sandboxArgs(settings);
+  const ignoreUserConfig = args.includes('--ignore-user-config');
+  const sandboxMode = workerPosture === 'trusted'
+    && (settings.codex_network === undefined
+      || settings.codex_network === null
+      || settings.codex_network === 'workspace')
+    ? 'workspace-write'
+    : null;
+  const networkAccess = args.some((arg) => arg === 'sandbox_workspace_write.network_access=true');
+  return {
+    type: 'lifecycle',
+    payload: {
+      state: 'worker_posture',
+      backend: 'codex',
+      worker_posture: workerPosture,
+      codex: {
+        ignore_user_config: ignoreUserConfig,
+        sandbox: sandboxMode,
+        network_access: networkAccess,
+        codex_network: settings.codex_network ?? null,
+      },
+    },
+  };
 }
 
 function modelSettingsArgs(settings: BackendStartInput['modelSettings']): string[] {

--- a/src/backend/cursor/runtime.ts
+++ b/src/backend/cursor/runtime.ts
@@ -3,6 +3,7 @@ import type {
   RunError,
   RunMeta,
   RunStatus,
+  WorkerPosture,
   WorkerResult,
 } from '../../contract.js';
 import { WorkerResultSchema } from '../../contract.js';
@@ -164,17 +165,31 @@ export class CursorSdkRuntime implements WorkerRuntime {
       };
     }
 
+    // Issue #58 Decision 7: under 'trusted' posture (the new default), pass
+    // `local.settingSources: ['all']` so the SDK loads every ambient Cursor
+    // settings layer (project / user / team / mdm / plugins). Under
+    // 'restricted' posture, omit `settingSources` so the SDK's pre-#58
+    // behavior is preserved verbatim (no ambient settings loaded by the
+    // shim). `[all]` is the SDK-documented forward-compatible primitive;
+    // adding more SettingSource values later does not require code changes
+    // here.
+    const workerPosture: WorkerPosture = input.modelSettings.worker_posture ?? 'trusted';
+    const localOptions: { cwd: string; settingSources?: ('all')[] } = { cwd: input.cwd };
+    if (workerPosture === 'trusted') {
+      localOptions.settingSources = ['all'];
+    }
+
     let agent: CursorAgent;
     try {
       agent = sessionId
         ? await agentApi.resume(sessionId, {
             apiKey,
-            local: { cwd: input.cwd },
+            local: localOptions,
           })
         : await agentApi.create({
             apiKey,
             model: input.model ? { id: input.model } : undefined,
-            local: { cwd: input.cwd },
+            local: localOptions,
           });
     } catch (error) {
       return {
@@ -201,6 +216,27 @@ export class CursorSdkRuntime implements WorkerRuntime {
         failure: cursorSpawnFailure('Failed to send prompt to cursor agent', error, { phase: 'send' }),
       };
     }
+
+    // Issue #58 Decision 18: emit the worker_posture lifecycle event after
+    // the SDK actually accepted the prompt (Agent.create / Agent.resume +
+    // agent.send both resolved) and BEFORE the drain loop in
+    // `createCursorHandle` appends any SDK stream events. Cursor doesn't use
+    // `WorkerInvocation` (no `ProcessManager.start()` path), so the event
+    // goes through `store.appendEvent()` directly. Pre-spawn failures
+    // (WORKER_BINARY_MISSING / SPAWN_FAILED from any of `available`,
+    // `loadAgentApi`, `create`/`resume`, or `send`) emit zero events because
+    // we return early above this point — review follow-up Medium 2 closed.
+    await this.options.store.appendEvent(input.runId, {
+      type: 'lifecycle',
+      payload: {
+        state: 'worker_posture',
+        backend: 'cursor',
+        worker_posture: workerPosture,
+        cursor: {
+          setting_sources: localOptions.settingSources ?? null,
+        },
+      },
+    });
 
     return {
       ok: true,

--- a/src/backend/cursor/runtime.ts
+++ b/src/backend/cursor/runtime.ts
@@ -226,17 +226,29 @@ export class CursorSdkRuntime implements WorkerRuntime {
     // (WORKER_BINARY_MISSING / SPAWN_FAILED from any of `available`,
     // `loadAgentApi`, `create`/`resume`, or `send`) emit zero events because
     // we return early above this point — review follow-up Medium 2 closed.
-    await this.options.store.appendEvent(input.runId, {
-      type: 'lifecycle',
-      payload: {
-        state: 'worker_posture',
-        backend: 'cursor',
-        worker_posture: workerPosture,
-        cursor: {
-          setting_sources: localOptions.settingSources ?? null,
+    try {
+      await this.options.store.appendEvent(input.runId, {
+        type: 'lifecycle',
+        payload: {
+          state: 'worker_posture',
+          backend: 'cursor',
+          worker_posture: workerPosture,
+          cursor: {
+            setting_sources: localOptions.settingSources ?? null,
+          },
         },
-      },
-    });
+      });
+    } catch (error) {
+      await disposeAgentSafely(agent);
+      return {
+        ok: false,
+        failure: cursorSpawnFailure(
+          'Failed to persist worker_posture lifecycle event',
+          error,
+          { phase: 'append_event' },
+        ),
+      };
+    }
 
     return {
       ok: true,

--- a/src/backend/cursor/sdk.ts
+++ b/src/backend/cursor/sdk.ts
@@ -123,10 +123,24 @@ export interface CursorAgent {
   [Symbol.asyncDispose]?: () => Promise<void>;
 }
 
+// Issue #58: subset of @cursor/sdk's SettingSource (LocalAgentOptions.settingSources)
+// re-declared here so the shim stays decoupled from the optional SDK package
+// when it is not installed. Type kept in sync with @cursor/sdk 1.0.12.
+export type CursorSettingSource = 'project' | 'user' | 'team' | 'mdm' | 'plugins' | 'all';
+
+export interface CursorSandboxOptions {
+  enabled: boolean;
+}
+
 export interface CursorAgentCreateOptions {
   apiKey?: string;
   model?: { id: string; params?: { id: string; value: string }[] };
-  local?: { cwd?: string };
+  // Issue #58: extend local options to forward `settingSources` and
+  // `sandboxOptions` to `Agent.create`. Trusted-posture cursor workers
+  // pass `settingSources: ['all']` so the SDK loads every ambient settings
+  // layer (project / user / team / mdm / plugins) — the documented full-parity
+  // value (review rev. 2 F4).
+  local?: { cwd?: string; settingSources?: CursorSettingSource[]; sandboxOptions?: CursorSandboxOptions };
   agentId?: string;
   name?: string;
 }
@@ -134,7 +148,11 @@ export interface CursorAgentCreateOptions {
 export interface CursorAgentResumeOptions {
   apiKey?: string;
   model?: { id: string; params?: { id: string; value: string }[] };
-  local?: { cwd?: string };
+  // Resume must also receive `settingSources` to preserve parity across the
+  // start → resume boundary (SDK docs note inline `mcpServers` do not
+  // persist across resume, so file-backed `settingSources` is the resume-safe
+  // path).
+  local?: { cwd?: string; settingSources?: CursorSettingSource[]; sandboxOptions?: CursorSandboxOptions };
 }
 
 export interface CursorAgentApi {

--- a/src/backend/runtime.ts
+++ b/src/backend/runtime.ts
@@ -109,6 +109,14 @@ export class CliRuntime implements WorkerRuntime {
       // Single-shot enforcement (D-COR-Resume-Layer): the retry invocation
       // itself never carries an interceptor, regardless of caller intent.
       invocation.earlyEventInterceptor = undefined;
+      // Issue #58 review follow-up (Medium 3): keep `initialEvents` on the
+      // retry invocation. `ProcessManager`'s `executeAttempt` only flushes
+      // them at an actual spawn — a pre-baked invocation that never spawns
+      // produces zero telemetry naturally. If the retry fires, the first
+      // attempt's posture event was dropped along with the cancelled
+      // attempt's event buffer (intentional, per D-COR-Resume), so the
+      // retry attempt's own `initialEvents` is what makes the run end with
+      // exactly one posture event in `events.jsonl`.
       return { ok: true, invocation };
     } catch (error) {
       return {

--- a/src/claude/config.ts
+++ b/src/claude/config.ts
@@ -223,6 +223,7 @@ function formatProfiles(profiles: ValidatedWorkerProfiles | undefined): string {
         profile.variant ? `variant=${profile.variant}` : null,
         profile.reasoning_effort ? `reasoning_effort=${profile.reasoning_effort}` : null,
         profile.service_tier ? `service_tier=${profile.service_tier}` : null,
+        workerPostureLine(profile),
         codexNetworkLine(profile),
       ].filter(Boolean).join(', ');
       return `- ${profile.id}: ${settings}${profile.description ? `; ${profile.description}` : ''}`;
@@ -230,14 +231,28 @@ function formatProfiles(profiles: ValidatedWorkerProfiles | undefined): string {
     .join('\n');
 }
 
+// Issue #58: render the effective worker_posture for every profile so the
+// Claude supervisor sees whether each profile launches workers under the
+// trusted (backend-native, default) or restricted (isolated, opt-in) envelope.
+function workerPostureLine(profile: { worker_posture?: string }): string {
+  if (profile.worker_posture) return `worker_posture=${profile.worker_posture}`;
+  return 'worker_posture=trusted (default)';
+}
+
 // Issue #31 / B1: render the *effective* codex_network on codex profiles so
-// the supervisor sees the resolved posture (and the OD1=B default of
-// 'isolated') in the prompt, even when the manifest does not set it. Non-codex
-// profiles continue to render identically to today.
-function codexNetworkLine(profile: { backend: string; codex_network?: string }): string | null {
+// the supervisor sees the resolved posture in the prompt. Non-codex profiles
+// render no codex_network line.
+//
+// Issue #58 follow-up: the "default" depends on worker_posture. Under
+// restricted, unset codex_network resolves to 'isolated'. Under trusted,
+// unset codex_network resolves to the trusted-default sandbox (workspace-write
+// with network on; persisted as null).
+function codexNetworkLine(profile: { backend: string; codex_network?: string; worker_posture?: string }): string | null {
   if (profile.backend !== 'codex') return null;
   if (profile.codex_network) return `codex_network=${profile.codex_network}`;
-  return 'codex_network=isolated (default)';
+  return profile.worker_posture === 'restricted'
+    ? 'codex_network=isolated (default for restricted)'
+    : 'codex_network=workspace-write+network (trusted default)';
 }
 
 function formatEmbeddedOrchestrationSkills(skills: readonly ResolvedClaudeSkill[]): string {

--- a/src/contract.ts
+++ b/src/contract.ts
@@ -250,11 +250,23 @@ export const CodexNetworkSchema = z.enum([
 ]);
 export type CodexNetwork = z.infer<typeof CodexNetworkSchema>;
 
+// Issue #58: worker posture controls whether worker runs get backend-native
+// parity with a manual launch ('trusted') or the orchestrator's curated
+// isolated envelope ('restricted'). The supervisor is always restricted and
+// ignores this field. See plans/58-issue-with-setting-sources for the full
+// per-backend mapping.
+export const WorkerPostureSchema = z.enum([
+  'trusted',
+  'restricted',
+]);
+export type WorkerPosture = z.infer<typeof WorkerPostureSchema>;
+
 const defaultRunModelSettings = {
   reasoning_effort: null,
   service_tier: null,
   mode: null,
   codex_network: null,
+  worker_posture: null,
 };
 
 export const RunModelSettingsSchema = z.object({
@@ -262,6 +274,10 @@ export const RunModelSettingsSchema = z.object({
   service_tier: ServiceTierSchema.nullable().optional().default(null),
   mode: z.string().nullable().optional().default(null),
   codex_network: CodexNetworkSchema.nullable().optional().default(null),
+  // Issue #58: nullable for backward compatibility with legacy run records.
+  // Read paths tolerate null; write paths on `start_run` / `send_followup`
+  // normalize to a concrete posture before persistence (default `'trusted'`).
+  worker_posture: WorkerPostureSchema.nullable().optional().default(null),
 }).default(defaultRunModelSettings);
 export type RunModelSettings = z.infer<typeof RunModelSettingsSchema>;
 
@@ -368,6 +384,9 @@ export const StartRunInputSchema = z.object({
   reasoning_effort: ReasoningEffortSchema.optional(),
   service_tier: ServiceTierSchema.optional(),
   codex_network: CodexNetworkSchema.optional(),
+  // Issue #58: direct-mode override for worker posture. Profile mode reads
+  // the field off the profile and rejects mixing (see superRefine below).
+  worker_posture: WorkerPostureSchema.optional(),
   metadata: z.record(z.unknown()).optional().default({}),
   idle_timeout_seconds: z.number().int().positive().optional(),
   execution_timeout_seconds: z.number().int().positive().optional(),
@@ -382,10 +401,10 @@ export const StartRunInputSchema = z.object({
     });
   }
 
-  if (input.profile && (input.backend || input.model || input.reasoning_effort || input.service_tier || input.codex_network)) {
+  if (input.profile && (input.backend || input.model || input.reasoning_effort || input.service_tier || input.codex_network || input.worker_posture)) {
     context.addIssue({
       code: z.ZodIssueCode.custom,
-      message: 'Profile mode cannot be mixed with direct backend/model/reasoning_effort/service_tier/codex_network settings',
+      message: 'Profile mode cannot be mixed with direct backend/model/reasoning_effort/service_tier/codex_network/worker_posture settings',
       path: ['profile'],
     });
   }
@@ -446,6 +465,9 @@ export const UpsertWorkerProfileInputSchema = z.object({
   reasoning_effort: ReasoningEffortSchema.optional(),
   service_tier: ServiceTierSchema.optional(),
   codex_network: CodexNetworkSchema.optional(),
+  // Issue #58: declare the worker posture on the profile manifest. Optional;
+  // absence is normalized to `'trusted'` at run time.
+  worker_posture: WorkerPostureSchema.optional(),
   description: z.string().trim().min(1).optional(),
   metadata: z.record(z.unknown()).optional(),
   create_if_missing: z.boolean().optional().default(true),
@@ -492,6 +514,11 @@ export const SendFollowupInputSchema = z.object({
   reasoning_effort: ReasoningEffortSchema.optional(),
   service_tier: ServiceTierSchema.optional(),
   codex_network: CodexNetworkSchema.optional(),
+  // Issue #58: direct-mode follow-up may override the inherited posture only
+  // when the chain originated from direct mode; the orchestrator service
+  // rejects profile-mode-chain overrides at runtime, mirroring the existing
+  // codex_network rule.
+  worker_posture: WorkerPostureSchema.optional(),
   metadata: z.record(z.unknown()).optional().default({}),
   idle_timeout_seconds: z.number().int().positive().optional(),
   execution_timeout_seconds: z.number().int().positive().optional(),

--- a/src/harness/capabilities.ts
+++ b/src/harness/capabilities.ts
@@ -46,6 +46,10 @@ export const WorkerProfileSchema = z.object({
   reasoning_effort: z.string().trim().min(1).optional(),
   service_tier: z.string().trim().min(1).optional(),
   codex_network: z.string().trim().min(1).optional(),
+  // Issue #58: optional manifest field; validated against `WorkerPostureSchema`
+  // at start-run time by `parseProfileModelSettings`. Stored as a plain string
+  // here to keep the manifest schema unaware of the orchestrator's RunModelSettings.
+  worker_posture: z.string().trim().min(1).optional(),
   description: z.string().trim().min(1).optional(),
   metadata: z.record(z.unknown()).optional(),
   claude_account: ClaudeAccountNameSchema.optional(),
@@ -108,7 +112,7 @@ export function createWorkerCapabilityCatalog(statusReport?: BackendStatusReport
         },
         notes: [
           'Models are user-defined; the backend validates CLI availability and supported settings.',
-          'codex_network controls network egress: isolated (default; --ignore-user-config, no network), workspace (network on, codex skips $CODEX_HOME/config.toml), user-config (codex reads $CODEX_HOME/config.toml verbatim).',
+          'worker_posture controls config/MCP visibility: trusted (default; codex loads user + project config.toml and MCP servers) vs restricted (opt-in; codex skips user config via --ignore-user-config). codex_network controls the codex sandbox/network shape inside the chosen posture: isolated (codex defaults; no network override), workspace (sandbox_workspace_write.network_access=true), user-config (codex defaults). Under trusted with codex_network unset, the daemon emits -c sandbox_mode="workspace-write" -c sandbox_workspace_write.network_access=true.',
         ],
       },
       {
@@ -252,6 +256,14 @@ function validateProfile(
   if (profile.variant && !capability.settings.variants.includes(profile.variant)) {
     errors.push(`profile ${profileId} uses unsupported variant ${profile.variant} for backend ${profile.backend}`);
   }
+  // Issue #58 review follow-up (Medium 2): validate worker_posture at
+  // inspection time so a hand-edited manifest with a typo lands as an
+  // `invalid_profiles` diagnostic in `list_worker_profiles` instead of
+  // surprising the caller at `start_run` time. Backend-agnostic — the same
+  // values apply to every backend.
+  if (profile.worker_posture && !(WORKER_POSTURE_VALUES as readonly string[]).includes(profile.worker_posture)) {
+    errors.push(`profile ${profileId} uses unsupported worker_posture ${profile.worker_posture}; expected one of ${WORKER_POSTURE_VALUES.join(', ')}`);
+  }
   errors.push(...validateBackendSpecificProfile(profileId, profile));
   if (profile.backend === 'claude' && knownClaudeAccounts) {
     if (profile.claude_account && !knownClaudeAccounts.has(profile.claude_account)) {
@@ -269,6 +281,11 @@ function validateProfile(
 }
 
 const CODEX_NETWORK_VALUES = ['isolated', 'workspace', 'user-config'] as const;
+
+// Issue #58: kept in sync with `WorkerPostureSchema` in `src/contract.ts`. The
+// harness layer can't import from `contract.ts` without pulling daemon types,
+// so the enum is restated here and validated above.
+const WORKER_POSTURE_VALUES = ['trusted', 'restricted'] as const;
 
 function validateBackendSpecificProfile(profileId: string, profile: WorkerProfile): string[] {
   if (profile.backend === 'codex') return [

--- a/src/mcpTools.ts
+++ b/src/mcpTools.ts
@@ -37,7 +37,12 @@ export const tools = [
         codex_network: {
           type: 'string',
           enum: ['isolated', 'workspace', 'user-config'],
-          description: 'Codex-only network egress posture. isolated (default): --ignore-user-config; codex skips $CODEX_HOME/config.toml; no network. workspace: --ignore-user-config plus -c sandbox_workspace_write.network_access=true; network on. user-config: codex reads $CODEX_HOME/config.toml verbatim. Direct mode only; profile mode rejects this field.',
+          description: 'Codex-only sandbox / network egress shape. Independent axis from worker_posture (issue #58 review follow-up). Under worker_posture=trusted: isolated => codex defaults (no sandbox flags); workspace => -c sandbox_workspace_write.network_access=true; user-config => codex defaults; unset => trusted-default (-c sandbox_mode="workspace-write" with network on). Under worker_posture=restricted: isolated (default) and workspace add --ignore-user-config; user-config adds no flags. Direct mode only; profile mode rejects this field.',
+        },
+        worker_posture: {
+          type: 'string',
+          enum: ['trusted', 'restricted'],
+          description: 'Worker access posture (issue #58). Controls config/MCP visibility, independent of codex_network. trusted (default): worker gets backend-native parity with a manual run — Claude loads project/user/local setting-sources and enableAllProjectMcpServers; Codex loads user + project config.toml (no --ignore-user-config); Cursor loads all ambient SDK settingSources. restricted: orchestrator-curated isolated envelope (the pre-#58 closed-by-default behavior). Supervisor envelope ignores this field. Direct mode only; profile mode rejects this field.',
         },
         metadata: { type: 'object', additionalProperties: true },
         idle_timeout_seconds: {
@@ -116,7 +121,12 @@ export const tools = [
         codex_network: {
           type: 'string',
           enum: ['isolated', 'workspace', 'user-config'],
-          description: 'Codex-only profile field. Controls codex network egress: isolated (default; --ignore-user-config; no network), workspace (network on; codex skips $CODEX_HOME/config.toml), user-config (codex reads $CODEX_HOME/config.toml verbatim). When omitted, codex profiles default to isolated (issue #31, BREAKING).',
+          description: 'Codex-only profile field. Independent of worker_posture. Controls the codex sandbox/network shape only. Effective argv depends on the chosen worker_posture (issue #58): under trusted, isolated/user-config keep codex defaults, workspace adds -c sandbox_workspace_write.network_access=true, and an unset value emits the trusted-default sandbox (workspace-write with network on); under restricted, isolated (default) and workspace add --ignore-user-config, and user-config adds no flags.',
+        },
+        worker_posture: {
+          type: 'string',
+          enum: ['trusted', 'restricted'],
+          description: 'Worker access posture (issue #58). Controls config/MCP visibility, independent of codex_network. trusted (default): backend-native parity with a manual run — loads project/user MCP and config. restricted: orchestrator-curated isolated envelope (pre-#58 closed-by-default). Valid for every backend; the supervisor envelope ignores this field.',
         },
         description: { type: 'string' },
         metadata: { type: 'object', additionalProperties: true },
@@ -288,6 +298,11 @@ export const tools = [
           type: 'string',
           enum: ['isolated', 'workspace', 'user-config'],
           description: 'Codex-only network egress posture override for this follow-up. Omit to inherit the parent run setting. Direct-mode follow-ups only; profile-mode parents reject this field.',
+        },
+        worker_posture: {
+          type: 'string',
+          enum: ['trusted', 'restricted'],
+          description: 'Worker access posture override for this follow-up (issue #58). Omit to inherit the parent run setting. Direct-mode follow-ups only; profile-mode parents reject this field.',
         },
         metadata: { type: 'object', additionalProperties: true },
         idle_timeout_seconds: {

--- a/src/opencode/config.ts
+++ b/src/opencode/config.ts
@@ -171,7 +171,7 @@ function orchestrationPrompt(input: OpenCodeHarnessConfigInput): string {
     '',
     'Profiles manifest guidance:',
     '- You may create or update only the writable profiles manifest path when the user asks you to configure profiles.',
-    '- Keep profiles provider-agnostic: profile ids map to backend, model, variant, reasoning effort, service tier, codex_network (codex-only network egress posture; defaults to isolated when unset), description, and metadata.',
+    '- Keep profiles provider-agnostic: profile ids map to backend, model, variant, reasoning effort, service tier, worker_posture (issue #58 — controls config/MCP visibility: trusted (default) loads project/user MCP and config; restricted is the orchestrator-curated isolated envelope), codex_network (codex-only sandbox/network shape, independent of worker_posture), description, and metadata.',
     '- Use list_worker_profiles with profiles_file to inspect the live profile manifest before choosing workers.',
     '- For normal worker starts, call start_run with profile and profiles_file using the writable profiles manifest path.',
     '- Use direct backend/model/reasoning_effort/service_tier in start_run only when the user explicitly requests a one-off direct model or when live profile resolution is broken.',
@@ -239,6 +239,7 @@ function formatProfiles(profiles: ValidatedWorkerProfiles | undefined): string {
         profile.variant ? `variant=${profile.variant}` : null,
         profile.reasoning_effort ? `reasoning_effort=${profile.reasoning_effort}` : null,
         profile.service_tier ? `service_tier=${profile.service_tier}` : null,
+        workerPostureLine(profile),
         codexNetworkLine(profile),
       ].filter(Boolean).join(', ');
       return `- ${profile.id}: ${settings}${profile.description ? `; ${profile.description}` : ''}`;
@@ -246,14 +247,28 @@ function formatProfiles(profiles: ValidatedWorkerProfiles | undefined): string {
     .join('\n');
 }
 
+// Issue #58: render the effective worker_posture for every profile so the
+// supervisor sees whether each profile launches workers under the trusted
+// (backend-native, default) or restricted (isolated, opt-in) envelope.
+function workerPostureLine(profile: { worker_posture?: string }): string {
+  if (profile.worker_posture) return `worker_posture=${profile.worker_posture}`;
+  return 'worker_posture=trusted (default)';
+}
+
 // Issue #31 / B1: render the *effective* codex_network on codex profiles so
-// the supervisor sees the resolved posture (and the OD1=B default of
-// 'isolated') in the prompt, even when the manifest does not set it. Non-codex
-// profiles continue to render identically to today (no codex_network line).
-function codexNetworkLine(profile: { backend: string; codex_network?: string }): string | null {
+// the supervisor sees the resolved posture in the prompt, even when the
+// manifest does not set it. Non-codex profiles render no codex_network line.
+//
+// Issue #58 follow-up: the "default" depends on worker_posture. Under
+// restricted, unset codex_network resolves to 'isolated'. Under trusted,
+// unset codex_network resolves to the trusted-default sandbox (workspace-write
+// with network on; persisted as null). Display both branches honestly.
+function codexNetworkLine(profile: { backend: string; codex_network?: string; worker_posture?: string }): string | null {
   if (profile.backend !== 'codex') return null;
   if (profile.codex_network) return `codex_network=${profile.codex_network}`;
-  return 'codex_network=isolated (default)';
+  return profile.worker_posture === 'restricted'
+    ? 'codex_network=isolated (default for restricted)'
+    : 'codex_network=workspace-write+network (trusted default)';
 }
 
 function formatCatalog(catalog: WorkerCapabilityCatalog): string {

--- a/src/orchestratorService.ts
+++ b/src/orchestratorService.ts
@@ -837,14 +837,31 @@ export class OrchestratorService {
       ? modelSettingsForBackend(backendName, model, parsed.data.reasoning_effort, parsed.data.service_tier, inheritedCodexNetwork, inheritedWorkerPosture)
       : parsed.data.codex_network !== undefined
         ? patchCodexNetwork(parent.meta.model_settings, parsed.data.codex_network, inheritedWorkerPosture)
-        : parsed.data.worker_posture !== undefined
-          ? { ok: true as const, value: { ...parent.meta.model_settings, worker_posture: parsed.data.worker_posture } }
-          : parsed.data.model || backendName === 'cursor'
-            ? validateInheritedModelSettingsForBackend(backendName, model, parent.meta.model_settings)
-            : { ok: true as const, value: parent.meta.model_settings };
+        : {
+            ok: true as const,
+            value: parsed.data.worker_posture !== undefined
+              ? { ...parent.meta.model_settings, worker_posture: parsed.data.worker_posture }
+              : parent.meta.model_settings,
+          };
     if (!settings.ok) {
       releaseLock?.();
       return wrapErr(settings.error);
+    }
+    // Issue #58 review Major (Comment 6): the posture-only branch above
+    // intentionally skips backend validation so a follow-up that only flips
+    // worker_posture does not have to re-validate the parent's inherited
+    // settings. But if the follow-up *also* changes the model (or targets
+    // cursor), the merged settings must run through
+    // validateInheritedModelSettingsForBackend just like a non-posture
+    // model-changing follow-up does — otherwise a `worker_posture + model`
+    // override could persist an invalid claude reasoning_effort/model
+    // combination or an incomplete cursor setup.
+    const validated = parsed.data.model || backendName === 'cursor'
+      ? validateInheritedModelSettingsForBackend(backendName, model, settings.value)
+      : settings;
+    if (!validated.ok) {
+      releaseLock?.();
+      return wrapErr(validated.error);
     }
     // B2 (issue #31): normalize legacy parent records before persisting the
     // child. A legacy codex parent has model_settings.codex_network === null;
@@ -859,10 +876,10 @@ export class OrchestratorService {
     // restricted-only. Under trusted, codex_network=null is the *effective*
     // value (it means "trusted-default sandbox": workspace-write + network on)
     // and must persist as null so re-runs spawn with the trusted-default argv.
-    const childPosture: WorkerPosture = settings.value.worker_posture ?? 'trusted';
-    const codexNormalized = backendName === 'codex' && settings.value.codex_network === null && childPosture === 'restricted'
-      ? { ...settings.value, codex_network: 'isolated' as CodexNetwork, mode: 'normal' as const }
-      : settings.value;
+    const childPosture: WorkerPosture = validated.value.worker_posture ?? 'trusted';
+    const codexNormalized = backendName === 'codex' && validated.value.codex_network === null && childPosture === 'restricted'
+      ? { ...validated.value, codex_network: 'isolated' as CodexNetwork, mode: 'normal' as const }
+      : validated.value;
     const persistedSettings: RunModelSettings = codexNormalized.worker_posture === null
       ? { ...codexNormalized, worker_posture: 'trusted' as WorkerPosture }
       : codexNormalized;

--- a/src/orchestratorService.ts
+++ b/src/orchestratorService.ts
@@ -28,6 +28,7 @@ import {
   UpsertWorkerProfileInputSchema,
   WaitForAnyRunInputSchema,
   WaitForRunInputSchema,
+  WorkerPostureSchema,
   wrapErr,
   wrapOk,
   type Backend,
@@ -50,6 +51,7 @@ import {
   type ToolResponse,
   type UpsertWorkerProfile,
   type WorkerEvent,
+  type WorkerPosture,
   type WorkerResult,
 } from './contract.js';
 import { errorFromEvent } from './backend/common.js';
@@ -147,6 +149,10 @@ interface ResolvedStartRunTarget {
   reasoningEffort: ReasoningEffort | undefined;
   serviceTier: ServiceTier | undefined;
   codexNetwork: CodexNetwork | undefined;
+  // Issue #58: resolved worker posture from profile or direct-mode input.
+  // `undefined` means "not specified"; `modelSettingsForBackend` normalizes
+  // to the concrete `'trusted'` default before persistence.
+  workerPosture: WorkerPosture | undefined;
   metadata: Record<string, unknown>;
   profileId: string | null;
   accountSpawn?: AccountSpawnContribution;
@@ -350,14 +356,14 @@ export class OrchestratorService {
     const input = parsed.data;
     const resolved = await this.resolveStartRunTarget(input);
     if (!resolved.ok) return wrapErr(resolved.error);
-    const { backendName, runtime, model, reasoningEffort, serviceTier, codexNetwork, metadata: resolvedMetadata, profileId } = resolved.value;
+    const { backendName, runtime, model, reasoningEffort, serviceTier, codexNetwork, workerPosture, metadata: resolvedMetadata, profileId } = resolved.value;
     const metadata = stampOrchestratorIdInMetadata(resolvedMetadata, context.policy_context);
     const accountSpawn = resolved.value.accountSpawn;
     const idleTimeout = this.resolveIdleTimeout(input.idle_timeout_seconds);
     if (!idleTimeout.ok) return wrapErr(idleTimeout.error);
     const executionTimeout = this.resolveExecutionTimeout(input.execution_timeout_seconds);
     if (!executionTimeout.ok) return wrapErr(executionTimeout.error);
-    const settings = modelSettingsForBackend(backendName, model, reasoningEffort, serviceTier, codexNetwork);
+    const settings = modelSettingsForBackend(backendName, model, reasoningEffort, serviceTier, codexNetwork, workerPosture);
     if (!settings.ok) return wrapErr(settings.error);
 
     const meta = await this.store.createRun({
@@ -373,26 +379,38 @@ export class OrchestratorService {
       execution_timeout_seconds: executionTimeout.value,
     });
     await this.captureAndPersistGitSnapshot(meta.run_id, input.cwd);
-    await this.maybeEmitCodexNetworkDefaultWarning(meta.run_id, backendName, codexNetwork, profileId);
+    await this.maybeEmitCodexNetworkDefaultWarning(meta.run_id, backendName, codexNetwork, profileId, settings.value.worker_posture ?? 'trusted');
 
     await this.startManagedRun(meta.run_id, runtime, input.prompt, input.cwd, idleTimeout.value, executionTimeout.value, settings.value, model, undefined, accountSpawn);
     return wrapOk({ run_id: meta.run_id });
   }
 
   // C12 / T11: emit a single non-blocking lifecycle warning event when a codex
-  // run resolved its codex_network from the OD1=B default ('isolated') because
-  // neither the profile nor the direct-mode argument set it explicitly. The
-  // warning never blocks the run; it surfaces in the run's event log alongside
-  // failing tool calls so users hitting the breaking change can correlate.
+  // run resolved its codex_network from the issue #31 OD1=B default
+  // ('isolated', --ignore-user-config, no network) because neither the
+  // profile nor the direct-mode argument set it explicitly. The warning
+  // surfaces in the run's event log alongside failing tool calls so users
+  // hitting the breaking change can correlate.
+  //
+  // Issue #58 review follow-up (Medium 1): suppress the warning under
+  // `worker_posture: 'trusted'`. The trusted-default behavior (workspace-write
+  // sandbox + network on) is the intended product direction, not a surprise
+  // breaking change; there is also no explicit `codex_network` enum value
+  // an operator could set to preserve the same argv (null is the trusted
+  // default, distinct from 'isolated' / 'workspace' / 'user-config'). Only
+  // restricted+absent keeps emitting the warning, since restricted preserves
+  // the issue #31 closed-by-default isolated behavior.
   private async maybeEmitCodexNetworkDefaultWarning(
     runId: string,
     backendName: Backend,
     explicitCodexNetwork: CodexNetwork | undefined,
     profileId: string | null,
+    workerPosture: WorkerPosture,
   ): Promise<void> {
     if (backendName !== 'codex' || explicitCodexNetwork !== undefined) return;
+    if (workerPosture !== 'restricted') return;
     const profilePart = profileId ? `profile ${profileId}` : 'direct-mode run';
-    const message = `agent-orchestrator codex_network not set on ${profilePart}; defaulting to 'isolated' (no network access). Set codex_network explicitly to silence this warning. See docs/development/codex-backend.md for migration.`;
+    const message = `agent-orchestrator codex_network not set on ${profilePart} (worker_posture=restricted); defaulting to 'isolated' (no network access, --ignore-user-config). Set codex_network explicitly to silence this warning, or move the profile to worker_posture: 'trusted' to opt into backend-native parity. See docs/development/codex-backend.md for migration.`;
     try {
       await this.store.appendEvent(runId, {
         type: 'lifecycle',
@@ -400,6 +418,7 @@ export class OrchestratorService {
           state: 'codex_network_defaulted',
           warning: message,
           profile: profileId,
+          worker_posture: workerPosture,
           resolved_codex_network: 'isolated',
           migration_doc: 'docs/development/codex-backend.md',
           issue: 31,
@@ -434,6 +453,7 @@ export class OrchestratorService {
           reasoningEffort: input.reasoning_effort,
           serviceTier: input.service_tier,
           codexNetwork: input.codex_network,
+          workerPosture: input.worker_posture,
           metadata,
           profileId: null,
           accountSpawn: claudeBinding.binding?.accountSpawn,
@@ -518,6 +538,7 @@ export class OrchestratorService {
         reasoningEffort: profileSettings.reasoningEffort,
         serviceTier: profileSettings.serviceTier,
         codexNetwork: profileSettings.codexNetwork,
+        workerPosture: profileSettings.workerPosture,
         metadata: applyClaudeBindingToMetadata(baseMetadata, claudeBinding.binding),
         profileId: profile.id,
         accountSpawn: claudeBinding.binding?.accountSpawn,
@@ -759,6 +780,13 @@ export class OrchestratorService {
     if (parsed.data.codex_network !== undefined && backendName !== 'codex') {
       return wrapErr(orchestratorError('INVALID_INPUT', `codex_network is only supported on the codex backend; got backend ${backendName}`));
     }
+    // Issue #58: worker_posture override mirrors the codex_network rule —
+    // profile-mode chains reject direct overrides so the profile manifest
+    // stays authoritative for the chain. Direct-mode chains accept the
+    // override and persist the new value on the child run record.
+    if (parsed.data.worker_posture !== undefined && chainOriginIsProfileMode) {
+      return wrapErr(orchestratorError('INVALID_INPUT', 'Profile-mode follow-ups cannot override worker_posture; edit the profile or run a direct-mode follow-up instead'));
+    }
     // Rotation eligibility check (D7 / D8). The decision carries a
     // `releaseLock` callback when rotation succeeded — must be called after
     // the new child's meta.json is durably written.
@@ -799,26 +827,45 @@ export class OrchestratorService {
     const inheritedCodexNetwork = parsed.data.codex_network !== undefined
       ? parsed.data.codex_network
       : (parent.meta.model_settings.codex_network ?? undefined);
+    // Issue #58: inherit worker_posture from parent unless the follow-up
+    // overrides it. Legacy parents (pre-#58) have `null`; that gets
+    // normalized to 'trusted' on the child write below.
+    const inheritedWorkerPosture: WorkerPosture | undefined = parsed.data.worker_posture !== undefined
+      ? parsed.data.worker_posture
+      : (parent.meta.model_settings.worker_posture ?? undefined);
     const settings = hasModelSettingsInput(parsed.data)
-      ? modelSettingsForBackend(backendName, model, parsed.data.reasoning_effort, parsed.data.service_tier, inheritedCodexNetwork)
+      ? modelSettingsForBackend(backendName, model, parsed.data.reasoning_effort, parsed.data.service_tier, inheritedCodexNetwork, inheritedWorkerPosture)
       : parsed.data.codex_network !== undefined
-        ? patchCodexNetwork(parent.meta.model_settings, parsed.data.codex_network)
-        : parsed.data.model || backendName === 'cursor'
-          ? validateInheritedModelSettingsForBackend(backendName, model, parent.meta.model_settings)
-          : { ok: true as const, value: parent.meta.model_settings };
+        ? patchCodexNetwork(parent.meta.model_settings, parsed.data.codex_network, inheritedWorkerPosture)
+        : parsed.data.worker_posture !== undefined
+          ? { ok: true as const, value: { ...parent.meta.model_settings, worker_posture: parsed.data.worker_posture } }
+          : parsed.data.model || backendName === 'cursor'
+            ? validateInheritedModelSettingsForBackend(backendName, model, parent.meta.model_settings)
+            : { ok: true as const, value: parent.meta.model_settings };
     if (!settings.ok) {
       releaseLock?.();
       return wrapErr(settings.error);
     }
     // B2 (issue #31): normalize legacy parent records before persisting the
     // child. A legacy codex parent has model_settings.codex_network === null;
-    // sandboxArgs() defensively treats that as 'isolated', but the child run
-    // record must reflect the *effective* posture (plan invariant: "effective
-    // codex_network lands in run_summary.model_settings"). Only normalize for
-    // the codex backend; non-codex follow-ups must keep codex_network: null.
-    const persistedSettings = backendName === 'codex' && settings.value.codex_network === null
+    // sandboxArgs() defensively treats that as 'isolated' under restricted,
+    // and the child run record must reflect the *effective* posture under
+    // restricted (plan invariant: "effective codex_network lands in
+    // run_summary.model_settings"). Only normalize for the codex backend;
+    // non-codex follow-ups must keep codex_network: null.
+    //
+    // Issue #58: same pattern for worker_posture (every backend), with one
+    // refinement for codex — the legacy-null → 'isolated' normalization is
+    // restricted-only. Under trusted, codex_network=null is the *effective*
+    // value (it means "trusted-default sandbox": workspace-write + network on)
+    // and must persist as null so re-runs spawn with the trusted-default argv.
+    const childPosture: WorkerPosture = settings.value.worker_posture ?? 'trusted';
+    const codexNormalized = backendName === 'codex' && settings.value.codex_network === null && childPosture === 'restricted'
       ? { ...settings.value, codex_network: 'isolated' as CodexNetwork, mode: 'normal' as const }
       : settings.value;
+    const persistedSettings: RunModelSettings = codexNormalized.worker_posture === null
+      ? { ...codexNormalized, worker_posture: 'trusted' as WorkerPosture }
+      : codexNormalized;
 
     let accountSpawn: AccountSpawnContribution | undefined;
     let metadata: Record<string, unknown> = baseMetadata;
@@ -2083,6 +2130,7 @@ function workerProfileFromUpsert(input: UpsertWorkerProfile): WorkerProfile {
   if (input.reasoning_effort !== undefined) profile.reasoning_effort = input.reasoning_effort;
   if (input.service_tier !== undefined) profile.service_tier = input.service_tier;
   if (input.codex_network !== undefined) profile.codex_network = input.codex_network;
+  if (input.worker_posture !== undefined) profile.worker_posture = input.worker_posture;
   if (input.description !== undefined) profile.description = input.description;
   if (input.metadata !== undefined) profile.metadata = input.metadata;
   if (input.claude_account !== undefined) profile.claude_account = input.claude_account;
@@ -2100,6 +2148,7 @@ function formatValidProfile(profile: ValidatedWorkerProfile): Record<string, unk
     reasoning_effort: profile.reasoning_effort ?? null,
     service_tier: profile.service_tier ?? null,
     codex_network: profile.codex_network ?? null,
+    worker_posture: profile.worker_posture ?? null,
     description: profile.description ?? null,
     metadata: profile.metadata ?? {},
     claude_account: profile.claude_account ?? null,
@@ -2128,15 +2177,18 @@ function hasModelSettingsInput(input: { reasoning_effort?: ReasoningEffort; serv
   return input.reasoning_effort !== undefined || input.service_tier !== undefined;
 }
 
-function patchCodexNetwork(settings: RunModelSettings, codexNetwork: CodexNetwork): { ok: true; value: RunModelSettings } {
+function patchCodexNetwork(settings: RunModelSettings, codexNetwork: CodexNetwork, workerPosture: WorkerPosture | undefined): { ok: true; value: RunModelSettings } {
   // Preserve reasoning_effort/service_tier from the parent; only patch
-  // codex_network (and re-derive the mode breadcrumb).
+  // codex_network (and re-derive the mode breadcrumb). Issue #58: a
+  // follow-up may also override worker_posture; preserve the inherited
+  // value when the follow-up did not.
   return {
     ok: true,
     value: {
       ...settings,
       mode: codexNetwork === 'isolated' ? 'normal' : null,
       codex_network: codexNetwork,
+      worker_posture: workerPosture ?? settings.worker_posture ?? null,
     },
   };
 }
@@ -2150,7 +2202,7 @@ function isProfileModeMetadata(metadata: Record<string, unknown>): boolean {
 function parseProfileModelSettings(
   profile: ValidatedWorkerProfile,
   profilesFile: string,
-): { ok: true; reasoningEffort: ReasoningEffort | undefined; serviceTier: ServiceTier | undefined; codexNetwork: CodexNetwork | undefined } | { ok: false; error: OrchestratorError } {
+): { ok: true; reasoningEffort: ReasoningEffort | undefined; serviceTier: ServiceTier | undefined; codexNetwork: CodexNetwork | undefined; workerPosture: WorkerPosture | undefined } | { ok: false; error: OrchestratorError } {
   const reasoningEffort = profile.reasoning_effort
     ? ReasoningEffortSchema.safeParse(profile.reasoning_effort)
     : null;
@@ -2190,11 +2242,28 @@ function parseProfileModelSettings(
     };
   }
 
+  // Issue #58: profile manifests store worker_posture as a plain string
+  // (`WorkerProfileSchema`); validate against the orchestrator's typed enum
+  // here so invalid values fail at start-run time with a clear error.
+  const workerPosture = profile.worker_posture
+    ? WorkerPostureSchema.safeParse(profile.worker_posture)
+    : null;
+  if (workerPosture && !workerPosture.success) {
+    return {
+      ok: false,
+      error: orchestratorError('INVALID_INPUT', `Profile ${profile.id} has invalid worker_posture ${profile.worker_posture} (must be 'trusted' or 'restricted')`, {
+        profile: profile.id,
+        profiles_file: profilesFile,
+      }),
+    };
+  }
+
   return {
     ok: true,
     reasoningEffort: reasoningEffort?.data,
     serviceTier: serviceTier?.data,
     codexNetwork: codexNetwork?.data,
+    workerPosture: workerPosture?.data,
   };
 }
 
@@ -2300,23 +2369,32 @@ function modelSettingsForBackend(
   reasoningEffort: ReasoningEffort | undefined,
   serviceTier: ServiceTier | undefined,
   codexNetwork: CodexNetwork | undefined,
+  workerPosture: WorkerPosture | undefined,
 ): { ok: true; value: RunModelSettings } | { ok: false; error: OrchestratorError } {
+  // Issue #58: resolved posture lands on every run record. Default to
+  // 'trusted' when the caller did not specify one, so new runs always carry
+  // a concrete value (legacy null only persists for pre-#58 run records).
+  const resolvedWorkerPosture: WorkerPosture = workerPosture ?? 'trusted';
   if (backend === 'codex') {
     if (reasoningEffort === 'max') {
       return { ok: false, error: orchestratorError('INVALID_INPUT', 'Codex reasoning_effort must be one of none, minimal, low, medium, high, or xhigh') };
     }
-    // Per OD1 = B (issue #31, locked 2026-05-05): the codex backend's network
-    // posture is now driven exclusively by codex_network. service_tier no
-    // longer derives mode='normal' (and therefore no longer derives
-    // --ignore-user-config). When codex_network is unset we default to
-    // 'isolated', matching the locked OD1 = B uniform default. The internal
-    // `mode` field is retained as a derived breadcrumb (now derived from
-    // codex_network rather than service_tier) so observability and
-    // run-record back-compat keep working. service_tier='normal' continues
-    // to be suppressed in serialization because codex's CLI default is
-    // 'normal'; explicit re-emission of the default would add no behavior
-    // and would churn the codex argv shape.
-    const resolvedCodexNetwork: CodexNetwork = codexNetwork ?? 'isolated';
+    // Issue #58 review follow-up (High): codex_network defaulting is now
+    // posture-aware. The trusted-default argv (sandbox_mode="workspace-write"
+    // + network_access=true) is distinct from explicit codex_network='isolated'
+    // (no flags) and from explicit codex_network='workspace' (only
+    // network_access=true). To preserve those three argv cells distinctly,
+    // trusted+absent must leave codex_network null on the run record so
+    // `sandboxArgs()` can emit the trusted-default flags. Restricted keeps the
+    // issue #31 OD1=B uniform default of 'isolated' on absent so the v1
+    // contract continues to hold for opt-in callers.
+    //
+    // The internal `mode` field stays as a derived breadcrumb: 'normal' only
+    // when the resolved codex_network is 'isolated', otherwise null.
+    // service_tier='normal' continues to be suppressed in serialization
+    // because codex's CLI default is 'normal'.
+    const resolvedCodexNetwork: CodexNetwork | null = codexNetwork
+      ?? (resolvedWorkerPosture === 'restricted' ? 'isolated' : null);
     return {
       ok: true,
       value: {
@@ -2324,6 +2402,7 @@ function modelSettingsForBackend(
         service_tier: serviceTier && serviceTier !== 'normal' ? serviceTier : null,
         mode: resolvedCodexNetwork === 'isolated' ? 'normal' : null,
         codex_network: resolvedCodexNetwork,
+        worker_posture: resolvedWorkerPosture,
       },
     };
   }
@@ -2349,6 +2428,7 @@ function modelSettingsForBackend(
         service_tier: null,
         mode: null,
         codex_network: null,
+        worker_posture: resolvedWorkerPosture,
       },
     };
   }
@@ -2365,6 +2445,7 @@ function modelSettingsForBackend(
       service_tier: null,
       mode: null,
       codex_network: null,
+      worker_posture: resolvedWorkerPosture,
     },
   };
 }

--- a/src/processManager.ts
+++ b/src/processManager.ts
@@ -237,6 +237,17 @@ export class ProcessManager {
       return this.store.appendEvent(runId, event);
     };
 
+    // Issue #58: flush backend-supplied initial lifecycle events (e.g. the
+    // `worker_posture` event from Claude and Codex backends) BEFORE the
+    // `status: started` marker so operators see them at the head of the run
+    // event stream. Routed through `appendEventBuffered` so the D-COR-Resume
+    // interceptor still buffers them on a retry-eligible attempt.
+    if (invocation.initialEvents && invocation.initialEvents.length > 0) {
+      for (const initialEvent of invocation.initialEvents) {
+        trackPersistence(appendEventBuffered(initialEvent));
+      }
+    }
+
     trackPersistence(appendEventBuffered({
       type: 'lifecycle',
       payload: { status: 'started', pid: workerPid, pgid: workerPgid },

--- a/src/processManager.ts
+++ b/src/processManager.ts
@@ -240,18 +240,27 @@ export class ProcessManager {
     // Issue #58: flush backend-supplied initial lifecycle events (e.g. the
     // `worker_posture` event from Claude and Codex backends) BEFORE the
     // `status: started` marker so operators see them at the head of the run
-    // event stream. Routed through `appendEventBuffered` so the D-COR-Resume
-    // interceptor still buffers them on a retry-eligible attempt.
+    // event stream. The chain is required because in the non-buffered path
+    // (interceptor disengaged) `appendEventBuffered` returns
+    // `store.appendEvent`, which serializes through a filesystem run lock
+    // with EEXIST retry — two parallel appends race for the lock and
+    // ordering at the call site does not survive. Routed through
+    // `appendEventBuffered` so the D-COR-Resume interceptor still buffers
+    // them on a retry-eligible attempt.
+    let orderedInitialFlush: Promise<unknown> = Promise.resolve();
     if (invocation.initialEvents && invocation.initialEvents.length > 0) {
       for (const initialEvent of invocation.initialEvents) {
-        trackPersistence(appendEventBuffered(initialEvent));
+        orderedInitialFlush = orderedInitialFlush.then(() => appendEventBuffered(initialEvent));
       }
     }
-
-    trackPersistence(appendEventBuffered({
-      type: 'lifecycle',
-      payload: { status: 'started', pid: workerPid, pgid: workerPgid },
-    }));
+    trackPersistence(
+      orderedInitialFlush.then(() =>
+        appendEventBuffered({
+          type: 'lifecycle',
+          payload: { status: 'started', pid: workerPid, pgid: workerPgid },
+        }),
+      ),
+    );
     lastPersistedActivityMs = lastActivityMs;
 
     child.stdin.end(invocation.stdinPayload);

--- a/src/runStore.ts
+++ b/src/runStore.ts
@@ -176,6 +176,7 @@ export class RunStore {
         service_tier: null,
         mode: null,
         codex_network: null,
+        worker_posture: null,
       },
       requested_session_id: input.requested_session_id ?? null,
       observed_session_id: input.observed_session_id ?? null,


### PR DESCRIPTION
## Summary

- Introduce `worker_posture: 'trusted' | 'restricted'` on `WorkerProfile`, direct-mode `start_run` / `send_followup`, and persisted `RunModelSettings`. Default `'trusted'`; the Claude supervisor envelope is hard-restricted and ignores the field.
- Per-backend mapping under `trusted`:
  - **Claude**: `--setting-sources user,project,local` plus per-run `enableAllProjectMcpServers: true`. `disableAllHooks: true` and CLI `--permission-mode bypassPermissions` still pinned by precedence, so project hooks/permissions cannot break worker safety contracts (T5/T13/#47).
  - **Codex**: drops `--ignore-user-config`; sandbox/network argv driven by `-c sandbox_mode` and `-c sandbox_workspace_write.network_access` overrides (both resume-safe on `codex exec resume`). No `--sandbox`/`--cd` in the shared helper.
  - **Cursor**: SDK shim forwards `local.settingSources: ['all']` to `Agent.create` / `Agent.resume` for full ambient parity.
- Posture inheritance + persistence: `send_followup` inherits `parent.meta.model_settings.worker_posture`; `profile + worker_posture` rejected schema-side (`start_run`) and runtime-side (`send_followup`) the same way `codex_network` is.
- Spawn-time `worker_posture` lifecycle event per worker run: CLI backends emit via new `WorkerInvocation.initialEvents` flushed by `ProcessManager.start()`; Cursor uses `store.appendEvent()` after `agent.send()` succeeds. Pre-spawn failures emit no event.
- Codex defaulted-warning is now posture-aware: under `restricted+absent` the existing `codex_network_defaulted` lifecycle fires (with updated copy mentioning the trusted opt-in); under `trusted+absent` the warning is suppressed because the trusted-default sandbox is the intended product behavior.
- `list_worker_profiles` validates `worker_posture` at inspection time so hand-edited typos surface as `invalid_profiles` diagnostics before `start_run`.
- Docs updated: new "Workers And Project MCP Servers" + "Trust Boundary" sections in `docs/development/mcp-tooling.md`; trusted/restricted argv tables and migration narrative in `docs/development/codex-backend.md`; two-axis table in `docs/reference.md`; `worker_posture` in `cursor-backend.md`; `README.md` + `docs/first-run.md` first-run examples pin `worker_posture: 'restricted'` when demonstrating the closed-network envelope.
- New rules: `.agents/rules/worker-posture.md` and `.agents/rules/worker-safety.md` (projected to `.claude/rules/` and `.cursor/rules/`).

## Verification

- [x] `pnpm build`
- [x] Targeted tests: `claudeWorkerIsolation.test.ts` (restricted + trusted + telemetry + hostile project fixture), `backendInvocation.test.ts` (codex posture × `codex_network` matrix incl. resume-safety guard), `cursorRuntime.test.ts` (trusted/restricted `settingSources`, pre-spawn failure, send-failure regression, resume parity), `processManager.test.ts` (initialEvents flush + retry-pre-bake), `claudeResumeInterceptor.test.ts` (retry path emits exactly one posture event), `integration/orchestrator.test.ts` (direct + profile trusted Codex argv; trusted+absent suppresses warning; restricted+absent still warns), `claudeAccountContract.test.ts` (invalid `worker_posture` surfaced as invalid_profiles).
- [x] `pnpm verify` — tests 584 / pass 582 / fail 0 / skipped 2; publish-ready; no audit vulnerabilities; `npm pack --dry-run` produces `ralphkrauss-agent-orchestrator-0.2.2.tgz`.

## Checklist

- [x] The change is scoped to the described behavior or setup work.
- [x] Public behavior, MCP contracts, and CLI output are documented when changed.
- [x] Tests cover daemon lifecycle, run-store persistence, backend invocation, MCP contracts, or release behavior when those areas are touched.
- [x] No secrets, local credentials, private tokens, or `.env` contents are included.
- [x] Package, publishing, or external-service behavior is unchanged unless explicitly intended.

Closes #58.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced worker_posture (trusted | restricted) to control worker access to project MCP servers, settings sources, and Codex sandbox/network behavior.
  * Worker spawn emits a lifecycle event reporting the resolved posture and effective settings for better observability.

* **Documentation**
  * Expanded quickstart, backend, and reference docs with posture × codex_network semantics, migration guidance, and trust-boundary notes.
  * Added Worker Safety Contracts describing mandatory per-run invariants.

* **Tests**
  * Broad test coverage for posture behavior, isolation, telemetry, resume/retry, and follow-up validation.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ralphkrauss/agent-orchestrator/pull/60)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->