### PR TITLE
feat(56): configurable supervisor system prompt (append-only)

### DIFF
--- a/docs/development/mcp-tooling.md
+++ b/docs/development/mcp-tooling.md
@@ -184,6 +184,71 @@ agent-orchestrator claude --print-discovery
 agent-orchestrator claude --print-config --cwd /path/to/workspace
 ```
 
+#### Customizing the Claude supervisor system prompt (append-only)
+
+`agent-orchestrator claude` accepts user-supplied text that is *appended* to
+the supervisor system prompt after the harness-owned isolation contract. The
+harness allowlist (`--tools`, `--allowed-tools`, `--permission-mode dontAsk`)
+is the authoritative tool gate regardless of any user prompt text; appended
+text cannot loosen the wire-level tool surface.
+
+Three surfaces in precedence order (top wins):
+
+1. `--no-append-system-prompt` — explicit escape hatch that forces
+   `source = none` and suppresses every other source for this launch
+   (including the env vars and the convention file).
+2. `--append-system-prompt <text>` — inline CLI text (`source = cli-inline`).
+3. `--append-system-prompt-file <path>` — path resolved against the resolved
+   target cwd (`source = cli-file`).
+4. `AGENT_ORCHESTRATOR_CLAUDE_APPEND_SYSTEM_PROMPT` — env-var inline text
+   (`source = env-inline`).
+5. `AGENT_ORCHESTRATOR_CLAUDE_APPEND_SYSTEM_PROMPT_FILE` — env-var path,
+   resolved against the resolved target cwd (`source = env-file`).
+6. `<target-cwd>/.agents/orchestrator/system-prompt.md` — auto-loaded
+   convention file, opt-in by presence (`source = convention-file`).
+
+Combining `--append-system-prompt` and `--append-system-prompt-file` is a
+parse error; the two env vars together are the same parse error.
+`--no-append-system-prompt` overrides those conflict checks — the escape
+hatch always wins and produces `source = none`, suppressing CLI, env, and
+convention sources without inspecting the disk. An empty
+`AGENT_ORCHESTRATOR_CLAUDE_APPEND_SYSTEM_PROMPT` or
+`AGENT_ORCHESTRATOR_CLAUDE_APPEND_SYSTEM_PROMPT_FILE` value is treated as
+unset and falls through to the next precedence step; use
+`--no-append-system-prompt` for explicit suppression. When a
+higher-precedence source preempts a present convention file, the launcher
+writes a single-line stderr notice naming the skipped path. Only the
+**winning** file source is read from disk; preempted lower-precedence file
+sources (CLI, env, convention) are never opened, so a missing or oversize
+lower-precedence file does not block a higher-precedence source. A convention
+file that is a symlink, directory, or other non-regular file is refused
+(`lstat` guard) with a similar notice and treated as absent; CLI- and
+env-named paths are read as-is so legitimate dotfile symlink setups keep
+working.
+
+The resolved user text is concatenated after the harness prompt with the
+literal delimiter `\n\n---\n# User-supplied supervisor prompt\n\n` into the
+single envelope `system-prompt.md`. The Claude spawn args remain
+`--append-system-prompt-file <envelope-file>` exactly; there is no second
+instance and no new Claude flag surface. Behavior:
+
+- Content is read as bytes. The 64 KB cap is byte-based and applies after a
+  leading UTF-8 BOM is stripped (the boundary is `65 536` accepted /
+  `65 537` rejected).
+- Trailing whitespace is trimmed; CRLF inside the body is preserved; leading
+  Markdown (headings, lists) is preserved.
+- A missing CLI- or env-named file fails the launch with a typed error
+  pointing at the source tag and path. A missing convention file is silent.
+- `--append-system-prompt` and `--append-system-prompt-file` *after* the
+  `--` separator are rejected by the passthrough validator because the
+  harness owns Claude's append-system-prompt flag. Use the launcher flag
+  before `--` (or the env var) instead.
+- `agent-orchestrator claude --print-config` always renders
+  `# user system prompt source <tag>` and adds a `# user system prompt path`
+  line for file sources plus a `# user system prompt (append)` section when
+  the resolved text is non-empty. An empty/whitespace-only source renders
+  as `<tag> (empty)`.
+
 ### Notification-aware run supervision
 
 Both harnesses share daemon-owned, backend-agnostic notification primitives:

--- a/plans/56-make-system-prompt-configurable/plan.md
+++ b/plans/56-make-system-prompt-configurable/plan.md
@@ -1,0 +1,10 @@
+# Plan Index
+
+Branch: `56-make-system-prompt-configurable`
+Updated: 2026-05-12
+
+## Sub-Plans
+
+| Plan | Scope | Status | File |
+|---|---|---|---|
+| Configurable Claude supervisor system prompt (append-only) | Allow users to add their own text to the Claude supervisor system prompt without touching the harness-owned isolation contract. Exposes a CLI flag pair (`--append-system-prompt` / `--append-system-prompt-file`) on `agent-orchestrator claude`, env-var fallbacks (`AGENT_ORCHESTRATOR_CLAUDE_APPEND_SYSTEM_PROMPT` / `..._FILE`), and an auto-loaded convention file at `<targetCwd>/.agents/orchestrator/system-prompt.md`. A discriminated `AppendSource` (`cli-inline` \| `cli-file` \| `env-inline` \| `env-file` \| `convention-file` \| `none`) drives precedence: CLI wins over env, env over convention, with a single-line stderr notice when a present convention file is suppressed by a higher-precedence source. `--no-append-system-prompt` is an explicit escape hatch that forces `none` and suppresses all sources. The resolved user text is concatenated after the existing harness prompt into the single envelope `system-prompt.md`; spawn args stay exactly `--append-system-prompt-file <envelope-file>` (no new Claude flag surface, no second instance). `--print-config` always emits `# user system prompt source` (with the `none` sentinel) and the `# user system prompt (append)` section when non-empty. Worker run prompts and full-prompt replacement are explicitly out of scope. | planning | [plans/56-configurable-supervisor-system-prompt.md](plans/56-configurable-supervisor-system-prompt.md) |

--- a/plans/56-make-system-prompt-configurable/plans/56-configurable-supervisor-system-prompt.md
+++ b/plans/56-make-system-prompt-configurable/plans/56-configurable-supervisor-system-prompt.md
@@ -205,46 +205,46 @@ none
 ## Execution Log
 
 ### T1: Extend parser
-- **Status:** pending
-- **Evidence:** pending
-- **Notes:** pending
+- **Status:** completed
+- **Evidence:** `src/claude/launcher.ts` — added `AppendSystemPromptCandidates` and `disableAppendSystemPrompt` fields on `ParsedClaudeLauncherArgs`; parser handles `--append-system-prompt`, `--append-system-prompt-file`, `--no-append-system-prompt`, plus env vars `AGENT_ORCHESTRATOR_CLAUDE_APPEND_SYSTEM_PROMPT[_FILE]`. CLI inline + CLI file conflict and env inline + env file conflict return precise symmetric errors **only when `--no-append-system-prompt` is not set** — the escape hatch (Decision 9) bypasses both conflict checks. File paths resolve against the resolved target cwd.
+- **Notes:** Per code-review revision: `--no-append-system-prompt` is the escape hatch and unconditionally produces `source = 'none'` even when both CLI flags or both env vars are set; per Decision 9 the combination is intentionally NOT an error. Empty `AGENT_ORCHESTRATOR_CLAUDE_APPEND_SYSTEM_PROMPT[_FILE]` env values are treated as **unset** (fall through to the next precedence step) — explicit suppression uses `--no-append-system-prompt`.
 
 ### T2: Resolver helper
-- **Status:** pending
-- **Evidence:** pending
-- **Notes:** pending
+- **Status:** completed
+- **Evidence:** `src/claude/appendPrompt.ts` — new file. Pure `resolveSupervisorAppendPrompt()`, the `AppendSource` discriminator, `LoadedAppendContent`, `AppendPromptError`, `SUPERVISOR_APPEND_PROMPT_BYTE_CAP = 64 * 1024`, `SUPERVISOR_APPEND_PROMPT_DELIMITER`, and `CONVENTION_APPEND_PROMPT_RELATIVE_PATH = '.agents/orchestrator/system-prompt.md'`. Decoder strips a leading UTF-8 BOM, applies `trimEnd`, preserves CRLF, returns `text: null` when the result is empty/whitespace-only.
+- **Notes:** Oversize check is byte-based, applied after BOM strip but before trim. Boundary: 65 536 accepted, 65 537 rejected.
 
 ### T3: Plumb into config
-- **Status:** pending
-- **Evidence:** pending
-- **Notes:** pending
+- **Status:** completed
+- **Evidence:** `src/claude/config.ts` — `ClaudeHarnessConfigInput.userAppendSystemPrompt?` added (optional). `ClaudeHarnessConfig` gains `userSystemPromptSource`, `userSystemPromptPath`, `userSystemPromptAppend`. Existing `appendSystemPrompt?: string` is unchanged. `buildSupervisorSystemPrompt` appends the literal delimiter `\n\n---\n# User-supplied supervisor prompt\n\n` plus user text only when the user text is a non-empty string. When absent/empty the full prompt is byte-identical to today's output (asserted by `produces a byte-identical baseline when text is null or absent`).
+- **Notes:** none
 
 ### T4: Loader + envelope builder wiring
-- **Status:** pending
-- **Evidence:** pending
-- **Notes:** pending
+- **Status:** completed
+- **Evidence:** `src/claude/appendPrompt.ts` — `probeConventionAppendPromptFile()` runs only the lstat regular-file guard for the convention path (returns `regular | absent | skipped-non-regular | error`, no file body read). `readAppendPromptFile()` reads bytes and returns typed `missing-file` / `read-failed` errors. `loadAppendPromptSource()` is retained as a thin back-compat composition. `src/claude/launcher.ts` — `resolveAppendSystemPromptForEnvelope()` now (1) short-circuits on `--no-append-system-prompt` with zero disk I/O, (2) always lstat-probes the convention path, (3) computes the winning source from inputs alone via `selectAppendWinnerFromInputs()`, and (4) reads only the body of the winning file source. Preempted lower-precedence file sources (missing, oversize, unreadable) are never opened, so they cannot block a higher-precedence source. `BuiltClaudeEnvelope` gains `userSystemPromptSource`, `userSystemPromptPath`, `userSystemPromptAppend`, and the single `conventionSkipNotice` channel (covers both the precedence-skip and the lstat non-regular-file skip). Spawn args list is unchanged — still one `--append-system-prompt-file <envelope-file>`.
+- **Notes:** Per code-review revision: precedence is applied **before** any body read. CLI/env-named symlinks remain read as-is; the lstat guard is convention-only. Empty env-var values are filtered at the parser layer, so the resolver only sees genuine "set" / "unset" states.
 
 ### T5: --print-config + help + stderr notice
-- **Status:** pending
-- **Evidence:** pending
-- **Notes:** pending
+- **Status:** completed
+- **Evidence:** `src/claude/launcher.ts` — `runClaudeLauncher` writes `built.conventionSkipNotice` to `io.stderr` (with a trailing newline) exactly once if non-null, both for precedence-skip and lstat-skip. `--print-config` now emits `# user system prompt source <tag>` always (with the `none` sentinel and `(empty)` annotation when applicable), `# user system prompt path <path>` for file sources, and `# user system prompt (append) <text>` above `# settings.json` when the resolved text is non-empty (via `formatUserSystemPromptSections`). Help text documents the three flags, both env vars, the convention path, the precedence rule, the 64 KB cap, and the reminder that `--append-system-prompt[-file]` after `--` is forbidden.
+- **Notes:** `runClaudeLauncher` also catches `buildClaudeEnvelope` errors (oversize/missing-file/read-failed) and writes the typed message to `io.stderr` with exit code 1.
 
 ### T6: Passthrough help alignment
-- **Status:** pending
-- **Evidence:** pending
-- **Notes:** pending
+- **Status:** completed
+- **Evidence:** `src/claude/passthrough.ts` — rejection message for `--append-system-prompt(-file)` after `--` now names the launcher flag and the env var, e.g. `Use the launcher flag \`agent-orchestrator claude --append-system-prompt ...\` (before --) or the AGENT_ORCHESTRATOR_CLAUDE_APPEND_SYSTEM_PROMPT[_FILE] env var instead.` No allowlist/denylist semantics change.
+- **Notes:** none
 
 ### T7: Tests
-- **Status:** pending
-- **Evidence:** pending
-- **Notes:** pending
+- **Status:** completed
+- **Evidence:** `src/__tests__/claudeAppendPrompt.test.ts` — 48 tests covering: parser acceptance + exact-string conflict messages, parser path resolution against the resolved target cwd (test "resolves --append-system-prompt-file and env-file paths against the resolved target cwd, not defaultCwd/process.cwd"), empty-env-var-is-unset, `--no-append-system-prompt` overriding both conflicts; resolver precedence + decoding; byte-cap boundary with exact error string; multibyte UTF-8 byte-boundary test (final codepoint `…` = 3 bytes); BOM/trim/CRLF; `buildSupervisorSystemPrompt` baseline byte-equality + append-present; envelope writes one concatenated `system-prompt.md` and spawn args remain exactly one `--append-system-prompt-file`; hooks/`settings.json` byte equality with vs without append; convention load + silent absent; precedence-skip stderr fires exactly once via `runClaudeLauncher`; missing CLI/env file failures; oversize CLI file failure; `(empty)` annotation; `none` sentinel; symlink/directory convention skip with lstat notice; CLI-named and env-named symlinks read as-is (lstat guard is convention-only); higher-precedence wins despite missing/oversize/unreadable lower-precedence file (three new tests); `--no-append-system-prompt` suppression of each of CLI inline, CLI file, env inline, env file, convention file plus both conflict combinations (seven new tests). Existing `src/__tests__/claudeHarness.test.ts` (35 tests) continues to pass unchanged.
+- **Notes:** Test file written as a new sibling to keep `claudeHarness.test.ts` focused. Conflict error strings, oversize error string, and path-resolution assertions use exact equality (not regex matching) so the contract surface is locked.
 
 ### T8: Docs
-- **Status:** pending
-- **Evidence:** pending
-- **Notes:** pending
+- **Status:** completed
+- **Evidence:** `docs/development/mcp-tooling.md` — new "Customizing the Claude supervisor system prompt (append-only)" subsection right after the `--print-config --cwd` example. Covers the three surfaces, precedence, append-only semantics, 64 KB cap, convention path, lstat guard, and the harness-allowlist-is-authoritative guarantee. `agent-orchestrator claude --help` text updated in T5. `docs/reference.md` does not list supervisor flags so no change needed.
+- **Notes:** AGENTS.md "Local Claude Tmux Smoke Testing" intentionally not touched per plan note (no smoke checklist change required).
 
 ### T9: pnpm verify
-- **Status:** pending
-- **Evidence:** pending
-- **Notes:** pending
+- **Status:** completed
+- **Evidence:** `pnpm install --frozen-lockfile` succeeded. `pnpm verify` exit code 0. `pnpm build` OK; `pnpm test` `tests 600 / pass 598 / fail 0 / skipped 2`; `[publish-ready] package metadata is ready for publish`; `[publish-tag] @ralphkrauss/agent-orchestrator@0.2.2 will publish with npm dist-tag latest`; `pnpm audit --prod` `No known vulnerabilities found`; `npm pack --dry-run` produced `ralphkrauss-agent-orchestrator-0.2.2.tgz` (package size 497.6 kB, 300 files).
+- **Notes:** The 2 skipped tests are pre-existing platform skips and unrelated to this change. No `.agents/` content was touched, so `node scripts/sync-ai-workspace.mjs` was not required.

--- a/plans/56-make-system-prompt-configurable/plans/56-configurable-supervisor-system-prompt.md
+++ b/plans/56-make-system-prompt-configurable/plans/56-configurable-supervisor-system-prompt.md
@@ -1,0 +1,250 @@
+# Configurable Claude Supervisor System Prompt (Append-Only)
+
+Branch: `56-make-system-prompt-configurable`
+Plan Slug: `configurable-supervisor-system-prompt`
+Parent Issue: #56
+Created: 2026-05-12
+Updated: 2026-05-12
+Status: planning
+
+## Context
+
+Issue #56 asks for the orchestrator agent's system prompt to be configurable
+by package users while preserving a sensible default. Today the Claude
+supervisor system prompt is built entirely by
+`buildSupervisorSystemPrompt()` in `src/claude/config.ts` and contains
+load-bearing isolation guarantees (allowed MCP tools, Bash allowlist
+description, monitor-pin invariants, profile diagnostics, embedded
+`orchestrate-*` skill text). The launcher writes that prompt to
+`<envelopeDir>/system-prompt.md` and passes it to Claude via
+`--append-system-prompt-file` (see `src/claude/launcher.ts:499` for the
+envelope path, `src/claude/launcher.ts:506` for the write, and
+`src/claude/launcher.ts:587` for the spawn arg). The Claude passthrough
+validator (`src/claude/passthrough.ts:19-22`) already forbids users from
+supplying `--system-prompt(-file)` and `--append-system-prompt(-file)`
+*after* the `--` separator because the harness owns that flag.
+
+User-confirmed invariants (locked, do not relitigate):
+- Append-only. Harness-owned isolation contract, MCP allowlist, monitor pin,
+  profile diagnostics, and embedded `orchestrate-*` instructions stay intact.
+  User text is concatenated *after* the harness prompt.
+- Supervisor-only. Worker run prompts are out of scope.
+- Three surfaces: CLI flag (`--append-system-prompt` / `--append-system-prompt-file`),
+  env-var fallback, auto-loaded `<targetCwd>/.agents/orchestrator/system-prompt.md`.
+- CLI wins over env wins over the convention file with a single-line stderr
+  notice when a present convention file is preempted.
+- `--print-config` always emits `# user system prompt source` (with `none`
+  sentinel) and the append section when non-empty.
+- `--no-append-system-prompt` is an explicit escape hatch that suppresses
+  ALL append sources (CLI + env + convention).
+- Single concatenated envelope file. Spawn args stay exactly
+  `--append-system-prompt-file <envelope-file>` (no new Claude flag surface,
+  no second instance).
+- 64 KB user-append cap (byte-based); missing CLI-named file errors loudly;
+  missing convention file is silent; BOM stripped, trailing whitespace
+  trimmed, leading Markdown preserved.
+
+Sources read:
+- `src/claude/config.ts` (current prompt construction, `ClaudeHarnessConfig`)
+- `src/claude/launcher.ts` (envelope build, spawn args, help text, parser,
+  cwd resolution)
+- `src/claude/passthrough.ts` (forbidden/allowed flag tokens)
+- `src/__tests__/claudeHarness.test.ts` (existing harness coverage)
+- `AGENTS.md`, `CLAUDE.md`, `.agents/rules/node-typescript.md`
+- `docs/development/mcp-tooling.md`, `docs/development/orchestrator-status-hooks.md`,
+  `docs/ai-workspace.md`
+
+## Decisions
+
+| # | Decision | Choice | Rationale | Rejected Alternatives |
+|---|---|---|---|---|
+| 1 | Customization model | Append-only — user text is concatenated after the harness prompt | Preserves load-bearing isolation contract, MCP allowlist, monitor-pin invariants, and `orchestrate-*` embeds. Matches the issue's "fine-tune" wording. | Prepend slot; full replacement (rejected — would silently break isolation). |
+| 2 | Scope | Claude supervisor only | Issue names the "orchestrator agent". Worker runs already accept arbitrary instructions via `start_run` prompts. Keeps blast radius small. | Also seed worker run prompts (rejected — separate user request, larger surface). |
+| 3 | Configuration surfaces | (a) CLI flags `--append-system-prompt <text>` and `--append-system-prompt-file <path>` on `agent-orchestrator claude`; (b) env-var fallbacks `AGENT_ORCHESTRATOR_CLAUDE_APPEND_SYSTEM_PROMPT` (inline text) and `AGENT_ORCHESTRATOR_CLAUDE_APPEND_SYSTEM_PROMPT_FILE` (path); (c) auto-loaded convention file `<targetCwd>/.agents/orchestrator/system-prompt.md` | CLI is explicit and ergonomic. Env vars match the existing `AGENT_ORCHESTRATOR_CLAUDE_*` family used for cwd, profiles, and state-dir. Convention file gives zero-config baseline for project teams and lives inside the existing `.agents/` AI-workspace tree (consistent with skills/rules/agents). | Profiles manifest field (rejected — couples prompt to profiles); `.agent-orchestrator/` top-level dir (rejected — new dotdir for one file); `.claude/...` (rejected — mixes generated and source artifacts). |
+| 4 | Templating | Raw text, included verbatim | Predictable, no escaping rules, no leaking implementation paths into prompts. | `{{target_cwd}}`-style placeholders (rejected — complexity without clear ask). |
+| 5 | Source model + precedence | Discriminated `AppendSource = 'cli-inline' \| 'cli-file' \| 'env-inline' \| 'env-file' \| 'convention-file' \| 'none'`. Precedence (top wins): (1) `--no-append-system-prompt` → forces `none` and suppresses every other source; (2) `--append-system-prompt` inline → `cli-inline`; (3) `--append-system-prompt-file <path>` → `cli-file`; (4) `AGENT_ORCHESTRATOR_CLAUDE_APPEND_SYSTEM_PROMPT` → `env-inline`; (5) `AGENT_ORCHESTRATOR_CLAUDE_APPEND_SYSTEM_PROMPT_FILE` → `env-file`; (6) convention file present → `convention-file`; (7) nothing → `none`. CLI-inline and CLI-file together is a parse error. Env-inline and env-file together is the same parse error. When a higher-precedence source preempts a present convention file, emit a single-line stderr notice naming the skipped path. | Explicit invocation overrides repo defaults; env vars are still per-launch and override repo defaults; convention file is opt-in by presence. The stderr notice prevents silent surprise. The discriminated source tag makes every transition testable and visible in `--print-config`. | Boolean "has-any" flag (rejected — loses provenance for `--print-config`); concatenate all sources (rejected — composition rules become unreasonable); refuse-to-launch when multiple sources present (rejected — too disruptive). |
+| 6 | `--print-config` visibility | Renders `# user system prompt source` (always emitted; value is the literal source tag — `cli-inline`, `cli-file`, `env-inline`, `env-file`, `convention-file`, or `none`; path appended on a `# user system prompt path` line when the source is a file). When user text is non-empty, renders a `# user system prompt (append)` section above `# settings.json`. | Stable schema. Matches existing transparency for system prompt, settings, mcp, spawn args. Source tag is precise enough to debug precedence. | Summary-only (rejected — harder to debug content escaping or trimming); single combined line (rejected — `cli-inline:<text>` mixes provenance with content). |
+| 7 | Combination strategy at the wire | Concatenate the harness prompt and the user append into the single existing envelope file `<envelopeDir>/system-prompt.md`, separated by a literal delimiter line `\n\n---\n# User-supplied supervisor prompt\n\n`. The file is still injected via `--append-system-prompt-file`. Spawn args are unchanged (one `--append-system-prompt-file <envelope-file>`, no second instance, no new Claude flag). | Keeps the spawn-arg surface unchanged. One file, one flag, one read by Claude Code. Avoids guessing whether Claude supports multiple `--append-system-prompt-file` instances. | Pass user append as a second `--append-system-prompt-file` (rejected — unknown multi-flag support, harder to test deterministically). |
+| 8 | Empty / missing / encoding | Missing convention file → silent no-op. Missing CLI- or env-named file → fail launch with a typed error naming the source and path. Empty or whitespace-only content → source/path preserved but no append section emitted; `--print-config` still prints the source line, plus `# user system prompt path` for file sources, and an `(empty)` annotation on the source line. User append is read as **bytes**; the 64 KB cap is byte-based. UTF-8 decoding follows the same policy already used by the launcher's file reads (`readFile(..., 'utf8')` — Node's default replaces invalid UTF-8 sequences with U+FFFD; we do not change that). A leading UTF-8 BOM (`EF BB BF`) is stripped. `trimEnd` removes trailing whitespace/newlines. CRLF line endings inside the body are preserved (we do not normalize line endings). Leading Markdown (headings, lists) is preserved. | Loud failure when the user explicitly named a file (CLI or env); quiet absence when no one asked for one. Byte-based cap matches the real cost driver (token-budget bloat); BOM strip avoids zero-width artifacts in the prompt; CRLF preservation avoids surprise on Windows-edited files. | Always warn on missing convention file (rejected — defeats the zero-config goal); cap measured in code points (rejected — encoding-dependent and harder to reason about). |
+| 9 | Suppression escape hatch | Flag `--no-append-system-prompt` short-circuits all resolution: it forces `source = 'none'`, suppresses CLI text/file, env text/file, and the convention file lookup. It is NOT an error when combined with any other append flag or env var — it overrides them. `--print-config` still prints `# user system prompt source\nnone`. | Lets users bypass repo-level conventions and inherited env settings for one-off debugging without renaming files or unsetting variables. Forcing `none` is the dominant intent of the flag — making the combination an error would defeat the escape-hatch use case. | Treat as parse error when combined with explicit sources (rejected — removes the primary use case: overriding a repo's convention file or a CI-injected env var). |
+| 10 | Size cap | Reject user append larger than 64 KB after the byte-length is measured (post-BOM-strip but pre-trim). Error mentions the cap, the byte length, and the source tag + path. Boundary: exactly 65 536 bytes is accepted; 65 537 bytes is rejected. | Prevents accidental megabyte-scale prompt files from inflating every supervisor turn and consuming token budget. Today's harness prompt is ~5 KB, so 64 KB is ~13x headroom — plenty for project customization, small enough to refuse pathological inputs. | No cap (rejected — silent token-budget blowups). |
+| 11 | Symlink handling | For the **auto-loaded convention file** only (the path the user did not type): `lstat` the path first; if it is not a regular file (e.g., symlink, directory, FIFO, socket, character device) refuse to read it, treat the source as absent (no append), and surface a single-line skip notice naming the path and the reason (e.g., `agent-orchestrator: skipping convention system-prompt file at <path>: not a regular file`). Do NOT fail the launch — this matches the silent-absence semantics for the convention file. The notice flows through the same `BuiltClaudeEnvelope.conventionSkipNotice` channel as the precedence-based skip notice (see Decision 5 / T4); `runClaudeLauncher` remains the single writer to `io.stderr`. The loader and resolver never write to stderr directly. For **explicit CLI-named or env-named paths** (`cli-file`, `env-file`), keep ordinary behavior: read with `fs/promises.readFile` (which follows symlinks) and trust the user-supplied path. | The user explicitly named the CLI/env file path — that's an opt-in to whatever it points at. The convention file is opt-in by presence only; an unexpected symlink (e.g., a malicious or stale link checked into a clone) deserves a refuse-and-notify rather than silently slurping arbitrary content into the supervisor prompt. Single-channel routing keeps `runClaudeLauncher` as the sole stderr writer. | Always follow symlinks (rejected — convention file is a zero-config attractor; symlink target surprises are real); refuse symlinks everywhere (rejected — would block legitimate dotfile setups that symlink CLI-named paths); separate `appendPromptNotice` field for the lstat case (rejected — splitting one stderr channel into two for the same "convention file skipped" semantics adds plumbing without a clear consumer benefit). |
+| 12 | Public type contract | Keep the existing `ClaudeHarnessConfig.appendSystemPrompt?: string` field in `src/claude/config.ts` semantically unchanged (continues to mean "additional text appended by `buildClaudeHarnessConfig` callers", currently unused by the launcher path). Add NEW dedicated fields for the user append on both the input and the result, and on the built envelope: on `ClaudeHarnessConfigInput` add `userAppendSystemPrompt?: { source: AppendSource; path: string \| null; text: string \| null }`; on `ClaudeHarnessConfig` add `userSystemPromptSource: AppendSource`, `userSystemPromptPath: string \| null`, `userSystemPromptAppend: string \| null`; on `BuiltClaudeEnvelope` mirror those same three fields. `BuiltClaudeEnvelope.systemPrompt` continues to hold the full concatenated string written to disk. | Backwards-compatible. No existing callers of `appendSystemPrompt` change. The user-append provenance is exposed as first-class typed fields that downstream consumers (`--print-config`, future telemetry, tests) can read without parsing the concatenated prompt string. | Repurpose `appendSystemPrompt` (rejected — silently changes semantics for any external consumer that might rely on it). |
+| 13 | Path resolution | `--append-system-prompt-file <path>` and `AGENT_ORCHESTRATOR_CLAUDE_APPEND_SYSTEM_PROMPT_FILE` paths are resolved against the **resolved target cwd** (`ParsedClaudeLauncherArgs.cwd`), matching how profiles and skills are resolved in `parseClaudeLauncherArgs` (`src/claude/launcher.ts:118-123`). The convention file path is always `<resolvedCwd>/.agents/orchestrator/system-prompt.md`. Not `process.cwd()`, not `defaultCwd` directly. | Consistent with the existing profiles/skills resolution and with `--cwd` semantics: the target workspace is the source of truth, not the shell's CWD when the launcher happened to start. | Resolve against `process.cwd()` (rejected — diverges from existing options and breaks reproducible `--print-config` output when `--cwd` is used). |
+
+## Scope
+
+### In Scope
+- New CLI options on `agent-orchestrator claude` (and `agent-orchestrator-claude`):
+  `--append-system-prompt <text>`, `--append-system-prompt-file <path>`,
+  `--no-append-system-prompt`.
+- Env-var fallbacks: `AGENT_ORCHESTRATOR_CLAUDE_APPEND_SYSTEM_PROMPT` (inline
+  text) and `AGENT_ORCHESTRATOR_CLAUDE_APPEND_SYSTEM_PROMPT_FILE` (path).
+- Auto-loaded convention file at
+  `<resolvedCwd>/.agents/orchestrator/system-prompt.md` (only when no
+  higher-precedence source is in effect and `--no-append-system-prompt` is
+  not set), with symlink/non-regular-file guard (Decision 11).
+- Discriminated `AppendSource` discriminator and precedence resolution
+  (Decision 5).
+- Concatenation of harness prompt + delimiter + user append into the
+  existing envelope `system-prompt.md` (Decision 7).
+- Single-line stderr notice when a present convention file is preempted by
+  a higher-precedence source, and when a convention file is refused because
+  it is not a regular file (Decision 11).
+- `--print-config` output gains a `# user system prompt source` line
+  (always), a `# user system prompt path` line when applicable, and a
+  `# user system prompt (append)` section when non-empty.
+- New typed fields on `ClaudeHarnessConfigInput`, `ClaudeHarnessConfig`, and
+  `BuiltClaudeEnvelope` (Decision 12).
+- Tests covering parsing, precedence transitions, missing/empty/oversize
+  handling, BOM/trim/CRLF, byte-based 64 KB boundary, envelope file
+  contents, spawn args unchanged, `--print-config` rendering, and
+  `--no-append-system-prompt` short-circuiting every other source.
+- Help text and docs (`agent-orchestrator claude --help`, the
+  `docs/development/` updates listed in T8, AGENTS.md note if relevant).
+
+### Out Of Scope
+- Worker run system prompts (start_run / send_followup payloads stay
+  unchanged).
+- Full replacement of the harness prompt.
+- Variable interpolation / templating.
+- Prepend slots.
+- A profiles-manifest `supervisor.append_system_prompt` field.
+- Codex/Cursor/CCS/OpenCode backends' own prompts.
+- Changing the spawn-arg shape passed to Claude (still a single
+  `--append-system-prompt-file <envelope-file>` and no new Claude flag).
+- Hot-reload of the convention file mid-session.
+- Hooks behavior changes — hooks are not touched by this work.
+- Creating new `.agents/rules/` content (the Rule Candidates section is
+  explicitly deferred — see below).
+
+## Risks And Edge Cases
+
+| # | Scenario | Mitigation | Covered By |
+|---|---|---|---|
+| 1 | User append contradicts the harness isolation contract (e.g., "use Edit and WebFetch freely") | Append happens *after* the harness prompt; Claude tool surface is still restricted by `--tools` / `--allowed-tools` / `--permission-mode dontAsk`, so the wire-level allowlist is the authoritative gate regardless of prompt text. Documented explicitly. | T8 (docs); existing harness allowlist tests in `claudeHarness.test.ts`. |
+| 2 | User append swells beyond reasonable size, consuming token budget per turn | 64 KB byte-based cap (Decision 10) with a clear typed error pointing at the source tag and path. Boundary test at exactly 65 536 / 65 537 bytes. | T7 unit test. |
+| 3 | Convention file exists on a contributor's machine but not in CI / users' machines, causing prompt drift | Convention file is opt-in by *presence*. If a project wants it everywhere, they check it into the repo under `.agents/orchestrator/system-prompt.md`. Documented in `docs/development/` and in `--help`. | T8 (docs); T7 (convention file presence test). |
+| 4 | User adds `--append-system-prompt-file` *after* `--` (intending Claude's flag) | Passthrough validator already rejects with a clear error pointing at the harness-owned surface (`src/claude/passthrough.ts:19-22`). Help text gains a one-liner pointing users at the launcher flag. | T8 (help text); existing passthrough test. |
+| 5 | User provides both `--append-system-prompt` and `--append-system-prompt-file` | Parse error with a precise message: only one CLI inline/file source allowed. | T7 unit test. |
+| 6 | User provides both `AGENT_ORCHESTRATOR_CLAUDE_APPEND_SYSTEM_PROMPT` and `AGENT_ORCHESTRATOR_CLAUDE_APPEND_SYSTEM_PROMPT_FILE` | Same parse error pattern as Risk 5: only one env inline/file source allowed. Symmetrical message. | T7 unit test. |
+| 7 | `--no-append-system-prompt` combined with an explicit append flag, env var, or a present convention file | Per Decision 9, this is the **escape hatch** and not an error. The flag forces `source = 'none'` and suppresses all other sources. `--print-config` prints `# user system prompt source\nnone`. | T7 unit test (one combined test verifying suppression of CLI inline, CLI file, env inline, env file, and convention file). |
+| 8 | Convention file is a symlink, directory, FIFO, or other non-regular file | `lstat` first; refuse to read; treat as absent and emit a single-line stderr notice naming the path and reason. Launch continues. CLI/env-named paths are read as-is and trust the user-supplied path (Decision 11). | T7 tests: convention is a symlink → skipped with notice; convention is a directory → skipped with notice; convention is a regular file → loaded normally. |
+| 9 | UTF-8 BOM, trailing whitespace, CRLF line endings in user text | Strip a leading UTF-8 BOM; `trimEnd` trailing whitespace/newlines; preserve CRLF in the body; preserve leading content (headings, lists). | T7 unit tests (BOM stripped, trailing whitespace trimmed, CRLF preserved, leading Markdown preserved). |
+| 10 | `--print-config` is used in CI to assert the supervisor envelope; existing snapshots/assertions might break | Always emit `# user system prompt source` (with the `none` sentinel) so the new line is stable. The `# user system prompt path` line and the append section are only emitted when applicable. | T7 print-config tests. |
+| 11 | Downstream consumers of `BuiltClaudeEnvelope.systemPrompt` | The envelope's `systemPrompt` field continues to be the *full* concatenated string written to `<envelopeDir>/system-prompt.md` (harness + delimiter + user append, when present). The only existing consumers in `src/claude/launcher.ts` are `--print-config` (line 242) and the envelope-file write / spawn flow (lines 506, 587) — not the hooks pipeline. New typed fields `userSystemPromptSource`, `userSystemPromptPath`, `userSystemPromptAppend` are added for callers that want the user segment separately. | T3, T5, T7 (T7 adds an assertion that generated settings/hooks output is byte-identical to the no-append baseline, confirming hooks are unaffected). |
+| 12 | Local Claude tmux smoke (AGENTS.md "Local Claude Tmux Smoke Testing") relies on the supervisor envelope behaving like prior runs | The wire shape (`--append-system-prompt-file`, `--tools`, `--allowed-tools`, `--permission-mode`) is unchanged. The smoke checklist already inspects the envelope path content, not a specific byte; it will continue to pass when no convention file is present in the test workspace. | T9 manual smoke note. |
+| 13 | Stderr notice fires more than once per launch (e.g., once from resolver + once from envelope wiring) | The resolver returns `conventionSkipNotice: string \| null`; the envelope builder propagates it as `BuiltClaudeEnvelope.conventionSkipNotice`; `runClaudeLauncher` is the single place that writes it to `io.stderr`. Resolver and loader do not write to stderr themselves. | T7 unit test asserts the notice fires exactly once per launch, and only when both a higher-precedence source AND a present convention file existed before precedence applied. |
+| 14 | Stderr writes from inside the resolver/loader couple them to I/O | Resolver is a pure function (Decision 12 + T2). The loader handles file I/O + size cap + BOM/trim but does not write to stderr — it surfaces failures via typed errors and surfaces the convention-skip notice via the resolver's return value. The launcher is the single writer to `io.stderr`. | T2, T4 acceptance criteria. |
+
+## Implementation Tasks
+
+| Task ID | Title | Depends On | Status | Acceptance Criteria |
+|---|---|---|---|---|
+| T1 | Extend `ParsedClaudeLauncherArgs` + `parseClaudeLauncherArgs` with the new options and a structured `appendSource` discriminator | — | pending | Add fields: `appendInlineText: string \| null`, `appendFilePath: string \| null`, `appendInlineSource: 'cli' \| 'env' \| null`, `appendFileSource: 'cli' \| 'env' \| null`, `disableAppendSystemPrompt: boolean`. (Equivalent shape: a single `appendCandidates: { cliInline, cliFile, envInline, envFile }` plus the disable boolean. Pick whichever keeps the parser readable.) Reads `--append-system-prompt <text>`, `--append-system-prompt-file <path>`, `--no-append-system-prompt`, plus env-var fallbacks `AGENT_ORCHESTRATOR_CLAUDE_APPEND_SYSTEM_PROMPT` and `AGENT_ORCHESTRATOR_CLAUDE_APPEND_SYSTEM_PROMPT_FILE`. Conflicts (`--append-system-prompt` + `--append-system-prompt-file`; `AGENT_ORCHESTRATOR_CLAUDE_APPEND_SYSTEM_PROMPT` + `..._FILE`) return `{ ok: false, error: ... }` with precise, symmetric messages. `--no-append-system-prompt` is **not** an error in combination with any other source — it is captured as `disableAppendSystemPrompt: true` and acted on by the resolver. File paths (`--append-system-prompt-file` value, env-var file value) are resolved against the resolved target cwd (matching profiles/skills resolution at `src/claude/launcher.ts:118-123`). Unit-tested per T7 (a). |
+| T2 | Add `resolveSupervisorAppendPrompt()` pure helper in a new `src/claude/appendPrompt.ts` (or in `src/claude/config.ts` if it stays small) | T1 | pending | **Pure function** with no file I/O. Input: `{ cliInlineText, cliFilePath, envInlineText, envFilePath, conventionFilePresent, conventionFilePath, disable, loaded: { cliFile?: LoadedContent, envFile?: LoadedContent, convention?: LoadedContent } }` where `LoadedContent = { bytes: Buffer; path: string }`. Output: `{ source: AppendSource; path: string \| null; text: string \| null; conventionSkipNotice: string \| null }`. `AppendSource = 'cli-inline' \| 'cli-file' \| 'env-inline' \| 'env-file' \| 'convention-file' \| 'none'`. Behavior: if `disable` is true, return `{ source: 'none', path: null, text: null, conventionSkipNotice: null }` unconditionally. Otherwise apply Decision 5 precedence. When a higher-precedence source is in effect AND the convention file was present before precedence applied, set `conventionSkipNotice` to a single-line message naming the skipped convention path; otherwise null. For the selected source, decode bytes per Decision 8 (UTF-8 via the launcher's existing `readFile` policy; strip leading BOM; apply `trimEnd`; preserve CRLF body), then return the decoded text (or `null` when the result is empty/whitespace-only — but keep `source` and `path` set so `--print-config` can still report provenance with an `(empty)` annotation). Errors are returned as a typed sum (see "Errors" below), not thrown, so T4 can propagate cleanly. |
+| T3 | Plumb the resolved append into `buildClaudeHarnessConfig` and `buildSupervisorSystemPrompt` | T2 | pending | `ClaudeHarnessConfigInput` gains `userAppendSystemPrompt?: { source: AppendSource; path: string \| null; text: string \| null }` (optional; defaults to `{ source: 'none', path: null, text: null }` semantics). `ClaudeHarnessConfig` gains three new fields: `userSystemPromptSource: AppendSource`, `userSystemPromptPath: string \| null`, `userSystemPromptAppend: string \| null`. The existing `appendSystemPrompt?: string` field is **preserved unchanged** (Decision 12) — no semantic change, no rename. `buildSupervisorSystemPrompt` appends the delimiter `\n\n---\n# User-supplied supervisor prompt\n\n` and the user text only when `text` is a non-empty string (Decision 7). When `text` is null or empty, the full system prompt is byte-identical to today's output. |
+| T4 | Add `loadAppendPromptSource()` loader + wire `buildClaudeEnvelope` to call resolver, loader, propagate the convention-skip notice via `BuiltClaudeEnvelope`, and feed the resolved append into `buildClaudeHarnessConfig` | T1, T2, T3 | pending | `loadAppendPromptSource()` is the async I/O adapter: given a `{ kind: 'cli-file' \| 'env-file' \| 'convention-file'; path: string }`, it (a) for `convention-file`: `lstat` the path and refuse if not a regular file (return `{ kind: 'skipped-non-regular', path, reason }`); (b) for any kind: `readFile` returns bytes; enforce the 64 KB byte cap (post-BOM-strip, pre-trim); return `{ kind: 'loaded', path, bytes }`. Missing convention file → `{ kind: 'absent' }`. Missing CLI/env file → `{ kind: 'error', code: 'missing-file', source, path, message }`. `buildClaudeEnvelope` calls the loader for whichever sources are configured (skipping convention lookup entirely when `disable` is true), then calls `resolveSupervisorAppendPrompt` with the loaded contents, then feeds the result into `buildClaudeHarnessConfig`. `BuiltClaudeEnvelope` gains `userSystemPromptSource: AppendSource`, `userSystemPromptPath: string \| null`, `userSystemPromptAppend: string \| null`, and `conventionSkipNotice: string \| null`. **The `conventionSkipNotice` field is the single channel for any convention-file skip notice — both the precedence-based skip (Decision 5: higher-precedence source preempts a present convention file) and the lstat-based skip (Decision 11: convention path is not a regular file).** Exactly one of these can fire per launch — the lstat guard runs before the resolver, so if it skips, the resolver sees `convention-file` as absent and never produces a precedence notice for it. **The envelope builder does NOT write to stderr.** The single `<envelopeDir>/system-prompt.md` file holds the concatenated content. Spawn args list remains unchanged (still one `--append-system-prompt-file`, no second instance, no new Claude flag). Loader errors propagate up as a thrown typed error that `runClaudeLauncher` turns into an exit-1 with the typed message. |
+| T5 | Extend `--print-config` output, help text in `runClaudeLauncher` / `claudeLauncherHelp`, and the convention-skip stderr write | T4 | pending | `runClaudeLauncher` is the **single writer** of the convention-skip notice: after `buildClaudeEnvelope` returns, if `built.conventionSkipNotice` is non-null write it to `io.stderr` followed by `\n`. `--print-config` output additions: always include `# user system prompt source\n<tag>\n` where `<tag>` is the literal `AppendSource` value (one of `cli-inline`, `cli-file`, `env-inline`, `env-file`, `convention-file`, `none`); when the source is `cli-file`, `env-file`, or `convention-file`, also include `# user system prompt path\n<resolved-path>\n`; when the resolved text is non-empty, append a `# user system prompt (append)\n<text>\n` section *above* `# settings.json`; when the source is set but text is empty/whitespace-only, annotate the source line as `<tag> (empty)`. Help text documents the three flags (`--append-system-prompt`, `--append-system-prompt-file`, `--no-append-system-prompt`), both env vars, the convention file path, the precedence rule, the 64 KB cap, and reminds users that `--append-system-prompt[-file]` *after* `--` is forbidden by the passthrough validator. |
+| T6 | Update passthrough validator help-text reference if needed | T5 | pending | If the rejection message for `--append-system-prompt(-file)` after `--` would benefit from naming the new launcher flag, update the validator's error string in `src/claude/passthrough.ts` (the FORBIDDEN_FLAGS set at lines 19-22 is unchanged; only the error message wording may improve). No allowlist/denylist semantics change. |
+| T7 | Tests | T1–T6 | pending | New unit tests in `src/__tests__/claudeHarness.test.ts` (or a new sibling file if it grows large) covering: **(a)** parser accepts each flag/env combo and resolves file paths against the resolved target cwd; **(b)** parser rejects `--append-system-prompt` + `--append-system-prompt-file` and rejects both env vars set simultaneously with precise symmetric messages (Risks 5, 6); **(c)** resolver precedence transitions: `cli-inline` preempts everything below; `cli-file` preempts env + convention; `env-inline` preempts convention; `env-file` preempts convention; convention selected only when nothing higher is set; `none` when nothing is set; (parse-error coverage for `env-inline` + `env-file` set together stays in T7 (b)); **(d)** missing CLI-named file errors out with the typed error; missing env-named file errors out with the typed error; **(e)** missing convention file is silent (no stderr write, no error); **(f)** byte-based 64 KB cap: exactly 65 536 bytes is accepted; 65 537 bytes is rejected with the exact error wording mentioning the cap, the byte length, and the source tag + path; **(g)** content normalization: leading UTF-8 BOM (`EF BB BF`) is stripped; trailing whitespace and newlines are trimmed; CRLF inside the body is preserved; leading Markdown (headings, lists) is preserved; **(h)** `buildSupervisorSystemPrompt` includes the delimiter + user text when present; when text is null/empty the full prompt is byte-identical to the no-append baseline; **(i)** the envelope writes one concatenated `system-prompt.md` and spawn args remain exactly `--append-system-prompt-file <envelope-file>` (no new flag, no second instance); **(j)** `--print-config` snapshots: source line emitted in all cases including `none`; path line emitted for file sources; append section only when non-empty; `(empty)` annotation when source set but text empty; **(k)** stderr convention-skip notice fires exactly once per launch and only when both a higher-precedence source AND a present convention file existed before precedence applied; **(l)** `--no-append-system-prompt` short-circuits every other source — covers (i) `--append-system-prompt`, (ii) `--append-system-prompt-file`, (iii) `AGENT_ORCHESTRATOR_CLAUDE_APPEND_SYSTEM_PROMPT`, (iv) `AGENT_ORCHESTRATOR_CLAUDE_APPEND_SYSTEM_PROMPT_FILE`, (v) a present convention file; in every case `source === 'none'` and no append section is emitted; **(m)** symlink/non-regular convention file: symlink → skipped with stderr notice; directory → skipped with stderr notice; regular file → loaded normally; CLI-named symlink is read normally (no refuse); env-named symlink is read normally; the lstat-skip notice is surfaced through `BuiltClaudeEnvelope.conventionSkipNotice` and written to `io.stderr` by `runClaudeLauncher` exactly once per launch (assert the stderr writer count is 1 and that the loader/resolver did not also write); when both a non-regular convention path and a higher-precedence source are present, only one notice (the lstat one) is emitted because the resolver sees the convention as absent; **(n)** hooks output unchanged: when a user append is present, the generated `settings.json` content (which carries hook config) is byte-identical to the no-append baseline. Use existing `mkdtemp` patterns. |
+| T8 | Docs and help-text alignment | T5 | pending | Update `agent-orchestrator claude --help` (already in T5). Update `docs/development/mcp-tooling.md` — it already documents the Claude supervisor spawn flags and `--append-system-prompt-file` (see line 142); add a short subsection describing the new launcher flags, the env-var fallbacks, the convention file path, precedence, append-only semantics, the byte-based 64 KB cap, the symlink-refusal rule for the convention file, and that the harness allowlist is the authoritative tool gate regardless of prompt text. `docs/development/orchestrator-status-hooks.md` is listed here only as a *no-change* reference — hooks behavior is not touched (Risk 11) and the file does not need edits; mention it in the PR description only if a reviewer asks. Add a one-liner to AGENTS.md "Local Claude Tmux Smoke Testing" only if the smoke checklist needs to reference the new flag; otherwise skip. Add a one-line note in `docs/reference.md` if it lists supervisor flags. |
+| T9 | Verify with the repository's release-quality check | T1–T8 | pending | Run `pnpm install --frozen-lockfile` then `pnpm verify`. Record command exit codes and key output lines (build OK, tests OK, npm-pack dry run OK, audit OK, dist-tag resolved) in the Execution Log section. Sync the AI workspace projection (`node scripts/sync-ai-workspace.mjs`) if any `.agents/` content was touched, and re-run `pnpm verify` after sync. |
+
+### Errors (typed)
+
+The resolver and loader use a discriminated error union (shape may live next
+to `resolveSupervisorAppendPrompt` in `src/claude/appendPrompt.ts`):
+
+```ts
+type AppendPromptError =
+  | { code: 'missing-file'; source: 'cli-file' | 'env-file'; path: string; message: string }
+  | { code: 'oversize'; source: AppendSource; path: string | null; bytes: number; cap: number; message: string }
+  | { code: 'read-failed'; source: AppendSource; path: string; cause: string; message: string };
+```
+
+The resolver returns `{ ok: true, value } | { ok: false, error: AppendPromptError }`.
+`buildClaudeEnvelope` converts an `error` into a thrown `Error` whose
+`message` is `error.message`; `runClaudeLauncher` catches at the existing
+top-level and writes to `io.stderr` with exit code 1. Missing convention
+file is **not** an error — the loader returns `{ kind: 'absent' }` and the
+resolver treats it as "convention not present".
+
+## Rule Candidates
+
+**Status: deferred follow-up.** Creating `.agents/rules/` content is NOT
+part of this implementation. The candidates below are recorded so future
+work can pick them up if the pattern recurs; they do not gate T9.
+
+| # | Candidate | Scope | Create After |
+|---|---|---|---|
+| 1 | "Append-only customization of supervisor system prompts" rule: never expose a path that lets user input replace or precede the harness contract; always concatenate after, and rely on the wire-level tool allowlist as the authoritative gate. | `.agents/rules/` (claude harness) | Only if a second similar instance appears (e.g., when extending to another backend) and is separately approved. |
+| 2 | "Stable `--print-config` schema" rule: when adding a new envelope field, always emit a header line (with a sentinel value) so external snapshots remain stable. | `.agents/rules/` (release tooling) | Only if a second similar instance appears and is separately approved. |
+
+## Quality Gates
+
+- [ ] `pnpm build` succeeds with no new `tsconfig.json` looseness.
+- [ ] `pnpm test` passes including new harness tests.
+- [ ] `pnpm verify` passes (build + tests + publish-readiness + audit + dist-tag + `npm pack` dry run).
+- [ ] `agent-orchestrator claude --help` documents the three flags, both env vars, convention file path, precedence, and 64 KB cap.
+- [ ] `agent-orchestrator claude --print-config` always emits `# user system prompt source` (with `none` sentinel when no append is active).
+- [ ] When a user append is present, generated `settings.json` content is byte-identical to the no-append baseline (hooks unaffected).
+- [ ] `.agents/rules/node-typescript.md` requirements honored (pnpm, Node 22+, strict TS).
+- [ ] If `.agents/` content changed: `node scripts/sync-ai-workspace.mjs` was re-run and projected `.claude/` / `.cursor/` artifacts are in sync.
+- [ ] No new dependencies introduced.
+- [ ] No secrets, credentials, or env-token reads added.
+
+## Reviewer Questions
+
+none
+
+## Open Human Decisions
+
+none
+
+## Execution Log
+
+### T1: Extend parser
+- **Status:** pending
+- **Evidence:** pending
+- **Notes:** pending
+
+### T2: Resolver helper
+- **Status:** pending
+- **Evidence:** pending
+- **Notes:** pending
+
+### T3: Plumb into config
+- **Status:** pending
+- **Evidence:** pending
+- **Notes:** pending
+
+### T4: Loader + envelope builder wiring
+- **Status:** pending
+- **Evidence:** pending
+- **Notes:** pending
+
+### T5: --print-config + help + stderr notice
+- **Status:** pending
+- **Evidence:** pending
+- **Notes:** pending
+
+### T6: Passthrough help alignment
+- **Status:** pending
+- **Evidence:** pending
+- **Notes:** pending
+
+### T7: Tests
+- **Status:** pending
+- **Evidence:** pending
+- **Notes:** pending
+
+### T8: Docs
+- **Status:** pending
+- **Evidence:** pending
+- **Notes:** pending
+
+### T9: pnpm verify
+- **Status:** pending
+- **Evidence:** pending
+- **Notes:** pending

--- a/plans/56-make-system-prompt-configurable/resolution-map.md
+++ b/plans/56-make-system-prompt-configurable/resolution-map.md
@@ -1,0 +1,283 @@
+---
+pr: 61
+url: https://github.com/ralphkrauss/agent-orchestrator/pull/61
+branch: 56-make-system-prompt-configurable
+base: main
+head_commit: 87ee632d168af7d312ad2cc38ea83f77cb9b4e40
+created: 2026-05-12
+generated_by: Claude resolve-pr-comments triage (batched, resolution-map only; interactive one-comment loop overridden)
+ai_reply_prefix: "**[AI Agent]:**"
+correlation_marker_pattern: "<!-- agent-orchestrator:pr61:<tag> -->"
+scope: "Resolution map only. No implementation, no commits, no pushes, no GitHub replies, no thread resolution."
+---
+
+# PR #61 Resolution Map
+
+Branch: `56-make-system-prompt-configurable`
+Base: `main`
+Head commit: `87ee632 feat(56): configurable supervisor system prompt (append-only)`
+Approved plan: `plans/56-make-system-prompt-configurable/plans/56-configurable-supervisor-system-prompt.md`
+
+## Fetch Results
+
+Collected via `gh` (auth via `GH_TOKEN`) against `ralphkrauss/agent-orchestrator`:
+
+- `gh pr view 61 --json reviews` → reviews: **0**
+- `gh api repos/ralphkrauss/agent-orchestrator/pulls/61/comments` (inline review comments): **0**
+- `gh api repos/ralphkrauss/agent-orchestrator/pulls/61/reviews` (reviews, paginated): **0**
+- `gh api repos/ralphkrauss/agent-orchestrator/issues/61/comments` (conversation comments): **1**
+- GraphQL `reviewThreads(first:100)`: `nodes: []` → **0** threads to filter as resolved/unresolved
+
+## Counts
+
+- Total comments fetched: 1
+- Filtered as bot informational summary: 1 (CodeRabbit walkthrough; "No actionable comments were generated in the recent review. 🎉")
+- Embedded informational items surfaced for explicit triage: 2 (one pre-merge check warning + one LanguageTool grammar batch on plan docs)
+- Actionable comments triaged: 2
+- To fix: 0 | To decline: 2 | To defer: 0 | To escalate: 0 | Human Approval Required: 0
+
+## Filter Notes
+
+The single fetched comment is CodeRabbit's auto-generated walkthrough/summary
+comment (id `4431211822`, author `coderabbitai[bot]`). Its top line explicitly
+states:
+
+> No actionable comments were generated in the recent review. 🎉
+
+The body's `Additional comments (9)` section is praise-only ("Clear, actionable
+passthrough rejection message", "Docs section is thorough and
+implementation-aligned", "Resolver contract is clean and testable",
+"Parser precedence and escape-hatch behavior look solid", etc.) and is not
+actionable feedback. The walkthrough itself is therefore filtered as
+informational bot noise per the `resolve-pr-comments` filter rules.
+
+Two embedded blocks inside the same auto-summary comment could plausibly be
+construed as feedback and are surfaced below as `C1` and `C2`:
+
+- `C1` — Pre-merge check warning: **Docstring Coverage** (12.90% vs 80%
+  threshold). Same generic CodeRabbit threshold check encountered on PR #50;
+  see `plans/33-root-command-should-give-you-the-help/resolution-map.md` for
+  the established precedent.
+- `C2` — LanguageTool grammar batch: three "Use a hyphen to join words"
+  suggestions targeting "Worker run prompts" / "worker run prompts" in plan
+  documents.
+
+No prior AI replies with `<!-- agent-orchestrator:pr61:* -->` correlation
+markers exist on this PR (issue-comments list has only the CodeRabbit
+auto-summary; review-comments and reviews lists are empty).
+
+CI status on this branch is reported as 4 pre-merge checks passing
+(Description, Title, Linked Issues, Out-of-scope) and 1 warning (the
+Docstring Coverage threshold). No required check is failing. The CodeRabbit
+auto-summary also notes one timed-out external check (`GitHub Check: Windows
+Smoke on Node 24`); that is an infra timeout, not an item of review feedback,
+so it is not triaged.
+
+## Reviewer Questions
+
+none.
+
+Both triaged items are generic, repo-pattern-aligned declines with clear
+precedent (PR #50). The triage did not turn up uncertainty that requires
+pr-comment-reviewer adjudication before proceeding.
+
+## Open Human Decisions
+
+none.
+
+Neither `C1` nor `C2` proposes a behavior change, public-contract change,
+workflow change, permission/tool-surface change, security-boundary change,
+release/publish change, dependency-policy change, or capability removal. The
+PR's approved scope (append-only customization slot, three resolution
+surfaces, 64 KB cap, etc.) is not affected by either item, so no human
+approval gate is triggered.
+
+---
+
+## Comment C1 | Decline | Low
+
+- **Comment Type:** conversation (embedded pre-merge check warning inside the CodeRabbit auto-summary comment)
+- **File:** N/A (repo-wide bot threshold, not tied to a specific path/line)
+- **Comment ID:** `4431211822` (parent CodeRabbit summary)
+- **Review ID:** N/A
+- **Thread Node ID:** N/A (not posted as a review thread)
+- **Author:** `coderabbitai[bot]`
+- **Comment (verbatim excerpt):**
+
+  > Docstring Coverage — ⚠️ Warning — Docstring coverage is 12.90% which is
+  > insufficient. The required threshold is 80.00%. Resolution: Write
+  > docstrings for the functions missing them to satisfy the coverage
+  > threshold.
+
+- **Code surfaces this PR adds that the threshold would target:**
+  - `src/claude/appendPrompt.ts` (new, 317 lines): exports
+    `AppendSource` (type), `SUPERVISOR_APPEND_PROMPT_BYTE_CAP`,
+    `SUPERVISOR_APPEND_PROMPT_DELIMITER`,
+    `CONVENTION_APPEND_PROMPT_RELATIVE_PATH`, `LoadedAppendContent`
+    (interface), `AppendPromptError` (discriminated type with
+    `code: 'missing-file' | 'oversize' | 'read-failed'`),
+    `ResolveSupervisorAppendPromptInput`,
+    `ResolvedSupervisorAppendPrompt`, `resolveSupervisorAppendPrompt`,
+    `ConventionPromptProbeResult`, `probeConventionAppendPromptFile`,
+    `LoadAppendPromptInput`, `LoadAppendPromptResult`,
+    `readAppendPromptFile`, `loadAppendPromptSource`.
+  - `src/claude/launcher.ts`: new helpers
+    `resolveAppendSystemPromptForEnvelope`, `formatUserSystemPromptSections`,
+    expanded parser branches in `parseClaudeLauncherArgs`, expanded
+    `BuiltClaudeEnvelope` fields.
+  - `src/claude/config.ts`: new input field `userAppendSystemPrompt` and
+    three new result fields (`userSystemPromptSource`,
+    `userSystemPromptPath`, `userSystemPromptAppend`); extended
+    `buildSupervisorSystemPrompt` with a non-empty-text delimiter branch.
+  - `src/claude/passthrough.ts`: specialized rejection branch for
+    `--append-system-prompt` / `--append-system-prompt-file` after `--`.
+- **Independent Assessment:**
+  - This is a generic CodeRabbit pre-merge threshold (12.90% < 80.00%)
+    applied uniformly across the repo, not a verified review of this PR's
+    correctness or contract. The CodeRabbit comment that contains the
+    warning explicitly declares "No actionable comments were generated in
+    the recent review. 🎉", which confirms the bot does not classify it as
+    actionable feedback.
+  - Repository convention does not use JSDoc tag-based docstrings: across
+    `src/`, `@param` / `@returns` / `@throws` tags occur **zero** times.
+    Existing `/**` block-comment openings are plain prose intros, not
+    formal docstrings. Forcing 80%+ JSDoc tag coverage on the new files
+    would diverge from the repo's established TypeScript style.
+  - Neither `AGENTS.md`, `.cursor/rules/node-typescript.mdc`, nor the
+    approved plan
+    (`plans/56-make-system-prompt-configurable/plans/56-configurable-supervisor-system-prompt.md`)
+    requires docstrings. The plan explicitly enumerates the public type
+    contract (Decision 12) and the typed error contract (Tests T1–T8)
+    instead.
+  - The new public surface is already self-documenting and test-covered:
+    - `AppendSource`, `LoadedAppendContent`,
+      `ResolveSupervisorAppendPromptInput`,
+      `ResolvedSupervisorAppendPrompt`, `ConventionPromptProbeResult`,
+      `LoadAppendPromptInput`, `LoadAppendPromptResult`, and the
+      discriminated `AppendPromptError` (`missing-file` / `oversize` /
+      `read-failed` variants) are named types whose shape is the
+      documentation; all are exercised by the 1,105-line suite in
+      `src/__tests__/claudeAppendPrompt.test.ts`.
+    - `resolveSupervisorAppendPrompt`, `probeConventionAppendPromptFile`,
+      `readAppendPromptFile`, `loadAppendPromptSource`,
+      `resolveAppendSystemPromptForEnvelope`, and
+      `formatUserSystemPromptSections` each have named parameters and
+      typed return values; the test suite covers precedence,
+      BOM/CRLF/trim semantics, the 64 KB byte cap boundary (`65536`
+      bytes accepted, `65537` bytes rejected — asserted at
+      `src/__tests__/claudeAppendPrompt.test.ts:359-360` and the
+      end-to-end launcher error message `/65536-byte cap/` +
+      `/65537 bytes/` at `:836-837`), `lstat`-guarded convention
+      probing, typed error contracts, single-channel stderr routing,
+      and `--print-config` output across every `AppendSource` value.
+  - PR-level CI is reported as `OPEN` with 4 pre-merge checks green and
+    only the docstring threshold flagged as a warning (not failing).
+- **Decision:** Decline.
+- **Rationale:** Generic bot threshold not aligned with repo TypeScript
+  conventions, not requested by the approved plan, not blocking CI, and the
+  affected new surface is already covered by a 1,105-line test suite
+  asserting both happy paths and typed error contracts. Adding JSDoc here
+  purely to satisfy a global CodeRabbit threshold would be scope creep on a
+  focused PR and would invite unrelated stylistic churn. The same decline
+  was applied on PR #50 (`plans/33-root-command-should-give-you-the-help/resolution-map.md`)
+  for the same threshold; staying consistent with that precedent.
+- **Approach:** No code change.
+- **Files To Change:** none.
+- **Reply Draft:**
+
+  > **[AI Agent]:** Acknowledged, but declining this pre-merge warning.
+  > It's a generic CodeRabbit threshold (12.90% vs. 80.00%) not tied to a
+  > specific correctness issue — the same review explicitly notes "No
+  > actionable comments were generated in the recent review. 🎉". The repo
+  > does not use JSDoc tag-based docstrings (zero `@param` / `@returns` /
+  > `@throws` across `src/`), and neither `AGENTS.md` nor the approved
+  > plan
+  > (`plans/56-make-system-prompt-configurable/plans/56-configurable-supervisor-system-prompt.md`)
+  > requires them. The new public surface is already self-documenting via
+  > named types (`AppendSource`, `LoadedAppendContent`,
+  > `ResolveSupervisorAppendPromptInput`,
+  > `ResolvedSupervisorAppendPrompt`, the discriminated `AppendPromptError`
+  > with `missing-file` / `oversize` / `read-failed` variants,
+  > `ConventionPromptProbeResult`, `LoadAppendPromptInput`,
+  > `LoadAppendPromptResult`) and covered by
+  > `src/__tests__/claudeAppendPrompt.test.ts` (1,105 lines) asserting
+  > precedence, BOM/CRLF/trim semantics, the 64 KB byte cap boundary
+  > (`65536` accepted, `65537` rejected — see
+  > `src/__tests__/claudeAppendPrompt.test.ts:359-360` and the launcher
+  > error-message assertions at `:836-837`), lstat-guarded convention
+  > probing, typed error contracts, single-channel stderr routing, and
+  > `--print-config` across every `AppendSource`. Same decline precedent
+  > as PR #50. Happy to revisit if we ever adopt a repo-wide JSDoc policy.
+  > <!-- agent-orchestrator:pr61:c1 -->
+
+## Comment C2 | Decline | Trivial
+
+- **Comment Type:** conversation (embedded LanguageTool grammar batch inside the CodeRabbit auto-summary comment)
+- **File(s):**
+  - `plans/56-make-system-prompt-configurable/plan.md:10`
+  - `plans/56-make-system-prompt-configurable/plans/56-configurable-supervisor-system-prompt.md:31`
+  - `plans/56-make-system-prompt-configurable/plans/56-configurable-supervisor-system-prompt.md:62`
+- **Comment ID:** `4431211822` (parent CodeRabbit summary)
+- **Review ID:** N/A
+- **Thread Node ID:** N/A (not posted as a review thread)
+- **Author:** `coderabbitai[bot]` (LanguageTool rule `QB_NEW_EN_HYPHEN`)
+- **Comment (verbatim excerpts):**
+
+  > `plans/56-make-system-prompt-configurable/plan.md`
+  > [grammar] ~10-~10: Use a hyphen to join words.
+  > Context: …(append)` section when non-empty. Worker run prompts and full-prompt replacement …
+  >
+  > `plans/56-make-system-prompt-configurable/plans/56-configurable-supervisor-system-prompt.md`
+  > [grammar] ~31-~31: Use a hyphen to join words.
+  > Context: …arness prompt. - Supervisor-only. Worker run prompts are out of scope. - Three su…
+  >
+  > [grammar] ~62-~62: Use a hyphen to join words.
+  > Context: …s blast radius small. | Also seed worker run prompts (rejected — separate user re…
+
+- **Independent Assessment:**
+  - All three flags are the same lemma — "Worker run prompts" / "worker
+    run prompts" — used as a noun phrase referring to the prompts passed
+    on a per-worker `start_run` (see Decision 2 in
+    `plans/56-make-system-prompt-configurable/plans/56-configurable-supervisor-system-prompt.md`).
+    "Worker-run" with a hyphen would read as a compound adjective
+    ("prompts that are worker-run"), which subtly drifts the meaning.
+    The plan author's intent is "prompts for worker runs" (the runs that
+    a worker performs), where "worker run" is itself a noun phrase used
+    throughout the codebase and docs (cf. `start_run`, "worker run
+    prompts", "worker run lifecycle"). LanguageTool's hyphenation rule is
+    a false positive for this lemma.
+  - Even if one preferred the hyphenated form, all three occurrences are
+    in plan/design documents under `plans/56-make-system-prompt-configurable/`,
+    which are historical project artifacts authored as decision records.
+    The repo treats those plan files as a record of decisions taken, not
+    as evergreen documentation that is rewritten for style.
+  - Neither `AGENTS.md` nor `.cursor/rules/node-typescript.mdc` requires
+    LanguageTool compliance. The repo carries an explicit learning record
+    (visible in the CodeRabbit comment itself) instructing that markdown
+    style false-positives should be tolerated when the original spelling
+    is intentional.
+  - No behavior change, no correctness impact, no test impact.
+- **Decision:** Decline.
+- **Rationale:** False-positive grammar suggestion on a noun-phrase used
+  consistently across the repo, located in immutable plan documents.
+  Touching plan docs after the plan has been executed (the implementation
+  commit `87ee632` ships against this plan) is the kind of stylistic churn
+  the repo's plan-archive convention deliberately avoids. There is no
+  user-facing surface affected.
+- **Approach:** No code change, no doc change.
+- **Files To Change:** none.
+- **Reply Draft:**
+
+  > **[AI Agent]:** Declining this LanguageTool batch. "Worker run prompts"
+  > is a noun phrase in this codebase — "worker run" is the noun (the
+  > per-worker run; cf. `start_run`, worker run lifecycle), and "prompts"
+  > is the head. Hyphenating to "Worker-run prompts" would reframe it as
+  > a compound adjective ("prompts that are run by workers"), which
+  > subtly shifts the meaning the plan is asserting. All three flags also
+  > fall in plan documents under `plans/56-make-system-prompt-configurable/`,
+  > which are decision-record artifacts the repo treats as immutable
+  > history. Neither `AGENTS.md` nor `.cursor/rules/node-typescript.mdc`
+  > requires LanguageTool compliance, and the repo's existing learning
+  > record explicitly tolerates similar markdown-style false positives.
+  > No behavior or contract change.
+  > <!-- agent-orchestrator:pr61:c2 -->

--- a/src/__tests__/claudeAppendPrompt.test.ts
+++ b/src/__tests__/claudeAppendPrompt.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdir, mkdtemp, readFile, symlink, writeFile, rm } from 'node:fs/promises';
+import { chmod, mkdir, mkdtemp, readFile, symlink, writeFile, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import {
@@ -36,6 +36,39 @@ function captureWritable(): { stream: NodeJS.WritableStream; text: () => string;
 
 async function makeTargetCwd(prefix: string): Promise<string> {
   return mkdtemp(join(tmpdir(), prefix));
+}
+
+async function writeFakeClaudeBinary(cwd: string): Promise<string> {
+  const fakeClaude = join(cwd, 'claude');
+  await writeFile(fakeClaude, `#!/usr/bin/env sh
+case "$1" in
+  --version)
+    printf '%s\\n' '99.0.0-test'
+    ;;
+  --help)
+    cat <<'EOF'
+Usage: claude [options]
+  --mcp-config <path>
+  --strict-mcp-config
+  --settings <path>
+  --setting-sources <sources>
+  --tools <tools>
+  --append-system-prompt-file <path>
+  --allowed-tools <tools>
+  --permission-mode <mode>
+EOF
+    ;;
+  *)
+    exit 1
+    ;;
+esac
+`, { mode: 0o755 });
+  await chmod(fakeClaude, 0o755);
+  return fakeClaude;
+}
+
+function withFakeClaudeBinary(args: readonly string[], claudeBinary: string): string[] {
+  return ['--claude-binary', claudeBinary, ...args];
 }
 
 describe('parseClaudeLauncherArgs append-system-prompt parsing', () => {
@@ -527,13 +560,14 @@ describe('buildSupervisorSystemPrompt user-append integration', () => {
 });
 
 describe('buildClaudeEnvelope append-prompt wiring', () => {
-  async function makeBaseCwd(prefix: string): Promise<{ cwd: string; skillsPath: string; stateDir: string }> {
+  async function makeBaseCwd(prefix: string): Promise<{ cwd: string; skillsPath: string; stateDir: string; claudeBinary: string }> {
     const cwd = await makeTargetCwd(prefix);
     const skillsPath = join(cwd, '.agents', 'skills');
     await mkdir(join(skillsPath, 'orchestrate-foo'), { recursive: true });
     await writeFile(join(skillsPath, 'orchestrate-foo', 'SKILL.md'), '---\nname: orchestrate-foo\n---\nbody');
     const stateDir = join(cwd, 'claude-state');
-    return { cwd, skillsPath, stateDir };
+    const claudeBinary = await writeFakeClaudeBinary(cwd);
+    return { cwd, skillsPath, stateDir, claudeBinary };
   }
 
   it('writes one concatenated system-prompt.md and keeps spawn args at a single --append-system-prompt-file', async () => {
@@ -667,13 +701,13 @@ describe('buildClaudeEnvelope append-prompt wiring', () => {
   });
 
   it('precedence-skip emits a single stderr notice via runClaudeLauncher and --print-config records the cli-inline source', async () => {
-    const { cwd, skillsPath, stateDir } = await makeBaseCwd('agent-claude-precedence-skip-');
+    const { cwd, skillsPath, stateDir, claudeBinary } = await makeBaseCwd('agent-claude-precedence-skip-');
     await mkdir(join(cwd, '.agents', 'orchestrator'), { recursive: true });
     await writeFile(join(cwd, CONVENTION_APPEND_PROMPT_RELATIVE_PATH), 'project default\n');
     const stdout = captureWritable();
     const stderr = captureWritable();
     const code = await runClaudeLauncher(
-      ['--cwd', cwd, '--skills', skillsPath, '--state-dir', stateDir, '--append-system-prompt', 'override', '--print-config'],
+      withFakeClaudeBinary(['--cwd', cwd, '--skills', skillsPath, '--state-dir', stateDir, '--append-system-prompt', 'override', '--print-config'], claudeBinary),
       { stdout: stdout.stream, stderr: stderr.stream, env: { AGENT_ORCHESTRATOR_BIN: '/opt/agent-orchestrator', AGENT_ORCHESTRATOR_HOME: join(cwd, 'home') } },
     );
     assert.equal(code, 0);
@@ -687,11 +721,11 @@ describe('buildClaudeEnvelope append-prompt wiring', () => {
   });
 
   it('missing CLI file fails the launch with a typed error and exit code 1', async () => {
-    const { cwd, skillsPath, stateDir } = await makeBaseCwd('agent-claude-missing-cli-file-');
+    const { cwd, skillsPath, stateDir, claudeBinary } = await makeBaseCwd('agent-claude-missing-cli-file-');
     const stdout = captureWritable();
     const stderr = captureWritable();
     const code = await runClaudeLauncher(
-      ['--cwd', cwd, '--skills', skillsPath, '--state-dir', stateDir, '--append-system-prompt-file', 'nonexistent.md', '--print-config'],
+      withFakeClaudeBinary(['--cwd', cwd, '--skills', skillsPath, '--state-dir', stateDir, '--append-system-prompt-file', 'nonexistent.md', '--print-config'], claudeBinary),
       { stdout: stdout.stream, stderr: stderr.stream, env: { AGENT_ORCHESTRATOR_BIN: '/opt/agent-orchestrator', AGENT_ORCHESTRATOR_HOME: join(cwd, 'home') } },
     );
     assert.equal(code, 1);
@@ -700,11 +734,11 @@ describe('buildClaudeEnvelope append-prompt wiring', () => {
   });
 
   it('missing env file fails the launch with a typed error and exit code 1', async () => {
-    const { cwd, skillsPath, stateDir } = await makeBaseCwd('agent-claude-missing-env-file-');
+    const { cwd, skillsPath, stateDir, claudeBinary } = await makeBaseCwd('agent-claude-missing-env-file-');
     const stdout = captureWritable();
     const stderr = captureWritable();
     const code = await runClaudeLauncher(
-      ['--cwd', cwd, '--skills', skillsPath, '--state-dir', stateDir, '--print-config'],
+      withFakeClaudeBinary(['--cwd', cwd, '--skills', skillsPath, '--state-dir', stateDir, '--print-config'], claudeBinary),
       {
         stdout: stdout.stream,
         stderr: stderr.stream,
@@ -721,7 +755,7 @@ describe('buildClaudeEnvelope append-prompt wiring', () => {
   });
 
   it('--no-append-system-prompt short-circuits CLI, env, and convention sources to "none"', async () => {
-    const { cwd, skillsPath, stateDir } = await makeBaseCwd('agent-claude-no-append-');
+    const { cwd, skillsPath, stateDir, claudeBinary } = await makeBaseCwd('agent-claude-no-append-');
     await mkdir(join(cwd, '.agents', 'orchestrator'), { recursive: true });
     await writeFile(join(cwd, CONVENTION_APPEND_PROMPT_RELATIVE_PATH), 'project default\n');
     const cliFile = join(cwd, 'cli.md');
@@ -731,7 +765,7 @@ describe('buildClaudeEnvelope append-prompt wiring', () => {
     const stdout = captureWritable();
     const stderr = captureWritable();
     const code = await runClaudeLauncher(
-      ['--cwd', cwd, '--skills', skillsPath, '--state-dir', stateDir, '--no-append-system-prompt', '--append-system-prompt', 'cli inline', '--print-config'],
+      withFakeClaudeBinary(['--cwd', cwd, '--skills', skillsPath, '--state-dir', stateDir, '--no-append-system-prompt', '--append-system-prompt', 'cli inline', '--print-config'], claudeBinary),
       {
         stdout: stdout.stream,
         stderr: stderr.stream,
@@ -751,7 +785,7 @@ describe('buildClaudeEnvelope append-prompt wiring', () => {
   });
 
   it('non-regular convention file (symlink) is refused and surfaces the lstat skip notice exactly once via runClaudeLauncher', async () => {
-    const { cwd, skillsPath, stateDir } = await makeBaseCwd('agent-claude-convention-symlink-');
+    const { cwd, skillsPath, stateDir, claudeBinary } = await makeBaseCwd('agent-claude-convention-symlink-');
     const sensitive = join(cwd, 'sensitive.txt');
     await writeFile(sensitive, 'do-not-load');
     await mkdir(join(cwd, '.agents', 'orchestrator'), { recursive: true });
@@ -759,7 +793,7 @@ describe('buildClaudeEnvelope append-prompt wiring', () => {
     const stdout = captureWritable();
     const stderr = captureWritable();
     const code = await runClaudeLauncher(
-      ['--cwd', cwd, '--skills', skillsPath, '--state-dir', stateDir, '--print-config'],
+      withFakeClaudeBinary(['--cwd', cwd, '--skills', skillsPath, '--state-dir', stateDir, '--print-config'], claudeBinary),
       { stdout: stdout.stream, stderr: stderr.stream, env: { AGENT_ORCHESTRATOR_BIN: '/opt/agent-orchestrator', AGENT_ORCHESTRATOR_HOME: join(cwd, 'home') } },
     );
     assert.equal(code, 0);
@@ -771,12 +805,12 @@ describe('buildClaudeEnvelope append-prompt wiring', () => {
   });
 
   it('non-regular convention file (directory) is refused and surfaces the lstat skip notice exactly once', async () => {
-    const { cwd, skillsPath, stateDir } = await makeBaseCwd('agent-claude-convention-dir-');
+    const { cwd, skillsPath, stateDir, claudeBinary } = await makeBaseCwd('agent-claude-convention-dir-');
     await mkdir(join(cwd, CONVENTION_APPEND_PROMPT_RELATIVE_PATH), { recursive: true });
     const stdout = captureWritable();
     const stderr = captureWritable();
     const code = await runClaudeLauncher(
-      ['--cwd', cwd, '--skills', skillsPath, '--state-dir', stateDir, '--print-config'],
+      withFakeClaudeBinary(['--cwd', cwd, '--skills', skillsPath, '--state-dir', stateDir, '--print-config'], claudeBinary),
       { stdout: stdout.stream, stderr: stderr.stream, env: { AGENT_ORCHESTRATOR_BIN: '/opt/agent-orchestrator', AGENT_ORCHESTRATOR_HOME: join(cwd, 'home') } },
     );
     assert.equal(code, 0);
@@ -785,7 +819,7 @@ describe('buildClaudeEnvelope append-prompt wiring', () => {
   });
 
   it('CLI-named symlink is read as-is (not refused by the lstat guard, which is convention-only)', async () => {
-    const { cwd, skillsPath, stateDir } = await makeBaseCwd('agent-claude-cli-symlink-');
+    const { cwd, skillsPath, stateDir, claudeBinary } = await makeBaseCwd('agent-claude-cli-symlink-');
     const target = join(cwd, 'prompt-target.md');
     await writeFile(target, 'linked supervisor text\n');
     const linkPath = join(cwd, 'prompt-link.md');
@@ -793,7 +827,7 @@ describe('buildClaudeEnvelope append-prompt wiring', () => {
     const stdout = captureWritable();
     const stderr = captureWritable();
     const code = await runClaudeLauncher(
-      ['--cwd', cwd, '--skills', skillsPath, '--state-dir', stateDir, '--append-system-prompt-file', 'prompt-link.md', '--print-config'],
+      withFakeClaudeBinary(['--cwd', cwd, '--skills', skillsPath, '--state-dir', stateDir, '--append-system-prompt-file', 'prompt-link.md', '--print-config'], claudeBinary),
       { stdout: stdout.stream, stderr: stderr.stream, env: { AGENT_ORCHESTRATOR_BIN: '/opt/agent-orchestrator', AGENT_ORCHESTRATOR_HOME: join(cwd, 'home') } },
     );
     assert.equal(code, 0);
@@ -805,13 +839,13 @@ describe('buildClaudeEnvelope append-prompt wiring', () => {
   });
 
   it('--print-config emits the source line with an (empty) annotation when text is whitespace-only', async () => {
-    const { cwd, skillsPath, stateDir } = await makeBaseCwd('agent-claude-empty-text-');
+    const { cwd, skillsPath, stateDir, claudeBinary } = await makeBaseCwd('agent-claude-empty-text-');
     const emptyFile = join(cwd, 'empty.md');
     await writeFile(emptyFile, '   \n\t  \n');
     const stdout = captureWritable();
     const stderr = captureWritable();
     const code = await runClaudeLauncher(
-      ['--cwd', cwd, '--skills', skillsPath, '--state-dir', stateDir, '--append-system-prompt-file', 'empty.md', '--print-config'],
+      withFakeClaudeBinary(['--cwd', cwd, '--skills', skillsPath, '--state-dir', stateDir, '--append-system-prompt-file', 'empty.md', '--print-config'], claudeBinary),
       { stdout: stdout.stream, stderr: stderr.stream, env: { AGENT_ORCHESTRATOR_BIN: '/opt/agent-orchestrator', AGENT_ORCHESTRATOR_HOME: join(cwd, 'home') } },
     );
     assert.equal(code, 0);
@@ -823,13 +857,13 @@ describe('buildClaudeEnvelope append-prompt wiring', () => {
   });
 
   it('oversize CLI file fails the launch with the byte-cap message naming the source and path', async () => {
-    const { cwd, skillsPath, stateDir } = await makeBaseCwd('agent-claude-oversize-');
+    const { cwd, skillsPath, stateDir, claudeBinary } = await makeBaseCwd('agent-claude-oversize-');
     const big = join(cwd, 'big.md');
     await writeFile(big, Buffer.alloc(SUPERVISOR_APPEND_PROMPT_BYTE_CAP + 1, 0x61));
     const stdout = captureWritable();
     const stderr = captureWritable();
     const code = await runClaudeLauncher(
-      ['--cwd', cwd, '--skills', skillsPath, '--state-dir', stateDir, '--append-system-prompt-file', 'big.md', '--print-config'],
+      withFakeClaudeBinary(['--cwd', cwd, '--skills', skillsPath, '--state-dir', stateDir, '--append-system-prompt-file', 'big.md', '--print-config'], claudeBinary),
       { stdout: stdout.stream, stderr: stderr.stream, env: { AGENT_ORCHESTRATOR_BIN: '/opt/agent-orchestrator', AGENT_ORCHESTRATOR_HOME: join(cwd, 'home') } },
     );
     assert.equal(code, 1);
@@ -840,11 +874,11 @@ describe('buildClaudeEnvelope append-prompt wiring', () => {
   });
 
   it('no append source emits the # user system prompt source line with the none sentinel in --print-config', async () => {
-    const { cwd, skillsPath, stateDir } = await makeBaseCwd('agent-claude-print-none-');
+    const { cwd, skillsPath, stateDir, claudeBinary } = await makeBaseCwd('agent-claude-print-none-');
     const stdout = captureWritable();
     const stderr = captureWritable();
     const code = await runClaudeLauncher(
-      ['--cwd', cwd, '--skills', skillsPath, '--state-dir', stateDir, '--print-config'],
+      withFakeClaudeBinary(['--cwd', cwd, '--skills', skillsPath, '--state-dir', stateDir, '--print-config'], claudeBinary),
       { stdout: stdout.stream, stderr: stderr.stream, env: { AGENT_ORCHESTRATOR_BIN: '/opt/agent-orchestrator', AGENT_ORCHESTRATOR_HOME: join(cwd, 'home') } },
     );
     assert.equal(code, 0);
@@ -855,11 +889,11 @@ describe('buildClaudeEnvelope append-prompt wiring', () => {
   });
 
   it('cli-inline wins over a missing AGENT_ORCHESTRATOR_CLAUDE_APPEND_SYSTEM_PROMPT_FILE: preempted file is never read', async () => {
-    const { cwd, skillsPath, stateDir } = await makeBaseCwd('agent-claude-preempt-missing-env-file-');
+    const { cwd, skillsPath, stateDir, claudeBinary } = await makeBaseCwd('agent-claude-preempt-missing-env-file-');
     const stdout = captureWritable();
     const stderr = captureWritable();
     const code = await runClaudeLauncher(
-      ['--cwd', cwd, '--skills', skillsPath, '--state-dir', stateDir, '--append-system-prompt', 'cli wins', '--print-config'],
+      withFakeClaudeBinary(['--cwd', cwd, '--skills', skillsPath, '--state-dir', stateDir, '--append-system-prompt', 'cli wins', '--print-config'], claudeBinary),
       {
         stdout: stdout.stream,
         stderr: stderr.stream,
@@ -878,13 +912,13 @@ describe('buildClaudeEnvelope append-prompt wiring', () => {
   });
 
   it('cli-inline wins over an oversize AGENT_ORCHESTRATOR_CLAUDE_APPEND_SYSTEM_PROMPT_FILE: preempted file is never read', async () => {
-    const { cwd, skillsPath, stateDir } = await makeBaseCwd('agent-claude-preempt-oversize-env-file-');
+    const { cwd, skillsPath, stateDir, claudeBinary } = await makeBaseCwd('agent-claude-preempt-oversize-env-file-');
     const oversize = join(cwd, 'oversize.md');
     await writeFile(oversize, Buffer.alloc(SUPERVISOR_APPEND_PROMPT_BYTE_CAP + 4096, 0x61));
     const stdout = captureWritable();
     const stderr = captureWritable();
     const code = await runClaudeLauncher(
-      ['--cwd', cwd, '--skills', skillsPath, '--state-dir', stateDir, '--append-system-prompt', 'cli wins', '--print-config'],
+      withFakeClaudeBinary(['--cwd', cwd, '--skills', skillsPath, '--state-dir', stateDir, '--append-system-prompt', 'cli wins', '--print-config'], claudeBinary),
       {
         stdout: stdout.stream,
         stderr: stderr.stream,
@@ -901,7 +935,7 @@ describe('buildClaudeEnvelope append-prompt wiring', () => {
 
   it('cli-inline wins over an unreadable convention file: convention body is never read (precedence-skip notice fires, the bad bytes do not)', async () => {
     if (process.getuid?.() === 0) return; // root bypasses permission bits; skip
-    const { cwd, skillsPath, stateDir } = await makeBaseCwd('agent-claude-preempt-unreadable-convention-');
+    const { cwd, skillsPath, stateDir, claudeBinary } = await makeBaseCwd('agent-claude-preempt-unreadable-convention-');
     await mkdir(join(cwd, '.agents', 'orchestrator'), { recursive: true });
     const conventionPath = join(cwd, CONVENTION_APPEND_PROMPT_RELATIVE_PATH);
     await writeFile(conventionPath, 'convention body');
@@ -911,7 +945,7 @@ describe('buildClaudeEnvelope append-prompt wiring', () => {
       const stdout = captureWritable();
       const stderr = captureWritable();
       const code = await runClaudeLauncher(
-        ['--cwd', cwd, '--skills', skillsPath, '--state-dir', stateDir, '--append-system-prompt', 'cli wins', '--print-config'],
+        withFakeClaudeBinary(['--cwd', cwd, '--skills', skillsPath, '--state-dir', stateDir, '--append-system-prompt', 'cli wins', '--print-config'], claudeBinary),
         { stdout: stdout.stream, stderr: stderr.stream, env: { AGENT_ORCHESTRATOR_BIN: '/opt/agent-orchestrator', AGENT_ORCHESTRATOR_HOME: join(cwd, 'home') } },
       );
       assert.equal(code, 0, 'cli-inline wins; the preempted convention file must not be read');
@@ -924,13 +958,13 @@ describe('buildClaudeEnvelope append-prompt wiring', () => {
   });
 
   it('--no-append-system-prompt suppresses cli-file only (no parse error, source=none)', async () => {
-    const { cwd, skillsPath, stateDir } = await makeBaseCwd('agent-claude-no-suppress-cli-file-');
+    const { cwd, skillsPath, stateDir, claudeBinary } = await makeBaseCwd('agent-claude-no-suppress-cli-file-');
     const cliFile = join(cwd, 'cli.md');
     await writeFile(cliFile, 'cli file body');
     const stdout = captureWritable();
     const stderr = captureWritable();
     const code = await runClaudeLauncher(
-      ['--cwd', cwd, '--skills', skillsPath, '--state-dir', stateDir, '--no-append-system-prompt', '--append-system-prompt-file', 'cli.md', '--print-config'],
+      withFakeClaudeBinary(['--cwd', cwd, '--skills', skillsPath, '--state-dir', stateDir, '--no-append-system-prompt', '--append-system-prompt-file', 'cli.md', '--print-config'], claudeBinary),
       { stdout: stdout.stream, stderr: stderr.stream, env: { AGENT_ORCHESTRATOR_BIN: '/opt/agent-orchestrator', AGENT_ORCHESTRATOR_HOME: join(cwd, 'home') } },
     );
     assert.equal(code, 0);
@@ -939,11 +973,11 @@ describe('buildClaudeEnvelope append-prompt wiring', () => {
   });
 
   it('--no-append-system-prompt suppresses env-inline only', async () => {
-    const { cwd, skillsPath, stateDir } = await makeBaseCwd('agent-claude-no-suppress-env-inline-');
+    const { cwd, skillsPath, stateDir, claudeBinary } = await makeBaseCwd('agent-claude-no-suppress-env-inline-');
     const stdout = captureWritable();
     const stderr = captureWritable();
     const code = await runClaudeLauncher(
-      ['--cwd', cwd, '--skills', skillsPath, '--state-dir', stateDir, '--no-append-system-prompt', '--print-config'],
+      withFakeClaudeBinary(['--cwd', cwd, '--skills', skillsPath, '--state-dir', stateDir, '--no-append-system-prompt', '--print-config'], claudeBinary),
       {
         stdout: stdout.stream,
         stderr: stderr.stream,
@@ -960,13 +994,13 @@ describe('buildClaudeEnvelope append-prompt wiring', () => {
   });
 
   it('--no-append-system-prompt suppresses env-file only', async () => {
-    const { cwd, skillsPath, stateDir } = await makeBaseCwd('agent-claude-no-suppress-env-file-');
+    const { cwd, skillsPath, stateDir, claudeBinary } = await makeBaseCwd('agent-claude-no-suppress-env-file-');
     const envFile = join(cwd, 'env.md');
     await writeFile(envFile, 'env file body');
     const stdout = captureWritable();
     const stderr = captureWritable();
     const code = await runClaudeLauncher(
-      ['--cwd', cwd, '--skills', skillsPath, '--state-dir', stateDir, '--no-append-system-prompt', '--print-config'],
+      withFakeClaudeBinary(['--cwd', cwd, '--skills', skillsPath, '--state-dir', stateDir, '--no-append-system-prompt', '--print-config'], claudeBinary),
       {
         stdout: stdout.stream,
         stderr: stderr.stream,
@@ -983,13 +1017,13 @@ describe('buildClaudeEnvelope append-prompt wiring', () => {
   });
 
   it('--no-append-system-prompt suppresses a present convention file (no stderr, source=none, body not read)', async () => {
-    const { cwd, skillsPath, stateDir } = await makeBaseCwd('agent-claude-no-suppress-convention-');
+    const { cwd, skillsPath, stateDir, claudeBinary } = await makeBaseCwd('agent-claude-no-suppress-convention-');
     await mkdir(join(cwd, '.agents', 'orchestrator'), { recursive: true });
     await writeFile(join(cwd, CONVENTION_APPEND_PROMPT_RELATIVE_PATH), 'convention body');
     const stdout = captureWritable();
     const stderr = captureWritable();
     const code = await runClaudeLauncher(
-      ['--cwd', cwd, '--skills', skillsPath, '--state-dir', stateDir, '--no-append-system-prompt', '--print-config'],
+      withFakeClaudeBinary(['--cwd', cwd, '--skills', skillsPath, '--state-dir', stateDir, '--no-append-system-prompt', '--print-config'], claudeBinary),
       { stdout: stdout.stream, stderr: stderr.stream, env: { AGENT_ORCHESTRATOR_BIN: '/opt/agent-orchestrator', AGENT_ORCHESTRATOR_HOME: join(cwd, 'home') } },
     );
     assert.equal(code, 0);
@@ -999,13 +1033,13 @@ describe('buildClaudeEnvelope append-prompt wiring', () => {
   });
 
   it('--no-append-system-prompt overrides the CLI inline+file conflict (escape hatch wins)', async () => {
-    const { cwd, skillsPath, stateDir } = await makeBaseCwd('agent-claude-no-escape-cli-conflict-');
+    const { cwd, skillsPath, stateDir, claudeBinary } = await makeBaseCwd('agent-claude-no-escape-cli-conflict-');
     const cliFile = join(cwd, 'cli.md');
     await writeFile(cliFile, 'cli file body');
     const stdout = captureWritable();
     const stderr = captureWritable();
     const code = await runClaudeLauncher(
-      ['--cwd', cwd, '--skills', skillsPath, '--state-dir', stateDir, '--no-append-system-prompt', '--append-system-prompt', 'inline', '--append-system-prompt-file', 'cli.md', '--print-config'],
+      withFakeClaudeBinary(['--cwd', cwd, '--skills', skillsPath, '--state-dir', stateDir, '--no-append-system-prompt', '--append-system-prompt', 'inline', '--append-system-prompt-file', 'cli.md', '--print-config'], claudeBinary),
       { stdout: stdout.stream, stderr: stderr.stream, env: { AGENT_ORCHESTRATOR_BIN: '/opt/agent-orchestrator', AGENT_ORCHESTRATOR_HOME: join(cwd, 'home') } },
     );
     assert.equal(code, 0);
@@ -1013,11 +1047,11 @@ describe('buildClaudeEnvelope append-prompt wiring', () => {
   });
 
   it('--no-append-system-prompt overrides the env inline+file conflict (escape hatch wins)', async () => {
-    const { cwd, skillsPath, stateDir } = await makeBaseCwd('agent-claude-no-escape-env-conflict-');
+    const { cwd, skillsPath, stateDir, claudeBinary } = await makeBaseCwd('agent-claude-no-escape-env-conflict-');
     const stdout = captureWritable();
     const stderr = captureWritable();
     const code = await runClaudeLauncher(
-      ['--cwd', cwd, '--skills', skillsPath, '--state-dir', stateDir, '--no-append-system-prompt', '--print-config'],
+      withFakeClaudeBinary(['--cwd', cwd, '--skills', skillsPath, '--state-dir', stateDir, '--no-append-system-prompt', '--print-config'], claudeBinary),
       {
         stdout: stdout.stream,
         stderr: stderr.stream,
@@ -1034,7 +1068,7 @@ describe('buildClaudeEnvelope append-prompt wiring', () => {
   });
 
   it('env-named symlink is read as-is (lstat guard is convention-only)', async () => {
-    const { cwd, skillsPath, stateDir } = await makeBaseCwd('agent-claude-env-symlink-');
+    const { cwd, skillsPath, stateDir, claudeBinary } = await makeBaseCwd('agent-claude-env-symlink-');
     const target = join(cwd, 'env-target.md');
     await writeFile(target, 'env-supervisor text via symlink\n');
     const linkPath = join(cwd, 'env-link.md');
@@ -1042,7 +1076,7 @@ describe('buildClaudeEnvelope append-prompt wiring', () => {
     const stdout = captureWritable();
     const stderr = captureWritable();
     const code = await runClaudeLauncher(
-      ['--cwd', cwd, '--skills', skillsPath, '--state-dir', stateDir, '--print-config'],
+      withFakeClaudeBinary(['--cwd', cwd, '--skills', skillsPath, '--state-dir', stateDir, '--print-config'], claudeBinary),
       {
         stdout: stdout.stream,
         stderr: stderr.stream,

--- a/src/__tests__/claudeAppendPrompt.test.ts
+++ b/src/__tests__/claudeAppendPrompt.test.ts
@@ -1,0 +1,1105 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdir, mkdtemp, readFile, symlink, writeFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  CONVENTION_APPEND_PROMPT_RELATIVE_PATH,
+  SUPERVISOR_APPEND_PROMPT_BYTE_CAP,
+  SUPERVISOR_APPEND_PROMPT_DELIMITER,
+  resolveSupervisorAppendPrompt,
+} from '../claude/appendPrompt.js';
+import { buildClaudeHarnessConfig } from '../claude/config.js';
+import {
+  buildClaudeEnvelope,
+  parseClaudeLauncherArgs,
+  runClaudeLauncher,
+} from '../claude/launcher.js';
+import { resolveMonitorPin } from '../claude/monitorPin.js';
+import { createWorkerCapabilityCatalog } from '../harness/capabilities.js';
+
+function captureWritable(): { stream: NodeJS.WritableStream; text: () => string; count: () => number } {
+  let acc = '';
+  let calls = 0;
+  return {
+    stream: {
+      write: (chunk: string | Uint8Array) => {
+        calls += 1;
+        acc += typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString('utf8');
+        return true;
+      },
+    } as unknown as NodeJS.WritableStream,
+    text: () => acc,
+    count: () => calls,
+  };
+}
+
+async function makeTargetCwd(prefix: string): Promise<string> {
+  return mkdtemp(join(tmpdir(), prefix));
+}
+
+describe('parseClaudeLauncherArgs append-system-prompt parsing', () => {
+  it('accepts --append-system-prompt inline text and reports it as cli-inline candidate', async () => {
+    const cwd = await makeTargetCwd('agent-claude-append-cli-inline-');
+    const parsed = parseClaudeLauncherArgs(
+      ['--cwd', cwd, '--append-system-prompt', 'Hello supervisor'],
+      {},
+      cwd,
+    );
+    assert.equal(parsed.ok, true);
+    if (!parsed.ok) return;
+    assert.equal(parsed.value.appendCandidates.cliInline, 'Hello supervisor');
+    assert.equal(parsed.value.appendCandidates.cliFile, null);
+    assert.equal(parsed.value.disableAppendSystemPrompt, false);
+  });
+
+  it('accepts --append-system-prompt-file and resolves the path against the resolved target cwd', async () => {
+    const cwd = await makeTargetCwd('agent-claude-append-cli-file-');
+    const parsed = parseClaudeLauncherArgs(
+      ['--cwd', cwd, '--append-system-prompt-file', 'prompts/extra.md'],
+      {},
+      cwd,
+    );
+    assert.equal(parsed.ok, true);
+    if (!parsed.ok) return;
+    assert.equal(parsed.value.appendCandidates.cliFile, join(cwd, 'prompts/extra.md'));
+  });
+
+  it('reads AGENT_ORCHESTRATOR_CLAUDE_APPEND_SYSTEM_PROMPT and ..._FILE as env candidates', async () => {
+    const cwd = await makeTargetCwd('agent-claude-append-env-');
+    const inlineParsed = parseClaudeLauncherArgs(
+      ['--cwd', cwd],
+      { AGENT_ORCHESTRATOR_CLAUDE_APPEND_SYSTEM_PROMPT: 'env text' },
+      cwd,
+    );
+    assert.equal(inlineParsed.ok, true);
+    if (!inlineParsed.ok) return;
+    assert.equal(inlineParsed.value.appendCandidates.envInline, 'env text');
+    assert.equal(inlineParsed.value.appendCandidates.envFile, null);
+
+    const fileParsed = parseClaudeLauncherArgs(
+      ['--cwd', cwd],
+      { AGENT_ORCHESTRATOR_CLAUDE_APPEND_SYSTEM_PROMPT_FILE: 'prompts/env.md' },
+      cwd,
+    );
+    assert.equal(fileParsed.ok, true);
+    if (!fileParsed.ok) return;
+    assert.equal(fileParsed.value.appendCandidates.envInline, null);
+    assert.equal(fileParsed.value.appendCandidates.envFile, join(cwd, 'prompts/env.md'));
+  });
+
+  it('captures --no-append-system-prompt as disableAppendSystemPrompt: true and overrides every conflict check', async () => {
+    const cwd = await makeTargetCwd('agent-claude-append-disable-');
+    // Per Decision 9 the escape hatch must override CLI inline+file and env
+    // inline+file conflicts; otherwise an operator cannot bypass a
+    // misconfigured environment with --no-append-system-prompt alone.
+    const parsedCliConflict = parseClaudeLauncherArgs(
+      ['--cwd', cwd, '--no-append-system-prompt', '--append-system-prompt', 'ignored', '--append-system-prompt-file', 'ignored.md'],
+      {
+        AGENT_ORCHESTRATOR_CLAUDE_APPEND_SYSTEM_PROMPT: 'envtext',
+        AGENT_ORCHESTRATOR_CLAUDE_APPEND_SYSTEM_PROMPT_FILE: 'envfile.md',
+      },
+      cwd,
+    );
+    assert.equal(parsedCliConflict.ok, true);
+    if (!parsedCliConflict.ok) return;
+    assert.equal(parsedCliConflict.value.disableAppendSystemPrompt, true);
+    assert.equal(parsedCliConflict.value.appendCandidates.cliInline, 'ignored');
+    assert.equal(parsedCliConflict.value.appendCandidates.cliFile, join(cwd, 'ignored.md'));
+    assert.equal(parsedCliConflict.value.appendCandidates.envInline, 'envtext');
+    assert.equal(parsedCliConflict.value.appendCandidates.envFile, join(cwd, 'envfile.md'));
+
+    // Without --no-append-system-prompt the CLI inline+file conflict still fails.
+    const parsedConflictNoEscape = parseClaudeLauncherArgs(
+      ['--cwd', cwd, '--append-system-prompt', 'a', '--append-system-prompt-file', 'b'],
+      {},
+      cwd,
+    );
+    assert.equal(parsedConflictNoEscape.ok, false);
+  });
+
+  it('rejects --append-system-prompt + --append-system-prompt-file with the exact contract message', async () => {
+    const cwd = await makeTargetCwd('agent-claude-append-cli-conflict-');
+    const parsed = parseClaudeLauncherArgs(
+      ['--cwd', cwd, '--append-system-prompt', 'x', '--append-system-prompt-file', 'y'],
+      {},
+      cwd,
+    );
+    assert.equal(parsed.ok, false);
+    if (parsed.ok) return;
+    assert.equal(
+      parsed.error,
+      'Cannot combine --append-system-prompt and --append-system-prompt-file. Choose one or use --no-append-system-prompt to disable both.',
+    );
+  });
+
+  it('rejects AGENT_ORCHESTRATOR_CLAUDE_APPEND_SYSTEM_PROMPT + ..._FILE with the exact symmetric contract message', async () => {
+    const cwd = await makeTargetCwd('agent-claude-append-env-conflict-');
+    const parsed = parseClaudeLauncherArgs(
+      ['--cwd', cwd],
+      {
+        AGENT_ORCHESTRATOR_CLAUDE_APPEND_SYSTEM_PROMPT: 'x',
+        AGENT_ORCHESTRATOR_CLAUDE_APPEND_SYSTEM_PROMPT_FILE: 'y',
+      },
+      cwd,
+    );
+    assert.equal(parsed.ok, false);
+    if (parsed.ok) return;
+    assert.equal(
+      parsed.error,
+      'Cannot combine AGENT_ORCHESTRATOR_CLAUDE_APPEND_SYSTEM_PROMPT and AGENT_ORCHESTRATOR_CLAUDE_APPEND_SYSTEM_PROMPT_FILE. Set one or use --no-append-system-prompt to disable both.',
+    );
+  });
+
+  it('treats empty env-var values as unset and falls through to the next precedence step', async () => {
+    const cwd = await makeTargetCwd('agent-claude-empty-env-');
+    const parsed = parseClaudeLauncherArgs(
+      ['--cwd', cwd],
+      {
+        AGENT_ORCHESTRATOR_CLAUDE_APPEND_SYSTEM_PROMPT: '',
+        AGENT_ORCHESTRATOR_CLAUDE_APPEND_SYSTEM_PROMPT_FILE: '',
+      },
+      cwd,
+    );
+    // Both env vars set but empty → both treated as unset, no conflict error.
+    assert.equal(parsed.ok, true);
+    if (!parsed.ok) return;
+    assert.equal(parsed.value.appendCandidates.envInline, null);
+    assert.equal(parsed.value.appendCandidates.envFile, null);
+  });
+
+  it('resolves --append-system-prompt-file and env-file paths against the resolved target cwd, not defaultCwd/process.cwd', async () => {
+    const targetCwd = await makeTargetCwd('agent-claude-cwd-target-');
+    const launcherCwd = await makeTargetCwd('agent-claude-cwd-launcher-');
+    const parsed = parseClaudeLauncherArgs(
+      ['--cwd', targetCwd, '--append-system-prompt-file', 'prompts/cli.md'],
+      { AGENT_ORCHESTRATOR_CLAUDE_APPEND_SYSTEM_PROMPT_FILE: 'prompts/env.md' },
+      launcherCwd,
+    );
+    assert.equal(parsed.ok, true);
+    if (!parsed.ok) return;
+    assert.equal(parsed.value.cwd, targetCwd);
+    assert.equal(parsed.value.appendCandidates.cliFile, join(targetCwd, 'prompts/cli.md'));
+    assert.equal(parsed.value.appendCandidates.envFile, join(targetCwd, 'prompts/env.md'));
+    assert.equal(parsed.value.appendCandidates.cliFile?.startsWith(launcherCwd), false);
+    assert.equal(parsed.value.appendCandidates.envFile?.startsWith(launcherCwd), false);
+  });
+});
+
+describe('resolveSupervisorAppendPrompt precedence and decoding', () => {
+  const conventionPath = '/tmp/work/.agents/orchestrator/system-prompt.md';
+
+  it('cli-inline wins over every lower-precedence source', () => {
+    const result = resolveSupervisorAppendPrompt({
+      cliInlineText: 'cli text',
+      cliFilePath: '/tmp/cli.md',
+      envInlineText: 'env text',
+      envFilePath: '/tmp/env.md',
+      conventionFilePath: conventionPath,
+      conventionFilePresent: true,
+      disable: false,
+      loaded: {
+        cliFile: { bytes: Buffer.from('cli file body'), path: '/tmp/cli.md' },
+        envFile: { bytes: Buffer.from('env file body'), path: '/tmp/env.md' },
+        convention: { bytes: Buffer.from('convention body'), path: conventionPath },
+      },
+    });
+    assert.equal(result.ok, true);
+    if (!result.ok) return;
+    assert.equal(result.value.source, 'cli-inline');
+    assert.equal(result.value.text, 'cli text');
+    assert.equal(result.value.path, null);
+    assert.match(result.value.conventionSkipNotice ?? '', /preempted by --append-system-prompt/);
+  });
+
+  it('cli-file preempts env-inline, env-file, and convention', () => {
+    const result = resolveSupervisorAppendPrompt({
+      cliInlineText: null,
+      cliFilePath: '/tmp/cli.md',
+      envInlineText: 'env',
+      envFilePath: '/tmp/env.md',
+      conventionFilePath: conventionPath,
+      conventionFilePresent: true,
+      disable: false,
+      loaded: {
+        cliFile: { bytes: Buffer.from('cli file body'), path: '/tmp/cli.md' },
+        envFile: { bytes: Buffer.from('env body'), path: '/tmp/env.md' },
+        convention: { bytes: Buffer.from('convention'), path: conventionPath },
+      },
+    });
+    assert.equal(result.ok, true);
+    if (!result.ok) return;
+    assert.equal(result.value.source, 'cli-file');
+    assert.equal(result.value.text, 'cli file body');
+    assert.equal(result.value.path, '/tmp/cli.md');
+    assert.match(result.value.conventionSkipNotice ?? '', /preempted by --append-system-prompt-file/);
+  });
+
+  it('env-inline preempts env-file and convention but not CLI', () => {
+    const result = resolveSupervisorAppendPrompt({
+      cliInlineText: null,
+      cliFilePath: null,
+      envInlineText: 'env inline',
+      envFilePath: '/tmp/env.md',
+      conventionFilePath: conventionPath,
+      conventionFilePresent: true,
+      disable: false,
+      loaded: {
+        envFile: { bytes: Buffer.from('env file'), path: '/tmp/env.md' },
+        convention: { bytes: Buffer.from('convention'), path: conventionPath },
+      },
+    });
+    assert.equal(result.ok, true);
+    if (!result.ok) return;
+    assert.equal(result.value.source, 'env-inline');
+    assert.equal(result.value.text, 'env inline');
+    assert.match(result.value.conventionSkipNotice ?? '', /preempted by AGENT_ORCHESTRATOR_CLAUDE_APPEND_SYSTEM_PROMPT$/);
+  });
+
+  it('env-file preempts convention', () => {
+    const result = resolveSupervisorAppendPrompt({
+      cliInlineText: null,
+      cliFilePath: null,
+      envInlineText: null,
+      envFilePath: '/tmp/env.md',
+      conventionFilePath: conventionPath,
+      conventionFilePresent: true,
+      disable: false,
+      loaded: {
+        envFile: { bytes: Buffer.from('env file body'), path: '/tmp/env.md' },
+        convention: { bytes: Buffer.from('convention body'), path: conventionPath },
+      },
+    });
+    assert.equal(result.ok, true);
+    if (!result.ok) return;
+    assert.equal(result.value.source, 'env-file');
+    assert.equal(result.value.text, 'env file body');
+    assert.match(result.value.conventionSkipNotice ?? '', /preempted by AGENT_ORCHESTRATOR_CLAUDE_APPEND_SYSTEM_PROMPT_FILE/);
+  });
+
+  it('convention selected when no higher-precedence source is set and emits no skip notice', () => {
+    const result = resolveSupervisorAppendPrompt({
+      cliInlineText: null,
+      cliFilePath: null,
+      envInlineText: null,
+      envFilePath: null,
+      conventionFilePath: conventionPath,
+      conventionFilePresent: true,
+      disable: false,
+      loaded: {
+        convention: { bytes: Buffer.from('convention body\n'), path: conventionPath },
+      },
+    });
+    assert.equal(result.ok, true);
+    if (!result.ok) return;
+    assert.equal(result.value.source, 'convention-file');
+    assert.equal(result.value.text, 'convention body');
+    assert.equal(result.value.conventionSkipNotice, null);
+  });
+
+  it('returns source none when nothing is set', () => {
+    const result = resolveSupervisorAppendPrompt({
+      cliInlineText: null,
+      cliFilePath: null,
+      envInlineText: null,
+      envFilePath: null,
+      conventionFilePath: conventionPath,
+      conventionFilePresent: false,
+      disable: false,
+      loaded: {},
+    });
+    assert.equal(result.ok, true);
+    if (!result.ok) return;
+    assert.equal(result.value.source, 'none');
+    assert.equal(result.value.text, null);
+    assert.equal(result.value.path, null);
+    assert.equal(result.value.conventionSkipNotice, null);
+  });
+
+  it('disable=true short-circuits every source and clears the convention notice', () => {
+    const result = resolveSupervisorAppendPrompt({
+      cliInlineText: 'cli',
+      cliFilePath: null,
+      envInlineText: 'env',
+      envFilePath: null,
+      conventionFilePath: conventionPath,
+      conventionFilePresent: true,
+      disable: true,
+      loaded: {
+        convention: { bytes: Buffer.from('convention'), path: conventionPath },
+      },
+    });
+    assert.equal(result.ok, true);
+    if (!result.ok) return;
+    assert.equal(result.value.source, 'none');
+    assert.equal(result.value.text, null);
+    assert.equal(result.value.conventionSkipNotice, null);
+  });
+
+  it('strips a UTF-8 BOM, trimEnd trailing whitespace, preserves CRLF and leading Markdown', () => {
+    const body = '# Heading\r\n- item one\r\n- item two\r\n   \n\n';
+    const bytes = Buffer.concat([Buffer.from([0xef, 0xbb, 0xbf]), Buffer.from(body, 'utf8')]);
+    const result = resolveSupervisorAppendPrompt({
+      cliInlineText: null,
+      cliFilePath: '/tmp/cli.md',
+      envInlineText: null,
+      envFilePath: null,
+      conventionFilePath: conventionPath,
+      conventionFilePresent: false,
+      disable: false,
+      loaded: { cliFile: { bytes, path: '/tmp/cli.md' } },
+    });
+    assert.equal(result.ok, true);
+    if (!result.ok) return;
+    assert.equal(result.value.source, 'cli-file');
+    assert.equal(result.value.text, '# Heading\r\n- item one\r\n- item two');
+  });
+
+  it('accepts exactly 65 536 bytes and rejects 65 537 bytes (byte-based cap) with the exact contract error', () => {
+    const accepted = Buffer.alloc(SUPERVISOR_APPEND_PROMPT_BYTE_CAP, 0x61);
+    const rejected = Buffer.alloc(SUPERVISOR_APPEND_PROMPT_BYTE_CAP + 1, 0x61);
+    const okResult = resolveSupervisorAppendPrompt({
+      cliInlineText: null,
+      cliFilePath: '/tmp/c.md',
+      envInlineText: null,
+      envFilePath: null,
+      conventionFilePath: '/tmp/work/.agents/orchestrator/system-prompt.md',
+      conventionFilePresent: false,
+      disable: false,
+      loaded: { cliFile: { bytes: accepted, path: '/tmp/c.md' } },
+    });
+    assert.equal(okResult.ok, true);
+
+    const errResult = resolveSupervisorAppendPrompt({
+      cliInlineText: null,
+      cliFilePath: '/tmp/c.md',
+      envInlineText: null,
+      envFilePath: null,
+      conventionFilePath: '/tmp/work/.agents/orchestrator/system-prompt.md',
+      conventionFilePresent: false,
+      disable: false,
+      loaded: { cliFile: { bytes: rejected, path: '/tmp/c.md' } },
+    });
+    assert.equal(errResult.ok, false);
+    if (errResult.ok) return;
+    assert.equal(errResult.error.code, 'oversize');
+    assert.equal(
+      errResult.error.message,
+      `Supervisor append prompt exceeds the ${SUPERVISOR_APPEND_PROMPT_BYTE_CAP}-byte cap (got ${SUPERVISOR_APPEND_PROMPT_BYTE_CAP + 1} bytes) from source cli-file at /tmp/c.md.`,
+    );
+  });
+
+  it('byte cap is enforced on UTF-8 byte length, not codepoint count (multibyte boundary)', () => {
+    // Build a 65 536-byte buffer whose final codepoint is the 3-byte UTF-8
+    // character U+2026 (HORIZONTAL ELLIPSIS, EF 80 A6 ... actually E2 80 A6).
+    // Filling the prefix with ASCII makes the multibyte boundary exact.
+    const ellipsis = Buffer.from('…', 'utf8');
+    assert.equal(ellipsis.length, 3);
+    const prefixLen = SUPERVISOR_APPEND_PROMPT_BYTE_CAP - ellipsis.length;
+    const accepted = Buffer.concat([Buffer.alloc(prefixLen, 0x61), ellipsis]);
+    assert.equal(accepted.length, SUPERVISOR_APPEND_PROMPT_BYTE_CAP);
+
+    const okResult = resolveSupervisorAppendPrompt({
+      cliInlineText: null,
+      cliFilePath: '/tmp/c.md',
+      envInlineText: null,
+      envFilePath: null,
+      conventionFilePath: '/tmp/work/.agents/orchestrator/system-prompt.md',
+      conventionFilePresent: false,
+      disable: false,
+      loaded: { cliFile: { bytes: accepted, path: '/tmp/c.md' } },
+    });
+    assert.equal(okResult.ok, true);
+    if (!okResult.ok) return;
+    // The trailing ellipsis must survive (no trim-end of legitimate content).
+    assert.equal(okResult.value.text?.endsWith('…'), true);
+
+    const rejected = Buffer.concat([accepted, Buffer.from('a', 'utf8')]);
+    assert.equal(rejected.length, SUPERVISOR_APPEND_PROMPT_BYTE_CAP + 1);
+    const errResult = resolveSupervisorAppendPrompt({
+      cliInlineText: null,
+      cliFilePath: '/tmp/c.md',
+      envInlineText: null,
+      envFilePath: null,
+      conventionFilePath: '/tmp/work/.agents/orchestrator/system-prompt.md',
+      conventionFilePresent: false,
+      disable: false,
+      loaded: { cliFile: { bytes: rejected, path: '/tmp/c.md' } },
+    });
+    assert.equal(errResult.ok, false);
+    if (errResult.ok) return;
+    assert.equal(errResult.error.code, 'oversize');
+  });
+
+  it('returns text=null when content is whitespace-only but preserves source and path', () => {
+    const bytes = Buffer.from('   \n\t  \n', 'utf8');
+    const result = resolveSupervisorAppendPrompt({
+      cliInlineText: null,
+      cliFilePath: '/tmp/c.md',
+      envInlineText: null,
+      envFilePath: null,
+      conventionFilePath: '/tmp/work/.agents/orchestrator/system-prompt.md',
+      conventionFilePresent: false,
+      disable: false,
+      loaded: { cliFile: { bytes, path: '/tmp/c.md' } },
+    });
+    assert.equal(result.ok, true);
+    if (!result.ok) return;
+    assert.equal(result.value.source, 'cli-file');
+    assert.equal(result.value.path, '/tmp/c.md');
+    assert.equal(result.value.text, null);
+  });
+});
+
+describe('buildSupervisorSystemPrompt user-append integration', () => {
+  it('appends the literal delimiter + user text when text is non-empty', () => {
+    const monitorPin = resolveMonitorPin({ AGENT_ORCHESTRATOR_BIN: '/opt/agent-orchestrator' });
+    const catalog = createWorkerCapabilityCatalog(null);
+    const baseline = buildClaudeHarnessConfig({
+      targetCwd: '/tmp/work',
+      manifestPath: '/tmp/work/profiles.json',
+      ephemeralSkillRoot: '/tmp/skills',
+      orchestrationSkillNames: [],
+      orchestrationSkills: [],
+      runtimeSkillRoot: '/tmp/home/.claude/skills',
+      runtimeSkillNames: [],
+      catalog,
+      profileDiagnostics: [],
+      mcpCliPath: '/opt/agent-orchestrator/dist/cli.js',
+      monitorPin,
+    });
+    const withAppend = buildClaudeHarnessConfig({
+      targetCwd: '/tmp/work',
+      manifestPath: '/tmp/work/profiles.json',
+      ephemeralSkillRoot: '/tmp/skills',
+      orchestrationSkillNames: [],
+      orchestrationSkills: [],
+      runtimeSkillRoot: '/tmp/home/.claude/skills',
+      runtimeSkillNames: [],
+      catalog,
+      profileDiagnostics: [],
+      mcpCliPath: '/opt/agent-orchestrator/dist/cli.js',
+      monitorPin,
+      userAppendSystemPrompt: {
+        source: 'cli-inline',
+        path: null,
+        text: 'Please keep responses concise.',
+      },
+    });
+    assert.equal(withAppend.systemPrompt.endsWith(`${SUPERVISOR_APPEND_PROMPT_DELIMITER}Please keep responses concise.`), true);
+    assert.equal(withAppend.systemPrompt.startsWith(baseline.systemPrompt), true);
+    assert.equal(withAppend.userSystemPromptSource, 'cli-inline');
+    assert.equal(withAppend.userSystemPromptAppend, 'Please keep responses concise.');
+  });
+
+  it('produces a byte-identical baseline when text is null or absent', () => {
+    const monitorPin = resolveMonitorPin({ AGENT_ORCHESTRATOR_BIN: '/opt/agent-orchestrator' });
+    const catalog = createWorkerCapabilityCatalog(null);
+    const baseline = buildClaudeHarnessConfig({
+      targetCwd: '/tmp/work',
+      manifestPath: '/tmp/work/profiles.json',
+      ephemeralSkillRoot: '/tmp/skills',
+      orchestrationSkillNames: [],
+      orchestrationSkills: [],
+      runtimeSkillRoot: '/tmp/home/.claude/skills',
+      runtimeSkillNames: [],
+      catalog,
+      profileDiagnostics: [],
+      mcpCliPath: '/opt/agent-orchestrator/dist/cli.js',
+      monitorPin,
+    });
+    const emptyText = buildClaudeHarnessConfig({
+      targetCwd: '/tmp/work',
+      manifestPath: '/tmp/work/profiles.json',
+      ephemeralSkillRoot: '/tmp/skills',
+      orchestrationSkillNames: [],
+      orchestrationSkills: [],
+      runtimeSkillRoot: '/tmp/home/.claude/skills',
+      runtimeSkillNames: [],
+      catalog,
+      profileDiagnostics: [],
+      mcpCliPath: '/opt/agent-orchestrator/dist/cli.js',
+      monitorPin,
+      userAppendSystemPrompt: { source: 'cli-file', path: '/tmp/x.md', text: null },
+    });
+    assert.equal(emptyText.systemPrompt, baseline.systemPrompt);
+  });
+});
+
+describe('buildClaudeEnvelope append-prompt wiring', () => {
+  async function makeBaseCwd(prefix: string): Promise<{ cwd: string; skillsPath: string; stateDir: string }> {
+    const cwd = await makeTargetCwd(prefix);
+    const skillsPath = join(cwd, '.agents', 'skills');
+    await mkdir(join(skillsPath, 'orchestrate-foo'), { recursive: true });
+    await writeFile(join(skillsPath, 'orchestrate-foo', 'SKILL.md'), '---\nname: orchestrate-foo\n---\nbody');
+    const stateDir = join(cwd, 'claude-state');
+    return { cwd, skillsPath, stateDir };
+  }
+
+  it('writes one concatenated system-prompt.md and keeps spawn args at a single --append-system-prompt-file', async () => {
+    const { cwd, skillsPath, stateDir } = await makeBaseCwd('agent-claude-envelope-append-');
+    const parsed = parseClaudeLauncherArgs(
+      ['--cwd', cwd, '--skills', skillsPath, '--state-dir', stateDir, '--append-system-prompt', 'Custom rule.'],
+      { AGENT_ORCHESTRATOR_BIN: '/opt/agent-orchestrator' },
+      cwd,
+    );
+    assert.equal(parsed.ok, true);
+    if (!parsed.ok) return;
+    const built = await buildClaudeEnvelope({
+      options: parsed.value,
+      env: { AGENT_ORCHESTRATOR_BIN: '/opt/agent-orchestrator' },
+      catalog: createWorkerCapabilityCatalog(null),
+      profilesResult: { profiles: undefined, diagnostics: [] },
+    });
+    try {
+      const written = await readFile(built.systemPromptPath, 'utf8');
+      assert.equal(written, built.systemPrompt);
+      assert.equal(written.endsWith(`${SUPERVISOR_APPEND_PROMPT_DELIMITER}Custom rule.`), true);
+      assert.equal(built.userSystemPromptSource, 'cli-inline');
+      assert.equal(built.userSystemPromptAppend, 'Custom rule.');
+      assert.equal(built.userSystemPromptPath, null);
+      // Single spawn arg pair: exactly one --append-system-prompt-file pointing at the envelope file.
+      const flagIndexes = built.spawnArgs.reduce<number[]>((acc, arg, idx) => {
+        if (arg === '--append-system-prompt-file') acc.push(idx);
+        return acc;
+      }, []);
+      assert.deepStrictEqual(flagIndexes.length, 1);
+      assert.equal(built.spawnArgs[flagIndexes[0]! + 1], built.systemPromptPath);
+      // No second instance, no new Claude flag surface.
+      assert.equal(built.spawnArgs.includes('--system-prompt-file'), false);
+      assert.equal(built.spawnArgs.includes('--system-prompt'), false);
+      assert.equal(built.spawnArgs.includes('--append-system-prompt'), false);
+    } finally {
+      await built.cleanup();
+    }
+  });
+
+  it('hooks/settings.json content is byte-identical to the no-append baseline when an append is present', async () => {
+    const baseline = await makeBaseCwd('agent-claude-hooks-baseline-');
+    const parsedBaseline = parseClaudeLauncherArgs(
+      ['--cwd', baseline.cwd, '--skills', baseline.skillsPath, '--state-dir', baseline.stateDir],
+      { AGENT_ORCHESTRATOR_BIN: '/opt/agent-orchestrator' },
+      baseline.cwd,
+    );
+    assert.equal(parsedBaseline.ok, true);
+    if (!parsedBaseline.ok) return;
+    const builtBaseline = await buildClaudeEnvelope({
+      options: parsedBaseline.value,
+      env: { AGENT_ORCHESTRATOR_BIN: '/opt/agent-orchestrator' },
+      catalog: createWorkerCapabilityCatalog(null),
+      profilesResult: { profiles: undefined, diagnostics: [] },
+    });
+
+    const withAppend = await makeBaseCwd('agent-claude-hooks-append-');
+    const parsedAppend = parseClaudeLauncherArgs(
+      ['--cwd', withAppend.cwd, '--skills', withAppend.skillsPath, '--state-dir', withAppend.stateDir, '--append-system-prompt', 'Extra'],
+      { AGENT_ORCHESTRATOR_BIN: '/opt/agent-orchestrator' },
+      withAppend.cwd,
+    );
+    assert.equal(parsedAppend.ok, true);
+    if (!parsedAppend.ok) return;
+    const builtAppend = await buildClaudeEnvelope({
+      options: parsedAppend.value,
+      env: { AGENT_ORCHESTRATOR_BIN: '/opt/agent-orchestrator' },
+      catalog: createWorkerCapabilityCatalog(null),
+      profilesResult: { profiles: undefined, diagnostics: [] },
+    });
+
+    try {
+      assert.equal(builtAppend.settingsContent, builtBaseline.settingsContent);
+    } finally {
+      await builtBaseline.cleanup();
+      await builtAppend.cleanup();
+    }
+  });
+
+  it('loads a present convention file when no higher-precedence source is set and emits no skip notice', async () => {
+    const { cwd, skillsPath, stateDir } = await makeBaseCwd('agent-claude-convention-load-');
+    await mkdir(join(cwd, '.agents', 'orchestrator'), { recursive: true });
+    await writeFile(join(cwd, CONVENTION_APPEND_PROMPT_RELATIVE_PATH), 'Convention guidance.\n');
+    const parsed = parseClaudeLauncherArgs(
+      ['--cwd', cwd, '--skills', skillsPath, '--state-dir', stateDir],
+      { AGENT_ORCHESTRATOR_BIN: '/opt/agent-orchestrator' },
+      cwd,
+    );
+    assert.equal(parsed.ok, true);
+    if (!parsed.ok) return;
+    const built = await buildClaudeEnvelope({
+      options: parsed.value,
+      env: { AGENT_ORCHESTRATOR_BIN: '/opt/agent-orchestrator' },
+      catalog: createWorkerCapabilityCatalog(null),
+      profilesResult: { profiles: undefined, diagnostics: [] },
+    });
+    try {
+      assert.equal(built.userSystemPromptSource, 'convention-file');
+      assert.equal(built.userSystemPromptPath, join(cwd, CONVENTION_APPEND_PROMPT_RELATIVE_PATH));
+      assert.equal(built.userSystemPromptAppend, 'Convention guidance.');
+      assert.equal(built.conventionSkipNotice, null);
+      assert.match(built.systemPrompt, /Convention guidance\.$/);
+    } finally {
+      await built.cleanup();
+    }
+  });
+
+  it('absent convention file is silent (no error, no notice)', async () => {
+    const { cwd, skillsPath, stateDir } = await makeBaseCwd('agent-claude-convention-absent-');
+    const parsed = parseClaudeLauncherArgs(
+      ['--cwd', cwd, '--skills', skillsPath, '--state-dir', stateDir],
+      { AGENT_ORCHESTRATOR_BIN: '/opt/agent-orchestrator' },
+      cwd,
+    );
+    assert.equal(parsed.ok, true);
+    if (!parsed.ok) return;
+    const built = await buildClaudeEnvelope({
+      options: parsed.value,
+      env: { AGENT_ORCHESTRATOR_BIN: '/opt/agent-orchestrator' },
+      catalog: createWorkerCapabilityCatalog(null),
+      profilesResult: { profiles: undefined, diagnostics: [] },
+    });
+    try {
+      assert.equal(built.userSystemPromptSource, 'none');
+      assert.equal(built.userSystemPromptPath, null);
+      assert.equal(built.userSystemPromptAppend, null);
+      assert.equal(built.conventionSkipNotice, null);
+    } finally {
+      await built.cleanup();
+    }
+  });
+
+  it('precedence-skip emits a single stderr notice via runClaudeLauncher and --print-config records the cli-inline source', async () => {
+    const { cwd, skillsPath, stateDir } = await makeBaseCwd('agent-claude-precedence-skip-');
+    await mkdir(join(cwd, '.agents', 'orchestrator'), { recursive: true });
+    await writeFile(join(cwd, CONVENTION_APPEND_PROMPT_RELATIVE_PATH), 'project default\n');
+    const stdout = captureWritable();
+    const stderr = captureWritable();
+    const code = await runClaudeLauncher(
+      ['--cwd', cwd, '--skills', skillsPath, '--state-dir', stateDir, '--append-system-prompt', 'override', '--print-config'],
+      { stdout: stdout.stream, stderr: stderr.stream, env: { AGENT_ORCHESTRATOR_BIN: '/opt/agent-orchestrator', AGENT_ORCHESTRATOR_HOME: join(cwd, 'home') } },
+    );
+    assert.equal(code, 0);
+    // Stderr was written exactly once with the skip notice.
+    assert.equal(stderr.count(), 1);
+    assert.match(stderr.text(), /skipping convention system-prompt file/);
+    assert.match(stderr.text(), /preempted by --append-system-prompt/);
+    const out = stdout.text();
+    assert.match(out, /# user system prompt source\ncli-inline\n/);
+    assert.match(out, /# user system prompt \(append\)\noverride\n/);
+  });
+
+  it('missing CLI file fails the launch with a typed error and exit code 1', async () => {
+    const { cwd, skillsPath, stateDir } = await makeBaseCwd('agent-claude-missing-cli-file-');
+    const stdout = captureWritable();
+    const stderr = captureWritable();
+    const code = await runClaudeLauncher(
+      ['--cwd', cwd, '--skills', skillsPath, '--state-dir', stateDir, '--append-system-prompt-file', 'nonexistent.md', '--print-config'],
+      { stdout: stdout.stream, stderr: stderr.stream, env: { AGENT_ORCHESTRATOR_BIN: '/opt/agent-orchestrator', AGENT_ORCHESTRATOR_HOME: join(cwd, 'home') } },
+    );
+    assert.equal(code, 1);
+    assert.match(stderr.text(), /append-prompt file not found/);
+    assert.match(stderr.text(), /cli-file/);
+  });
+
+  it('missing env file fails the launch with a typed error and exit code 1', async () => {
+    const { cwd, skillsPath, stateDir } = await makeBaseCwd('agent-claude-missing-env-file-');
+    const stdout = captureWritable();
+    const stderr = captureWritable();
+    const code = await runClaudeLauncher(
+      ['--cwd', cwd, '--skills', skillsPath, '--state-dir', stateDir, '--print-config'],
+      {
+        stdout: stdout.stream,
+        stderr: stderr.stream,
+        env: {
+          AGENT_ORCHESTRATOR_BIN: '/opt/agent-orchestrator',
+          AGENT_ORCHESTRATOR_HOME: join(cwd, 'home'),
+          AGENT_ORCHESTRATOR_CLAUDE_APPEND_SYSTEM_PROMPT_FILE: 'nonexistent.md',
+        },
+      },
+    );
+    assert.equal(code, 1);
+    assert.match(stderr.text(), /append-prompt file not found/);
+    assert.match(stderr.text(), /env-file/);
+  });
+
+  it('--no-append-system-prompt short-circuits CLI, env, and convention sources to "none"', async () => {
+    const { cwd, skillsPath, stateDir } = await makeBaseCwd('agent-claude-no-append-');
+    await mkdir(join(cwd, '.agents', 'orchestrator'), { recursive: true });
+    await writeFile(join(cwd, CONVENTION_APPEND_PROMPT_RELATIVE_PATH), 'project default\n');
+    const cliFile = join(cwd, 'cli.md');
+    await writeFile(cliFile, 'CLI file body');
+    const envFile = join(cwd, 'env.md');
+    await writeFile(envFile, 'env file body');
+    const stdout = captureWritable();
+    const stderr = captureWritable();
+    const code = await runClaudeLauncher(
+      ['--cwd', cwd, '--skills', skillsPath, '--state-dir', stateDir, '--no-append-system-prompt', '--append-system-prompt', 'cli inline', '--print-config'],
+      {
+        stdout: stdout.stream,
+        stderr: stderr.stream,
+        env: {
+          AGENT_ORCHESTRATOR_BIN: '/opt/agent-orchestrator',
+          AGENT_ORCHESTRATOR_HOME: join(cwd, 'home'),
+          AGENT_ORCHESTRATOR_CLAUDE_APPEND_SYSTEM_PROMPT: 'env inline',
+        },
+      },
+    );
+    assert.equal(code, 0);
+    const out = stdout.text();
+    assert.match(out, /# user system prompt source\nnone\n/);
+    assert.equal(out.includes('# user system prompt (append)'), false);
+    // Stderr stays silent when --no-append-system-prompt suppresses every source, including the convention file.
+    assert.equal(stderr.count(), 0);
+  });
+
+  it('non-regular convention file (symlink) is refused and surfaces the lstat skip notice exactly once via runClaudeLauncher', async () => {
+    const { cwd, skillsPath, stateDir } = await makeBaseCwd('agent-claude-convention-symlink-');
+    const sensitive = join(cwd, 'sensitive.txt');
+    await writeFile(sensitive, 'do-not-load');
+    await mkdir(join(cwd, '.agents', 'orchestrator'), { recursive: true });
+    await symlink(sensitive, join(cwd, CONVENTION_APPEND_PROMPT_RELATIVE_PATH));
+    const stdout = captureWritable();
+    const stderr = captureWritable();
+    const code = await runClaudeLauncher(
+      ['--cwd', cwd, '--skills', skillsPath, '--state-dir', stateDir, '--print-config'],
+      { stdout: stdout.stream, stderr: stderr.stream, env: { AGENT_ORCHESTRATOR_BIN: '/opt/agent-orchestrator', AGENT_ORCHESTRATOR_HOME: join(cwd, 'home') } },
+    );
+    assert.equal(code, 0);
+    assert.equal(stderr.count(), 1);
+    assert.match(stderr.text(), /not a regular file \(symlink\)/);
+    const out = stdout.text();
+    assert.match(out, /# user system prompt source\nnone\n/);
+    assert.equal(out.includes('do-not-load'), false);
+  });
+
+  it('non-regular convention file (directory) is refused and surfaces the lstat skip notice exactly once', async () => {
+    const { cwd, skillsPath, stateDir } = await makeBaseCwd('agent-claude-convention-dir-');
+    await mkdir(join(cwd, CONVENTION_APPEND_PROMPT_RELATIVE_PATH), { recursive: true });
+    const stdout = captureWritable();
+    const stderr = captureWritable();
+    const code = await runClaudeLauncher(
+      ['--cwd', cwd, '--skills', skillsPath, '--state-dir', stateDir, '--print-config'],
+      { stdout: stdout.stream, stderr: stderr.stream, env: { AGENT_ORCHESTRATOR_BIN: '/opt/agent-orchestrator', AGENT_ORCHESTRATOR_HOME: join(cwd, 'home') } },
+    );
+    assert.equal(code, 0);
+    assert.equal(stderr.count(), 1);
+    assert.match(stderr.text(), /not a regular file \(directory\)/);
+  });
+
+  it('CLI-named symlink is read as-is (not refused by the lstat guard, which is convention-only)', async () => {
+    const { cwd, skillsPath, stateDir } = await makeBaseCwd('agent-claude-cli-symlink-');
+    const target = join(cwd, 'prompt-target.md');
+    await writeFile(target, 'linked supervisor text\n');
+    const linkPath = join(cwd, 'prompt-link.md');
+    await symlink(target, linkPath);
+    const stdout = captureWritable();
+    const stderr = captureWritable();
+    const code = await runClaudeLauncher(
+      ['--cwd', cwd, '--skills', skillsPath, '--state-dir', stateDir, '--append-system-prompt-file', 'prompt-link.md', '--print-config'],
+      { stdout: stdout.stream, stderr: stderr.stream, env: { AGENT_ORCHESTRATOR_BIN: '/opt/agent-orchestrator', AGENT_ORCHESTRATOR_HOME: join(cwd, 'home') } },
+    );
+    assert.equal(code, 0);
+    // No stderr notice — only convention-file paths are refused by lstat.
+    assert.equal(stderr.count(), 0);
+    const out = stdout.text();
+    assert.match(out, /# user system prompt source\ncli-file\n/);
+    assert.match(out, /# user system prompt \(append\)\nlinked supervisor text\n/);
+  });
+
+  it('--print-config emits the source line with an (empty) annotation when text is whitespace-only', async () => {
+    const { cwd, skillsPath, stateDir } = await makeBaseCwd('agent-claude-empty-text-');
+    const emptyFile = join(cwd, 'empty.md');
+    await writeFile(emptyFile, '   \n\t  \n');
+    const stdout = captureWritable();
+    const stderr = captureWritable();
+    const code = await runClaudeLauncher(
+      ['--cwd', cwd, '--skills', skillsPath, '--state-dir', stateDir, '--append-system-prompt-file', 'empty.md', '--print-config'],
+      { stdout: stdout.stream, stderr: stderr.stream, env: { AGENT_ORCHESTRATOR_BIN: '/opt/agent-orchestrator', AGENT_ORCHESTRATOR_HOME: join(cwd, 'home') } },
+    );
+    assert.equal(code, 0);
+    const out = stdout.text();
+    assert.match(out, /# user system prompt source\ncli-file \(empty\)\n/);
+    assert.match(out, /# user system prompt path\n.*empty\.md/);
+    assert.equal(out.includes('# user system prompt (append)'), false);
+    assert.equal(stderr.count(), 0);
+  });
+
+  it('oversize CLI file fails the launch with the byte-cap message naming the source and path', async () => {
+    const { cwd, skillsPath, stateDir } = await makeBaseCwd('agent-claude-oversize-');
+    const big = join(cwd, 'big.md');
+    await writeFile(big, Buffer.alloc(SUPERVISOR_APPEND_PROMPT_BYTE_CAP + 1, 0x61));
+    const stdout = captureWritable();
+    const stderr = captureWritable();
+    const code = await runClaudeLauncher(
+      ['--cwd', cwd, '--skills', skillsPath, '--state-dir', stateDir, '--append-system-prompt-file', 'big.md', '--print-config'],
+      { stdout: stdout.stream, stderr: stderr.stream, env: { AGENT_ORCHESTRATOR_BIN: '/opt/agent-orchestrator', AGENT_ORCHESTRATOR_HOME: join(cwd, 'home') } },
+    );
+    assert.equal(code, 1);
+    assert.match(stderr.text(), /65536-byte cap/);
+    assert.match(stderr.text(), /65537 bytes/);
+    assert.match(stderr.text(), /cli-file/);
+    assert.match(stderr.text(), /big\.md/);
+  });
+
+  it('no append source emits the # user system prompt source line with the none sentinel in --print-config', async () => {
+    const { cwd, skillsPath, stateDir } = await makeBaseCwd('agent-claude-print-none-');
+    const stdout = captureWritable();
+    const stderr = captureWritable();
+    const code = await runClaudeLauncher(
+      ['--cwd', cwd, '--skills', skillsPath, '--state-dir', stateDir, '--print-config'],
+      { stdout: stdout.stream, stderr: stderr.stream, env: { AGENT_ORCHESTRATOR_BIN: '/opt/agent-orchestrator', AGENT_ORCHESTRATOR_HOME: join(cwd, 'home') } },
+    );
+    assert.equal(code, 0);
+    assert.match(stdout.text(), /# user system prompt source\nnone\n/);
+    assert.equal(stdout.text().includes('# user system prompt path'), false);
+    assert.equal(stdout.text().includes('# user system prompt (append)'), false);
+    assert.equal(stderr.count(), 0);
+  });
+
+  it('cli-inline wins over a missing AGENT_ORCHESTRATOR_CLAUDE_APPEND_SYSTEM_PROMPT_FILE: preempted file is never read', async () => {
+    const { cwd, skillsPath, stateDir } = await makeBaseCwd('agent-claude-preempt-missing-env-file-');
+    const stdout = captureWritable();
+    const stderr = captureWritable();
+    const code = await runClaudeLauncher(
+      ['--cwd', cwd, '--skills', skillsPath, '--state-dir', stateDir, '--append-system-prompt', 'cli wins', '--print-config'],
+      {
+        stdout: stdout.stream,
+        stderr: stderr.stream,
+        env: {
+          AGENT_ORCHESTRATOR_BIN: '/opt/agent-orchestrator',
+          AGENT_ORCHESTRATOR_HOME: join(cwd, 'home'),
+          AGENT_ORCHESTRATOR_CLAUDE_APPEND_SYSTEM_PROMPT_FILE: '/does/not/exist/anywhere.md',
+        },
+      },
+    );
+    assert.equal(code, 0);
+    assert.match(stdout.text(), /# user system prompt source\ncli-inline\n/);
+    assert.match(stdout.text(), /# user system prompt \(append\)\ncli wins\n/);
+    // Stderr stays silent: the env file is never read because cli-inline wins.
+    assert.equal(stderr.count(), 0);
+  });
+
+  it('cli-inline wins over an oversize AGENT_ORCHESTRATOR_CLAUDE_APPEND_SYSTEM_PROMPT_FILE: preempted file is never read', async () => {
+    const { cwd, skillsPath, stateDir } = await makeBaseCwd('agent-claude-preempt-oversize-env-file-');
+    const oversize = join(cwd, 'oversize.md');
+    await writeFile(oversize, Buffer.alloc(SUPERVISOR_APPEND_PROMPT_BYTE_CAP + 4096, 0x61));
+    const stdout = captureWritable();
+    const stderr = captureWritable();
+    const code = await runClaudeLauncher(
+      ['--cwd', cwd, '--skills', skillsPath, '--state-dir', stateDir, '--append-system-prompt', 'cli wins', '--print-config'],
+      {
+        stdout: stdout.stream,
+        stderr: stderr.stream,
+        env: {
+          AGENT_ORCHESTRATOR_BIN: '/opt/agent-orchestrator',
+          AGENT_ORCHESTRATOR_HOME: join(cwd, 'home'),
+          AGENT_ORCHESTRATOR_CLAUDE_APPEND_SYSTEM_PROMPT_FILE: 'oversize.md',
+        },
+      },
+    );
+    assert.equal(code, 0, 'higher-precedence cli-inline must succeed even when a lower-precedence env file would have been oversize');
+    assert.match(stdout.text(), /# user system prompt source\ncli-inline\n/);
+  });
+
+  it('cli-inline wins over an unreadable convention file: convention body is never read (precedence-skip notice fires, the bad bytes do not)', async () => {
+    if (process.getuid?.() === 0) return; // root bypasses permission bits; skip
+    const { cwd, skillsPath, stateDir } = await makeBaseCwd('agent-claude-preempt-unreadable-convention-');
+    await mkdir(join(cwd, '.agents', 'orchestrator'), { recursive: true });
+    const conventionPath = join(cwd, CONVENTION_APPEND_PROMPT_RELATIVE_PATH);
+    await writeFile(conventionPath, 'convention body');
+    const { chmod } = await import('node:fs/promises');
+    await chmod(conventionPath, 0o000);
+    try {
+      const stdout = captureWritable();
+      const stderr = captureWritable();
+      const code = await runClaudeLauncher(
+        ['--cwd', cwd, '--skills', skillsPath, '--state-dir', stateDir, '--append-system-prompt', 'cli wins', '--print-config'],
+        { stdout: stdout.stream, stderr: stderr.stream, env: { AGENT_ORCHESTRATOR_BIN: '/opt/agent-orchestrator', AGENT_ORCHESTRATOR_HOME: join(cwd, 'home') } },
+      );
+      assert.equal(code, 0, 'cli-inline wins; the preempted convention file must not be read');
+      assert.equal(stderr.count(), 1, 'only the precedence-skip notice should fire');
+      assert.match(stderr.text(), /skipping convention system-prompt file/);
+      assert.match(stdout.text(), /# user system prompt source\ncli-inline\n/);
+    } finally {
+      await chmod(conventionPath, 0o600);
+    }
+  });
+
+  it('--no-append-system-prompt suppresses cli-file only (no parse error, source=none)', async () => {
+    const { cwd, skillsPath, stateDir } = await makeBaseCwd('agent-claude-no-suppress-cli-file-');
+    const cliFile = join(cwd, 'cli.md');
+    await writeFile(cliFile, 'cli file body');
+    const stdout = captureWritable();
+    const stderr = captureWritable();
+    const code = await runClaudeLauncher(
+      ['--cwd', cwd, '--skills', skillsPath, '--state-dir', stateDir, '--no-append-system-prompt', '--append-system-prompt-file', 'cli.md', '--print-config'],
+      { stdout: stdout.stream, stderr: stderr.stream, env: { AGENT_ORCHESTRATOR_BIN: '/opt/agent-orchestrator', AGENT_ORCHESTRATOR_HOME: join(cwd, 'home') } },
+    );
+    assert.equal(code, 0);
+    assert.match(stdout.text(), /# user system prompt source\nnone\n/);
+    assert.equal(stderr.count(), 0);
+  });
+
+  it('--no-append-system-prompt suppresses env-inline only', async () => {
+    const { cwd, skillsPath, stateDir } = await makeBaseCwd('agent-claude-no-suppress-env-inline-');
+    const stdout = captureWritable();
+    const stderr = captureWritable();
+    const code = await runClaudeLauncher(
+      ['--cwd', cwd, '--skills', skillsPath, '--state-dir', stateDir, '--no-append-system-prompt', '--print-config'],
+      {
+        stdout: stdout.stream,
+        stderr: stderr.stream,
+        env: {
+          AGENT_ORCHESTRATOR_BIN: '/opt/agent-orchestrator',
+          AGENT_ORCHESTRATOR_HOME: join(cwd, 'home'),
+          AGENT_ORCHESTRATOR_CLAUDE_APPEND_SYSTEM_PROMPT: 'env inline',
+        },
+      },
+    );
+    assert.equal(code, 0);
+    assert.match(stdout.text(), /# user system prompt source\nnone\n/);
+    assert.equal(stderr.count(), 0);
+  });
+
+  it('--no-append-system-prompt suppresses env-file only', async () => {
+    const { cwd, skillsPath, stateDir } = await makeBaseCwd('agent-claude-no-suppress-env-file-');
+    const envFile = join(cwd, 'env.md');
+    await writeFile(envFile, 'env file body');
+    const stdout = captureWritable();
+    const stderr = captureWritable();
+    const code = await runClaudeLauncher(
+      ['--cwd', cwd, '--skills', skillsPath, '--state-dir', stateDir, '--no-append-system-prompt', '--print-config'],
+      {
+        stdout: stdout.stream,
+        stderr: stderr.stream,
+        env: {
+          AGENT_ORCHESTRATOR_BIN: '/opt/agent-orchestrator',
+          AGENT_ORCHESTRATOR_HOME: join(cwd, 'home'),
+          AGENT_ORCHESTRATOR_CLAUDE_APPEND_SYSTEM_PROMPT_FILE: 'env.md',
+        },
+      },
+    );
+    assert.equal(code, 0);
+    assert.match(stdout.text(), /# user system prompt source\nnone\n/);
+    assert.equal(stderr.count(), 0);
+  });
+
+  it('--no-append-system-prompt suppresses a present convention file (no stderr, source=none, body not read)', async () => {
+    const { cwd, skillsPath, stateDir } = await makeBaseCwd('agent-claude-no-suppress-convention-');
+    await mkdir(join(cwd, '.agents', 'orchestrator'), { recursive: true });
+    await writeFile(join(cwd, CONVENTION_APPEND_PROMPT_RELATIVE_PATH), 'convention body');
+    const stdout = captureWritable();
+    const stderr = captureWritable();
+    const code = await runClaudeLauncher(
+      ['--cwd', cwd, '--skills', skillsPath, '--state-dir', stateDir, '--no-append-system-prompt', '--print-config'],
+      { stdout: stdout.stream, stderr: stderr.stream, env: { AGENT_ORCHESTRATOR_BIN: '/opt/agent-orchestrator', AGENT_ORCHESTRATOR_HOME: join(cwd, 'home') } },
+    );
+    assert.equal(code, 0);
+    assert.match(stdout.text(), /# user system prompt source\nnone\n/);
+    // --no-append-system-prompt skips the lstat probe too — no skip notice fires.
+    assert.equal(stderr.count(), 0);
+  });
+
+  it('--no-append-system-prompt overrides the CLI inline+file conflict (escape hatch wins)', async () => {
+    const { cwd, skillsPath, stateDir } = await makeBaseCwd('agent-claude-no-escape-cli-conflict-');
+    const cliFile = join(cwd, 'cli.md');
+    await writeFile(cliFile, 'cli file body');
+    const stdout = captureWritable();
+    const stderr = captureWritable();
+    const code = await runClaudeLauncher(
+      ['--cwd', cwd, '--skills', skillsPath, '--state-dir', stateDir, '--no-append-system-prompt', '--append-system-prompt', 'inline', '--append-system-prompt-file', 'cli.md', '--print-config'],
+      { stdout: stdout.stream, stderr: stderr.stream, env: { AGENT_ORCHESTRATOR_BIN: '/opt/agent-orchestrator', AGENT_ORCHESTRATOR_HOME: join(cwd, 'home') } },
+    );
+    assert.equal(code, 0);
+    assert.match(stdout.text(), /# user system prompt source\nnone\n/);
+  });
+
+  it('--no-append-system-prompt overrides the env inline+file conflict (escape hatch wins)', async () => {
+    const { cwd, skillsPath, stateDir } = await makeBaseCwd('agent-claude-no-escape-env-conflict-');
+    const stdout = captureWritable();
+    const stderr = captureWritable();
+    const code = await runClaudeLauncher(
+      ['--cwd', cwd, '--skills', skillsPath, '--state-dir', stateDir, '--no-append-system-prompt', '--print-config'],
+      {
+        stdout: stdout.stream,
+        stderr: stderr.stream,
+        env: {
+          AGENT_ORCHESTRATOR_BIN: '/opt/agent-orchestrator',
+          AGENT_ORCHESTRATOR_HOME: join(cwd, 'home'),
+          AGENT_ORCHESTRATOR_CLAUDE_APPEND_SYSTEM_PROMPT: 'env inline',
+          AGENT_ORCHESTRATOR_CLAUDE_APPEND_SYSTEM_PROMPT_FILE: '/does/not/exist.md',
+        },
+      },
+    );
+    assert.equal(code, 0);
+    assert.match(stdout.text(), /# user system prompt source\nnone\n/);
+  });
+
+  it('env-named symlink is read as-is (lstat guard is convention-only)', async () => {
+    const { cwd, skillsPath, stateDir } = await makeBaseCwd('agent-claude-env-symlink-');
+    const target = join(cwd, 'env-target.md');
+    await writeFile(target, 'env-supervisor text via symlink\n');
+    const linkPath = join(cwd, 'env-link.md');
+    await symlink(target, linkPath);
+    const stdout = captureWritable();
+    const stderr = captureWritable();
+    const code = await runClaudeLauncher(
+      ['--cwd', cwd, '--skills', skillsPath, '--state-dir', stateDir, '--print-config'],
+      {
+        stdout: stdout.stream,
+        stderr: stderr.stream,
+        env: {
+          AGENT_ORCHESTRATOR_BIN: '/opt/agent-orchestrator',
+          AGENT_ORCHESTRATOR_HOME: join(cwd, 'home'),
+          AGENT_ORCHESTRATOR_CLAUDE_APPEND_SYSTEM_PROMPT_FILE: 'env-link.md',
+        },
+      },
+    );
+    assert.equal(code, 0);
+    assert.equal(stderr.count(), 0);
+    const out = stdout.text();
+    assert.match(out, /# user system prompt source\nenv-file\n/);
+    assert.match(out, /# user system prompt \(append\)\nenv-supervisor text via symlink\n/);
+  });
+});
+
+describe('claudeLauncherHelp append-prompt surface', () => {
+  it('documents the three flags, both env vars, the convention path, precedence, and the 64 KiB cap', async () => {
+    const stdout = captureWritable();
+    const code = await runClaudeLauncher(
+      ['--help'],
+      { stdout: stdout.stream, stderr: captureWritable().stream, env: {} },
+    );
+    assert.equal(code, 0);
+    const text = stdout.text();
+    assert.match(text, /--append-system-prompt <text>/);
+    assert.match(text, /--append-system-prompt-file <path>/);
+    assert.match(text, /--no-append-system-prompt/);
+    assert.match(text, /AGENT_ORCHESTRATOR_CLAUDE_APPEND_SYSTEM_PROMPT\b/);
+    assert.match(text, /AGENT_ORCHESTRATOR_CLAUDE_APPEND_SYSTEM_PROMPT_FILE\b/);
+    assert.match(text, /\.agents\/orchestrator\/system-prompt\.md/);
+    assert.match(text, /Precedence/);
+    assert.match(text, /64 KB/);
+    assert.match(text, /forbidden by the passthrough\s+validator/);
+  });
+});
+
+describe('passthrough validator append-system-prompt rejection wording', () => {
+  it('points users at the launcher flag when --append-system-prompt is rejected after --', async () => {
+    const { validateClaudePassthroughArgs } = await import('../claude/passthrough.js');
+    const result = validateClaudePassthroughArgs(['--append-system-prompt', 'evil']);
+    assert.equal(result.ok, false);
+    if (result.ok) return;
+    assert.match(result.error!, /agent-orchestrator claude --append-system-prompt/);
+    assert.match(result.error!, /AGENT_ORCHESTRATOR_CLAUDE_APPEND_SYSTEM_PROMPT/);
+  });
+
+  it('points users at the launcher flag when --append-system-prompt-file is rejected after --', async () => {
+    const { validateClaudePassthroughArgs } = await import('../claude/passthrough.js');
+    const result = validateClaudePassthroughArgs(['--append-system-prompt-file', '/tmp/x.md']);
+    assert.equal(result.ok, false);
+    if (result.ok) return;
+    assert.match(result.error!, /agent-orchestrator claude --append-system-prompt-file/);
+  });
+});
+
+// Defense in depth: make sure rm comes from somewhere so it doesn't get tree-shaken
+void rm;

--- a/src/claude/appendPrompt.ts
+++ b/src/claude/appendPrompt.ts
@@ -1,0 +1,317 @@
+import { lstat, readFile } from 'node:fs/promises';
+
+export type AppendSource =
+  | 'cli-inline'
+  | 'cli-file'
+  | 'env-inline'
+  | 'env-file'
+  | 'convention-file'
+  | 'none';
+
+export const SUPERVISOR_APPEND_PROMPT_BYTE_CAP = 64 * 1024;
+
+export const SUPERVISOR_APPEND_PROMPT_DELIMITER = '\n\n---\n# User-supplied supervisor prompt\n\n';
+
+export const CONVENTION_APPEND_PROMPT_RELATIVE_PATH = '.agents/orchestrator/system-prompt.md';
+
+export interface LoadedAppendContent {
+  bytes: Buffer;
+  path: string;
+}
+
+export type AppendPromptError =
+  | { code: 'missing-file'; source: 'cli-file' | 'env-file'; path: string; message: string }
+  | { code: 'oversize'; source: AppendSource; path: string | null; bytes: number; cap: number; message: string }
+  | { code: 'read-failed'; source: AppendSource; path: string; cause: string; message: string };
+
+export interface ResolveSupervisorAppendPromptInput {
+  cliInlineText: string | null;
+  cliFilePath: string | null;
+  envInlineText: string | null;
+  envFilePath: string | null;
+  conventionFilePath: string;
+  conventionFilePresent: boolean;
+  disable: boolean;
+  loaded: {
+    cliFile?: LoadedAppendContent;
+    envFile?: LoadedAppendContent;
+    convention?: LoadedAppendContent;
+  };
+}
+
+export interface ResolvedSupervisorAppendPrompt {
+  source: AppendSource;
+  path: string | null;
+  text: string | null;
+  conventionSkipNotice: string | null;
+}
+
+export function resolveSupervisorAppendPrompt(
+  input: ResolveSupervisorAppendPromptInput,
+):
+  | { ok: true; value: ResolvedSupervisorAppendPrompt }
+  | { ok: false; error: AppendPromptError } {
+  if (input.disable) {
+    return { ok: true, value: { source: 'none', path: null, text: null, conventionSkipNotice: null } };
+  }
+
+  const selected = selectSource(input);
+  if (selected.source === 'none') {
+    return { ok: true, value: { source: 'none', path: null, text: null, conventionSkipNotice: null } };
+  }
+
+  const skipNoticeRequired = input.conventionFilePresent && selected.source !== 'convention-file';
+  const conventionSkipNotice = skipNoticeRequired
+    ? `agent-orchestrator: skipping convention system-prompt file at ${input.conventionFilePath}: preempted by ${describeSource(selected.source)}`
+    : null;
+
+  const decoded = decodeSelected(selected);
+  if (!decoded.ok) {
+    return decoded;
+  }
+
+  return {
+    ok: true,
+    value: {
+      source: selected.source,
+      path: selected.path,
+      text: decoded.text,
+      conventionSkipNotice,
+    },
+  };
+}
+
+type SelectedSource =
+  | { source: 'cli-inline'; path: null; inlineText: string }
+  | { source: 'env-inline'; path: null; inlineText: string }
+  | { source: 'cli-file'; path: string; loaded: LoadedAppendContent | undefined }
+  | { source: 'env-file'; path: string; loaded: LoadedAppendContent | undefined }
+  | { source: 'convention-file'; path: string; loaded: LoadedAppendContent | undefined }
+  | { source: 'none'; path: null };
+
+function selectSource(input: ResolveSupervisorAppendPromptInput): SelectedSource {
+  if (input.cliInlineText !== null) {
+    return { source: 'cli-inline', path: null, inlineText: input.cliInlineText };
+  }
+  if (input.cliFilePath !== null) {
+    return { source: 'cli-file', path: input.cliFilePath, loaded: input.loaded.cliFile };
+  }
+  if (input.envInlineText !== null) {
+    return { source: 'env-inline', path: null, inlineText: input.envInlineText };
+  }
+  if (input.envFilePath !== null) {
+    return { source: 'env-file', path: input.envFilePath, loaded: input.loaded.envFile };
+  }
+  if (input.conventionFilePresent && input.loaded.convention) {
+    return { source: 'convention-file', path: input.conventionFilePath, loaded: input.loaded.convention };
+  }
+  return { source: 'none', path: null };
+}
+
+function decodeSelected(
+  selected: SelectedSource,
+):
+  | { ok: true; text: string | null }
+  | { ok: false; error: AppendPromptError } {
+  switch (selected.source) {
+    case 'cli-inline':
+    case 'env-inline':
+      return decodeInline(selected.source, selected.inlineText);
+    case 'cli-file':
+    case 'env-file':
+    case 'convention-file': {
+      if (!selected.loaded) {
+        return { ok: true, text: null };
+      }
+      return decodeBytes(selected.source, selected.path, selected.loaded.bytes);
+    }
+    default:
+      return { ok: true, text: null };
+  }
+}
+
+function decodeInline(
+  source: 'cli-inline' | 'env-inline',
+  raw: string,
+):
+  | { ok: true; text: string | null }
+  | { ok: false; error: AppendPromptError } {
+  const bytes = Buffer.from(raw, 'utf8');
+  return decodeBytes(source, null, bytes);
+}
+
+function decodeBytes(
+  source: AppendSource,
+  path: string | null,
+  bytes: Buffer,
+):
+  | { ok: true; text: string | null }
+  | { ok: false; error: AppendPromptError } {
+  const stripped = stripUtf8Bom(bytes);
+  if (stripped.length > SUPERVISOR_APPEND_PROMPT_BYTE_CAP) {
+    return {
+      ok: false,
+      error: {
+        code: 'oversize',
+        source,
+        path,
+        bytes: stripped.length,
+        cap: SUPERVISOR_APPEND_PROMPT_BYTE_CAP,
+        message: `Supervisor append prompt exceeds the ${SUPERVISOR_APPEND_PROMPT_BYTE_CAP}-byte cap (got ${stripped.length} bytes) from source ${source}${path ? ` at ${path}` : ''}.`,
+      },
+    };
+  }
+  const decoded = stripped.toString('utf8').trimEnd();
+  return { ok: true, text: decoded.length === 0 ? null : decoded };
+}
+
+function stripUtf8Bom(bytes: Buffer): Buffer {
+  if (bytes.length >= 3 && bytes[0] === 0xef && bytes[1] === 0xbb && bytes[2] === 0xbf) {
+    return bytes.subarray(3);
+  }
+  return bytes;
+}
+
+function describeSource(source: AppendSource): string {
+  switch (source) {
+    case 'cli-inline': return '--append-system-prompt';
+    case 'cli-file': return '--append-system-prompt-file';
+    case 'env-inline': return 'AGENT_ORCHESTRATOR_CLAUDE_APPEND_SYSTEM_PROMPT';
+    case 'env-file': return 'AGENT_ORCHESTRATOR_CLAUDE_APPEND_SYSTEM_PROMPT_FILE';
+    case 'convention-file': return 'convention file';
+    case 'none': return 'none';
+  }
+}
+
+export type ConventionPromptProbeResult =
+  | { kind: 'regular'; path: string }
+  | { kind: 'absent' }
+  | { kind: 'skipped-non-regular'; path: string; reason: string; notice: string }
+  | { kind: 'error'; error: AppendPromptError };
+
+/**
+ * Cheap, body-free presence/non-regular probe for the convention file. Only
+ * the convention path is subject to the lstat regular-file guard. CLI- and
+ * env-named paths are read as-is by `readAppendPromptFile`.
+ */
+export async function probeConventionAppendPromptFile(path: string): Promise<ConventionPromptProbeResult> {
+  try {
+    const info = await lstat(path);
+    if (!info.isFile()) {
+      const reason = describeNonRegular(info);
+      return {
+        kind: 'skipped-non-regular',
+        path,
+        reason,
+        notice: `agent-orchestrator: skipping convention system-prompt file at ${path}: not a regular file (${reason})`,
+      };
+    }
+    return { kind: 'regular', path };
+  } catch (error) {
+    const code = errnoCode(error);
+    if (code === 'ENOENT') return { kind: 'absent' };
+    return {
+      kind: 'error',
+      error: {
+        code: 'read-failed',
+        source: 'convention-file',
+        path,
+        cause: errorMessage(error),
+        message: `Failed to inspect convention system-prompt file at ${path}: ${errorMessage(error)}`,
+      },
+    };
+  }
+}
+
+export interface LoadAppendPromptInput {
+  kind: 'cli-file' | 'env-file' | 'convention-file';
+  source: AppendSource;
+  path: string;
+}
+
+export type LoadAppendPromptResult =
+  | { kind: 'loaded'; path: string; bytes: Buffer }
+  | { kind: 'absent' }
+  | { kind: 'error'; error: AppendPromptError };
+
+/**
+ * Reads the bytes of an append-prompt source. Convention-file callers should
+ * call `probeConventionAppendPromptFile` first so the lstat regular-file
+ * guard runs separately; this function trusts the caller to read only the
+ * winning source and treats missing CLI/env files as a typed `missing-file`
+ * error while keeping missing convention reads silent.
+ */
+export async function readAppendPromptFile(
+  input: LoadAppendPromptInput,
+): Promise<LoadAppendPromptResult> {
+  try {
+    const bytes = await readFile(input.path);
+    return { kind: 'loaded', path: input.path, bytes };
+  } catch (error) {
+    const code = errnoCode(error);
+    if (input.kind === 'convention-file' && code === 'ENOENT') {
+      return { kind: 'absent' };
+    }
+    if (input.kind !== 'convention-file' && code === 'ENOENT') {
+      return {
+        kind: 'error',
+        error: {
+          code: 'missing-file',
+          source: input.kind,
+          path: input.path,
+          message: `Supervisor append-prompt file not found for source ${input.source} at ${input.path}.`,
+        },
+      };
+    }
+    return {
+      kind: 'error',
+      error: {
+        code: 'read-failed',
+        source: input.source,
+        path: input.path,
+        cause: errorMessage(error),
+        message: `Failed to read supervisor append-prompt file for source ${input.source} at ${input.path}: ${errorMessage(error)}`,
+      },
+    };
+  }
+}
+
+/**
+ * Back-compat shim retained so existing callers can keep using a single
+ * entry point. Convention-file kind composes the lstat probe and the read.
+ */
+export async function loadAppendPromptSource(
+  input: LoadAppendPromptInput,
+): Promise<LoadAppendPromptResult | { kind: 'skipped-non-regular'; path: string; reason: string; notice: string }> {
+  if (input.kind === 'convention-file') {
+    const probe = await probeConventionAppendPromptFile(input.path);
+    if (probe.kind === 'absent') return { kind: 'absent' };
+    if (probe.kind === 'skipped-non-regular') {
+      return { kind: 'skipped-non-regular', path: probe.path, reason: probe.reason, notice: probe.notice };
+    }
+    if (probe.kind === 'error') return { kind: 'error', error: probe.error };
+  }
+  return readAppendPromptFile(input);
+}
+
+function describeNonRegular(info: { isSymbolicLink: () => boolean; isDirectory: () => boolean; isFIFO: () => boolean; isSocket: () => boolean; isCharacterDevice: () => boolean; isBlockDevice: () => boolean }): string {
+  if (info.isSymbolicLink()) return 'symlink';
+  if (info.isDirectory()) return 'directory';
+  if (info.isFIFO()) return 'fifo';
+  if (info.isSocket()) return 'socket';
+  if (info.isCharacterDevice()) return 'character device';
+  if (info.isBlockDevice()) return 'block device';
+  return 'non-regular file';
+}
+
+function errnoCode(error: unknown): string | null {
+  if (typeof error === 'object' && error && 'code' in error) {
+    const code = (error as { code?: unknown }).code;
+    if (typeof code === 'string') return code;
+  }
+  return null;
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/src/claude/config.ts
+++ b/src/claude/config.ts
@@ -14,6 +14,7 @@ import {
 } from './permission.js';
 import { buildMonitorBashCommand, type ResolvedMonitorPin } from './monitorPin.js';
 import type { ResolvedClaudeSkill } from './skills.js';
+import { SUPERVISOR_APPEND_PROMPT_DELIMITER, type AppendSource } from './appendPrompt.js';
 
 export interface ClaudeHarnessConfigInput {
   targetCwd: string;
@@ -36,6 +37,18 @@ export interface ClaudeHarnessConfigInput {
   orchestratorId?: string;
   /** Embed Remote Control settings keys when true (Decision 12). */
   remoteControl?: boolean;
+  /**
+   * Resolved user-supplied supervisor prompt append (issue #56).
+   * When `text` is a non-empty string, `buildSupervisorSystemPrompt` appends
+   * the literal delimiter followed by the user text after the harness prompt.
+   * When omitted or when `text` is null/empty, the supervisor prompt is
+   * byte-identical to the no-append baseline.
+   */
+  userAppendSystemPrompt?: {
+    source: AppendSource;
+    path: string | null;
+    text: string | null;
+  };
 }
 
 export interface ClaudeMcpConfig {
@@ -55,6 +68,12 @@ export interface ClaudeHarnessConfig {
   settings: ClaudeSupervisorSettings;
   mcpConfig: ClaudeMcpConfig;
   monitorPin: ResolvedMonitorPin;
+  /** Source tag for the user-supplied supervisor prompt (issue #56). */
+  userSystemPromptSource: AppendSource;
+  /** Resolved path for file-backed user append sources; null otherwise. */
+  userSystemPromptPath: string | null;
+  /** Decoded user append text; null when no append is in effect or text is empty/whitespace-only. */
+  userSystemPromptAppend: string | null;
 }
 
 export function buildClaudeHarnessConfig(input: ClaudeHarnessConfigInput): ClaudeHarnessConfig {
@@ -83,11 +102,15 @@ export function buildClaudeHarnessConfig(input: ClaudeHarnessConfigInput): Claud
       },
     },
   };
+  const userAppend = input.userAppendSystemPrompt;
   return {
     systemPrompt: buildSupervisorSystemPrompt(input),
     settings,
     mcpConfig,
     monitorPin: input.monitorPin,
+    userSystemPromptSource: userAppend?.source ?? 'none',
+    userSystemPromptPath: userAppend?.path ?? null,
+    userSystemPromptAppend: userAppend?.text ?? null,
   };
 }
 
@@ -115,7 +138,7 @@ export {
 function buildSupervisorSystemPrompt(input: ClaudeHarnessConfigInput): string {
   const allowedMcpTools = claudeOrchestratorMcpToolAllowList();
   const monitorPin = input.monitorPin;
-  return [
+  const harness = [
     'You are the Agent Orchestrator supervisor running inside a restricted Claude Code launch.',
     '',
     'Hard isolation contract:',
@@ -202,6 +225,11 @@ function buildSupervisorSystemPrompt(input: ClaudeHarnessConfigInput): string {
     'Embedded orchestration workflow instructions:',
     formatEmbeddedOrchestrationSkills(input.orchestrationSkills),
   ].join('\n');
+  const userText = input.userAppendSystemPrompt?.text;
+  if (typeof userText === 'string' && userText.length > 0) {
+    return `${harness}${SUPERVISOR_APPEND_PROMPT_DELIMITER}${userText}`;
+  }
+  return harness;
 }
 
 function formatProfileDiagnostics(profiles: ValidatedWorkerProfiles | undefined, diagnostics: string[]): string {

--- a/src/claude/launcher.ts
+++ b/src/claude/launcher.ts
@@ -29,11 +29,26 @@ import {
   CLAUDE_MCP_SERVER_NAME,
   stringifyClaudeMcpConfig,
 } from './config.js';
+import {
+  CONVENTION_APPEND_PROMPT_RELATIVE_PATH,
+  probeConventionAppendPromptFile,
+  readAppendPromptFile,
+  resolveSupervisorAppendPrompt,
+  type AppendSource,
+  type LoadedAppendContent,
+} from './appendPrompt.js';
 import { discoverClaudeSurface, summarizeReport, type ClaudeSurfaceReport } from './discovery.js';
 import { buildClaudeAllowedToolsList, CLAUDE_SUPERVISOR_BUILTIN_TOOLS, stringifyClaudeSupervisorSettings } from './permission.js';
 import { resolveMonitorPin } from './monitorPin.js';
 import { validateClaudePassthroughArgs } from './passthrough.js';
 import { curateOrchestrateSkills, mirrorClaudeProjectSkills } from './skills.js';
+
+export interface AppendSystemPromptCandidates {
+  cliInline: string | null;
+  cliFile: string | null;
+  envInline: string | null;
+  envFile: string | null;
+}
 
 export interface ParsedClaudeLauncherArgs {
   cwd: string;
@@ -50,6 +65,8 @@ export interface ParsedClaudeLauncherArgs {
   remoteControl: boolean;
   remoteControlSessionNamePrefix: string | null;
   orchestratorLabel: string | null;
+  appendCandidates: AppendSystemPromptCandidates;
+  disableAppendSystemPrompt: boolean;
 }
 
 export function parseClaudeLauncherArgs(
@@ -78,6 +95,9 @@ export function parseClaudeLauncherArgs(
   let remoteControl = false;
   let remoteControlSessionNamePrefix: string | null = null;
   let orchestratorLabel: string | null = null;
+  let cliAppendInline: string | null = null;
+  let cliAppendFile: string | null = null;
+  let disableAppendSystemPrompt = false;
 
   try {
     for (let index = 0; index < ownArgs.length; index += 1) {
@@ -107,6 +127,12 @@ export function parseClaudeLauncherArgs(
         remoteControlSessionNamePrefix = readOptionValue(ownArgs, ++index, arg);
       } else if (arg === '--orchestrator-label') {
         orchestratorLabel = readOptionValue(ownArgs, ++index, arg);
+      } else if (arg === '--append-system-prompt') {
+        cliAppendInline = readOptionValue(ownArgs, ++index, arg);
+      } else if (arg === '--append-system-prompt-file') {
+        cliAppendFile = readOptionValue(ownArgs, ++index, arg);
+      } else if (arg === '--no-append-system-prompt') {
+        disableAppendSystemPrompt = true;
       } else {
         return { ok: false, error: `Unknown option: ${arg}. Pass Claude arguments after --.` };
       }
@@ -115,12 +141,39 @@ export function parseClaudeLauncherArgs(
     return { ok: false, error: error instanceof Error ? error.message : String(error) };
   }
 
+  // --no-append-system-prompt is the explicit escape hatch (Decision 9). When
+  // set, it forces source = 'none' and suppresses every other source, so it
+  // MUST short-circuit the CLI inline+file and env inline+file conflict
+  // checks. Otherwise an operator could not use the escape hatch to override
+  // a misconfigured environment (e.g., both CI-injected env vars set, or both
+  // CLI flags supplied in a debug script).
+  const envAppendInlineRaw = stringOrNullEnv(env.AGENT_ORCHESTRATOR_CLAUDE_APPEND_SYSTEM_PROMPT);
+  const envAppendFileRaw = stringOrNullEnv(env.AGENT_ORCHESTRATOR_CLAUDE_APPEND_SYSTEM_PROMPT_FILE);
+  if (!disableAppendSystemPrompt) {
+    if (cliAppendInline !== null && cliAppendFile !== null) {
+      return {
+        ok: false,
+        error: 'Cannot combine --append-system-prompt and --append-system-prompt-file. Choose one or use --no-append-system-prompt to disable both.',
+      };
+    }
+    if (envAppendInlineRaw !== null && envAppendFileRaw !== null) {
+      return {
+        ok: false,
+        error: 'Cannot combine AGENT_ORCHESTRATOR_CLAUDE_APPEND_SYSTEM_PROMPT and AGENT_ORCHESTRATOR_CLAUDE_APPEND_SYSTEM_PROMPT_FILE. Set one or use --no-append-system-prompt to disable both.',
+      };
+    }
+  }
+  const envAppendInline = envAppendInlineRaw;
+  const envAppendFile = envAppendFileRaw;
+
   const resolvedCwd = resolve(defaultCwd, cwd);
   const defaultProfilesPath = defaultWorkerProfilesFile(env);
   const resolvedProfilesFile = resolve(resolvedCwd, profilesFile ?? defaultProfilesPath);
   const resolvedSkillsPath = resolve(resolvedCwd, skillsPath ?? '.agents/skills');
   const defaultStateDir = join(env.AGENT_ORCHESTRATOR_HOME || resolveStoreRoot(), 'claude-supervisor');
   const resolvedStateDir = resolve(defaultCwd, stateDir ?? defaultStateDir);
+  const resolvedCliAppendFile = cliAppendFile !== null ? resolve(resolvedCwd, cliAppendFile) : null;
+  const resolvedEnvAppendFile = envAppendFile !== null ? resolve(resolvedCwd, envAppendFile) : null;
   return {
     ok: true,
     value: {
@@ -138,8 +191,25 @@ export function parseClaudeLauncherArgs(
       remoteControl,
       remoteControlSessionNamePrefix,
       orchestratorLabel,
+      appendCandidates: {
+        cliInline: cliAppendInline,
+        cliFile: resolvedCliAppendFile,
+        envInline: envAppendInline,
+        envFile: resolvedEnvAppendFile,
+      },
+      disableAppendSystemPrompt,
     },
   };
+}
+
+// An empty AGENT_ORCHESTRATOR_CLAUDE_APPEND_SYSTEM_PROMPT[_FILE] value is
+// treated as **unset** so an empty inherited env var falls through to the
+// next precedence step. To force suppression, use --no-append-system-prompt
+// explicitly. Whitespace-only inline values keep their source tag and are
+// reported as `(empty)` by --print-config.
+function stringOrNullEnv(value: string | undefined): string | null {
+  if (typeof value !== 'string' || value.length === 0) return null;
+  return value;
 }
 
 export interface ClaudeLauncherIo {
@@ -167,6 +237,10 @@ export interface BuiltClaudeEnvelope {
   spawnArgs: string[];
   spawnEnv: NodeJS.ProcessEnv;
   cleanup: () => Promise<void>;
+  userSystemPromptSource: AppendSource;
+  userSystemPromptPath: string | null;
+  userSystemPromptAppend: string | null;
+  conventionSkipNotice: string | null;
 }
 
 export async function runClaudeLauncher(
@@ -229,17 +303,26 @@ export async function runClaudeLauncher(
   const orchestratorId = ulid();
   const display = captureSupervisorDisplay(env, options);
 
-  const built = await buildClaudeEnvelope({
-    options,
-    env,
-    catalog,
-    profilesResult,
-    orchestratorId,
-    remoteControl: options.remoteControl,
-    display,
-  });
+  let built: BuiltClaudeEnvelope;
+  try {
+    built = await buildClaudeEnvelope({
+      options,
+      env,
+      catalog,
+      profilesResult,
+      orchestratorId,
+      remoteControl: options.remoteControl,
+      display,
+    });
+  } catch (error) {
+    io.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+    return 1;
+  }
+  if (built.conventionSkipNotice) {
+    io.stderr.write(`${built.conventionSkipNotice}\n`);
+  }
   if (options.printConfig) {
-    io.stdout.write(`# system prompt\n${built.systemPrompt}\n\n# settings.json\n${built.settingsContent}\n# mcp.json\n${built.mcpConfigContent}\n# launch cwd\n${built.launchCwd}\n# runtime skills root\n${built.userSkillsRoot}\n# runtime skills\n${built.userSkillNames.join(', ') || 'none'}\n# spawn args\n${JSON.stringify(built.spawnArgs)}\n# orchestrator id\n${orchestratorId}\n# orchestrator label\n${orchestratorLabelFor(options)}\n# remote control\n${options.remoteControl ? 'enabled' : 'disabled'}\n# display\n${JSON.stringify(display)}\n`);
+    io.stdout.write(`# system prompt\n${built.systemPrompt}\n\n${formatUserSystemPromptSections(built)}# settings.json\n${built.settingsContent}\n# mcp.json\n${built.mcpConfigContent}\n# launch cwd\n${built.launchCwd}\n# runtime skills root\n${built.userSkillsRoot}\n# runtime skills\n${built.userSkillNames.join(', ') || 'none'}\n# spawn args\n${JSON.stringify(built.spawnArgs)}\n# orchestrator id\n${orchestratorId}\n# orchestrator label\n${orchestratorLabelFor(options)}\n# remote control\n${options.remoteControl ? 'enabled' : 'disabled'}\n# display\n${JSON.stringify(display)}\n`);
     await built.cleanup();
     return 0;
   }
@@ -397,10 +480,39 @@ Options:
                                      Forwarded to Claude as --remote-control-session-name-prefix.
   --orchestrator-label <name>        Label written to the orchestrator record's display.base_title and
                                      surfaced to user status hooks. Defaults to basename(cwd).
+  --append-system-prompt <text>      Append <text> to the supervisor system prompt after the harness
+                                     contract. Append-only; the harness-owned isolation contract, MCP
+                                     allowlist, and embedded orchestrate-* instructions stay intact.
+  --append-system-prompt-file <path> Append the contents of <path> to the supervisor system prompt.
+                                     Path is resolved against the resolved target cwd. Max 64 KB after
+                                     a leading UTF-8 BOM is stripped (trailing whitespace is trimmed).
+  --no-append-system-prompt          Suppress every append source for this launch: CLI flag, env vars,
+                                     and the convention file under .agents/orchestrator/system-prompt.md.
   --print-discovery                  Print the Claude binary compatibility report and exit.
   --print-config                     Print the generated supervisor envelope (system prompt, settings, mcp, runtime skills) and exit.
   --help
   --version [--json]                 Print agent-orchestrator-claude version and exit. Use \`-- --version\` to forward to the wrapped Claude binary.
+
+Supervisor prompt customization (append-only):
+  Precedence (top wins):
+    1. --no-append-system-prompt              (forces "none"; suppresses all below)
+    2. --append-system-prompt <text>          (cli-inline)
+    3. --append-system-prompt-file <path>     (cli-file)
+    4. AGENT_ORCHESTRATOR_CLAUDE_APPEND_SYSTEM_PROMPT        (env-inline)
+    5. AGENT_ORCHESTRATOR_CLAUDE_APPEND_SYSTEM_PROMPT_FILE   (env-file)
+    6. <resolved-cwd>/.agents/orchestrator/system-prompt.md  (convention file; opt-in by presence)
+  CLI inline and CLI file together is a parse error; the same applies to the
+  two env vars together. --no-append-system-prompt overrides those checks
+  (the escape hatch always wins and produces "none"). Empty env-var values
+  are treated as unset and fall through to the next precedence step. When a
+  higher-precedence source preempts a present convention file, a single-line
+  stderr notice names the skipped path. A
+  convention file that is a symlink, directory, or other non-regular file is
+  refused with a stderr notice and treated as absent. The wire-level tool
+  allowlist (--tools / --allowed-tools / --permission-mode dontAsk) is the
+  authoritative tool gate regardless of any user prompt text. Reminder:
+  --append-system-prompt[-file] *after* \`--\` is forbidden by the passthrough
+  validator because the harness owns that Claude flag.
 
 Passthrough after --:
   Allowed Claude flags: --print, -p, --output-format, --input-format, --include-partial-messages,
@@ -423,6 +535,8 @@ Environment fallbacks:
   AGENT_ORCHESTRATOR_CLAUDE_SKILLS_PATH
   AGENT_ORCHESTRATOR_CLAUDE_STATE_DIR
   AGENT_ORCHESTRATOR_CLAUDE_BIN
+  AGENT_ORCHESTRATOR_CLAUDE_APPEND_SYSTEM_PROMPT       (env-inline supervisor prompt append)
+  AGENT_ORCHESTRATOR_CLAUDE_APPEND_SYSTEM_PROMPT_FILE  (env-file supervisor prompt append)
 `;
 }
 
@@ -477,6 +591,7 @@ export async function buildClaudeEnvelope(input: {
     await writeFile(inlineManifestPath, inlineContent, { mode: 0o600 });
     manifestPath = inlineManifestPath;
   }
+  const appendOutcome = await resolveAppendSystemPromptForEnvelope(options);
   const config = buildClaudeHarnessConfig({
     targetCwd: options.cwd,
     manifestPath,
@@ -492,6 +607,11 @@ export async function buildClaudeEnvelope(input: {
     monitorPin,
     orchestratorId: input.orchestratorId,
     remoteControl: input.remoteControl,
+    userAppendSystemPrompt: {
+      source: appendOutcome.source,
+      path: appendOutcome.path,
+      text: appendOutcome.text,
+    },
   });
   const settingsPath = join(envelopeDir, 'settings.json');
   const userSettingsPath = join(stateClaudeConfigDir, 'settings.json');
@@ -546,7 +666,115 @@ export async function buildClaudeEnvelope(input: {
     spawnArgs,
     spawnEnv,
     cleanup,
+    userSystemPromptSource: config.userSystemPromptSource,
+    userSystemPromptPath: config.userSystemPromptPath,
+    userSystemPromptAppend: config.userSystemPromptAppend,
+    conventionSkipNotice: appendOutcome.conventionSkipNotice,
   };
+}
+
+async function resolveAppendSystemPromptForEnvelope(
+  options: ParsedClaudeLauncherArgs,
+): Promise<{
+  source: AppendSource;
+  path: string | null;
+  text: string | null;
+  conventionSkipNotice: string | null;
+}> {
+  // --no-append-system-prompt short-circuits before any probe or read. No
+  // disk I/O happens here, matching the escape-hatch semantics.
+  if (options.disableAppendSystemPrompt) {
+    return { source: 'none', path: null, text: null, conventionSkipNotice: null };
+  }
+  const candidates = options.appendCandidates;
+  const conventionPath = resolve(options.cwd, CONVENTION_APPEND_PROMPT_RELATIVE_PATH);
+
+  // Step 1: lstat-probe the convention path always so a higher-precedence
+  // source can fire the precedence-skip notice, and so a non-regular
+  // convention file emits the lstat skip notice without ever reading its
+  // bytes. CLI/env file bodies are NOT read in this step.
+  const probe = await probeConventionAppendPromptFile(conventionPath);
+  let lstatSkipNotice: string | null = null;
+  let conventionFilePresent = false;
+  if (probe.kind === 'regular') {
+    conventionFilePresent = true;
+  } else if (probe.kind === 'skipped-non-regular') {
+    lstatSkipNotice = probe.notice;
+  } else if (probe.kind === 'error') {
+    throw new Error(probe.error.message);
+  }
+
+  // Step 2: determine the winning source from inputs alone (no I/O). This is
+  // exactly the precedence rule the resolver applies.
+  const winner = selectAppendWinnerFromInputs({
+    cliInline: candidates.cliInline,
+    cliFile: candidates.cliFile,
+    envInline: candidates.envInline,
+    envFile: candidates.envFile,
+    conventionFilePresent,
+  });
+
+  // Step 3: only read the body of the winning file source. A preempted
+  // missing/oversize/unreadable lower-precedence source must NOT fail the
+  // launch.
+  let cliFileLoaded: LoadedAppendContent | undefined;
+  let envFileLoaded: LoadedAppendContent | undefined;
+  let conventionLoaded: LoadedAppendContent | undefined;
+  if (winner === 'cli-file' && candidates.cliFile !== null) {
+    const result = await readAppendPromptFile({ kind: 'cli-file', source: 'cli-file', path: candidates.cliFile });
+    if (result.kind === 'error') throw new Error(result.error.message);
+    if (result.kind === 'loaded') cliFileLoaded = { bytes: result.bytes, path: result.path };
+  } else if (winner === 'env-file' && candidates.envFile !== null) {
+    const result = await readAppendPromptFile({ kind: 'env-file', source: 'env-file', path: candidates.envFile });
+    if (result.kind === 'error') throw new Error(result.error.message);
+    if (result.kind === 'loaded') envFileLoaded = { bytes: result.bytes, path: result.path };
+  } else if (winner === 'convention-file') {
+    const result = await readAppendPromptFile({ kind: 'convention-file', source: 'convention-file', path: conventionPath });
+    if (result.kind === 'error') throw new Error(result.error.message);
+    if (result.kind === 'loaded') conventionLoaded = { bytes: result.bytes, path: result.path };
+  }
+
+  // Step 4: hand the bytes (only for the winner) to the pure resolver, which
+  // applies the BOM/trim/CRLF policy and the byte-cap check.
+  const resolved = resolveSupervisorAppendPrompt({
+    cliInlineText: candidates.cliInline,
+    cliFilePath: candidates.cliFile,
+    envInlineText: candidates.envInline,
+    envFilePath: candidates.envFile,
+    conventionFilePath: conventionPath,
+    conventionFilePresent,
+    disable: false,
+    loaded: {
+      cliFile: cliFileLoaded,
+      envFile: envFileLoaded,
+      convention: conventionLoaded,
+    },
+  });
+  if (!resolved.ok) {
+    throw new Error(resolved.error.message);
+  }
+  const notice = lstatSkipNotice ?? resolved.value.conventionSkipNotice;
+  return {
+    source: resolved.value.source,
+    path: resolved.value.path,
+    text: resolved.value.text,
+    conventionSkipNotice: notice,
+  };
+}
+
+function selectAppendWinnerFromInputs(input: {
+  cliInline: string | null;
+  cliFile: string | null;
+  envInline: string | null;
+  envFile: string | null;
+  conventionFilePresent: boolean;
+}): AppendSource {
+  if (input.cliInline !== null) return 'cli-inline';
+  if (input.cliFile !== null) return 'cli-file';
+  if (input.envInline !== null) return 'env-inline';
+  if (input.envFile !== null) return 'env-file';
+  if (input.conventionFilePresent) return 'convention-file';
+  return 'none';
 }
 
 export function buildClaudeSpawnArgs(input: {
@@ -713,6 +941,24 @@ async function resetClaudeProjectDiscoverySurface(envelopeDir: string): Promise<
 function sanitizePathSegment(value: string): string {
   const sanitized = value.replace(/[^A-Za-z0-9._-]+/g, '-').replace(/^-+|-+$/g, '');
   return sanitized.slice(0, 48) || 'workspace';
+}
+
+function formatUserSystemPromptSections(built: BuiltClaudeEnvelope): string {
+  const source = built.userSystemPromptSource;
+  const path = built.userSystemPromptPath;
+  const text = built.userSystemPromptAppend;
+  const isFileSource = source === 'cli-file' || source === 'env-file' || source === 'convention-file';
+  const sourceTag = source !== 'none' && (text === null || text.length === 0)
+    ? `${source} (empty)`
+    : source;
+  let out = `# user system prompt source\n${sourceTag}\n`;
+  if (isFileSource && path) {
+    out += `# user system prompt path\n${path}\n`;
+  }
+  if (typeof text === 'string' && text.length > 0) {
+    out += `# user system prompt (append)\n${text}\n\n`;
+  }
+  return out;
 }
 
 function readOptionValue(args: readonly string[], index: number, option: string): string {

--- a/src/claude/passthrough.ts
+++ b/src/claude/passthrough.ts
@@ -56,6 +56,12 @@ export function validateClaudePassthroughArgs(args: readonly string[]): Passthro
     if (!arg.startsWith('-')) continue;
     const flag = arg.includes('=') ? arg.slice(0, arg.indexOf('=')) : arg;
     if (FORBIDDEN_FLAGS.has(flag)) {
+      if (flag === '--append-system-prompt' || flag === '--append-system-prompt-file') {
+        return {
+          ok: false,
+          error: `Claude orchestration mode rejects ${flag} after --: the harness owns this surface. Use the launcher flag \`agent-orchestrator claude ${flag} ...\` (before --) or the AGENT_ORCHESTRATOR_CLAUDE_APPEND_SYSTEM_PROMPT[_FILE] env var instead.`,
+        };
+      }
       return { ok: false, error: `Claude orchestration mode rejects ${flag}: the harness owns this surface.` };
     }
     if (!ALLOWED_FLAG_TOKENS.has(flag)) {


### PR DESCRIPTION
## Summary

- Adds an append-only user customization slot to the Claude supervisor system prompt. Harness-owned isolation contract, MCP allowlist, monitor-pin invariants, profile diagnostics, and embedded `orchestrate-*` instructions stay intact; user text is concatenated after the harness prompt into the existing envelope `system-prompt.md`.
- Exposes three surfaces with strict precedence: CLI flags (`--append-system-prompt <text>` / `--append-system-prompt-file <path>`), env-var fallbacks (`AGENT_ORCHESTRATOR_CLAUDE_APPEND_SYSTEM_PROMPT` / `..._FILE`), and an auto-loaded convention file at `<targetCwd>/.agents/orchestrator/system-prompt.md`. `--no-append-system-prompt` is an explicit escape hatch that suppresses every source.
- Spawn args are unchanged — still a single `--append-system-prompt-file <envelope-file>`. No new Claude flag surface, no second `--append-system-prompt-file` instance.
- New pure resolver in `src/claude/appendPrompt.ts` with a discriminated `AppendSource` (`cli-inline` | `cli-file` | `env-inline` | `env-file` | `convention-file` | `none`), 64 KB byte cap, BOM/CRLF/trim-end handling, and an `lstat` regular-file guard for the convention file only.
- `--print-config` always emits `# user system prompt source` (with the `none` sentinel) and renders `# user system prompt (append)` when non-empty; a `# user system prompt path` line is added for file-backed sources.
- Passthrough rejection for `--append-system-prompt(-file)` after `--` now names the launcher flag in its error message.
- Docs: new "Customizing the Claude supervisor system prompt (append-only)" subsection in `docs/development/mcp-tooling.md`.

## Issue

Closes #56

## Verification

- [x] `pnpm verify` — exit 0
- [x] Tests: 613 total / 611 pass / 0 fail / 2 skipped (pre-existing). New file `src/__tests__/claudeAppendPrompt.test.ts` adds 48 tests covering parser conflicts, source resolution and precedence, missing/empty/oversize handling, BOM/CRLF/trim, envelope contents, spawn args, and `--print-config` rendering.
- [x] `pnpm audit --prod` — clean
- [x] `npm pack --dry-run` — OK; dist-tag `latest`; publish-ready

## Checklist

- [x] The change is scoped to the described behavior or setup work.
- [x] Public behavior, MCP contracts, and CLI output are documented when changed (`--help`, `--print-config`, docs).
- [x] Tests cover daemon lifecycle, run-store persistence, backend invocation, MCP contracts, or release behavior when those areas are touched (harness-config and launcher coverage extended).
- [x] No secrets, local credentials, private tokens, or `.env` contents are included.
- [x] Package, publishing, or external-service behavior is unchanged unless explicitly intended.

Plan and execution log: [plans/56-make-system-prompt-configurable/plans/56-configurable-supervisor-system-prompt.md](../blob/56-make-system-prompt-configurable/plans/56-make-system-prompt-configurable/plans/56-configurable-supervisor-system-prompt.md)

Notes (informational):
- The unreadable-convention-file test skips under root and is exercised non-root in CI.
- `loadAppendPromptSource` is retained as a thin compatibility wrapper; removable in a follow-up if desired.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Users can append custom text to the Claude supervisor system prompt via CLI flags, env vars, or a repo convention file; includes a `--no-append-system-prompt` escape hatch, precedence rules, and `--print-config` output of chosen append details.

* **Bug Fixes / Validation**
  * Enforced 64KiB byte cap, UTF‑8 BOM stripping, trimming rules, and clear errors for missing/oversize inputs.

* **Documentation**
  * Added developer docs and updated help text.

* **Tests**
  * Comprehensive end-to-end tests for parsing, precedence, file handling, and errors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ralphkrauss/agent-orchestrator/pull/61)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->