### PR TITLE
Improve watch TUI

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -88,9 +88,74 @@ agent-orchestrator runs
 agent-orchestrator runs --json
 agent-orchestrator runs --json --prompts
 agent-orchestrator watch
+agent-orchestrator watch --recent-events 300
 ```
 
-`watch` opens an interactive terminal dashboard. Detail views include raw prompt, recent activity, model/source, session-resume audit state, artifact paths, and size indicators.
+`watch` opens an Ink-based interactive terminal dashboard designed for SSH and
+ordinary terminal panes. The default view focuses on live orchestrator sessions
+registered with the daemon. Each live orchestrator is shown as a collapsible
+group in the left sidebar, and expanded groups list worker conversations rather
+than raw run records. Completed workers remain visible while their orchestrator
+is live. When an orchestrator exits or reports `session_ended`, it leaves the
+live list and remains available from the archive view.
+
+The main pane has two deliberately different surfaces:
+
+- Selecting an orchestrator opens an overview dashboard with a double border,
+  worker counts, workspace context, elapsed session time, last-update age, and
+  one compact status row per named worker.
+- Selecting a worker opens a `Worker Timeline` chat view. Every run round has a
+  colored left rail, so the run start marker, supervisor prompt, tool activity,
+  worker messages, and run end marker are visually grouped.
+
+- Oldest loaded content appears above newer content, with the latest content at
+  the bottom like a chat history. Short transcripts are bottom-aligned in the
+  pane instead of floating at the top.
+- The view follows new output automatically until you scroll up.
+- The TUI explicitly enters raw input mode and decodes terminal escape
+  sequences itself. Mouse wheel scrolling is enabled in terminals that report
+  SGR, urxvt, or legacy X10 mouse wheel events, with each wheel tick moving one
+  rendered transcript row. Press `m` to release terminal mouse capture for
+  native text selection in the transcript pane, and press `m` again to restore
+  wheel scrolling.
+- The main pane shows a scroll indicator and a `top`/percentage/`bottom` label
+  so the current viewport position is visible.
+- Scrollback is independent of terminal height; `--recent-events <n>` controls
+  how many worker events are loaded per run.
+- Initial worker prompts and follow-up child runs are folded into one worker
+  conversation using parent run links and backend session ids. Follow-ups render
+  as `Supervisor -> Worker` turns inside the transcript, followed by distinct
+  `Worker message`, `Tool call`, `Tool result`, `Worker activity`, and
+  `Final response` entries.
+- Run completion status is shown on run boundary markers, not stamped onto old
+  chat messages.
+- Assistant and prompt text is rendered with real terminal Markdown handling
+  for paragraphs, lists, code fences, inline code, headings, links,
+  blockquotes, and tables where practical.
+- Worker timeline prompt, assistant, and final-response text wraps inside the
+  pane rather than being truncated. Source line breaks in Markdown responses
+  are preserved, including final answers. Compact summaries are reserved for
+  the overview and sidebar surfaces.
+- Tool calls and tool results are summarized by tool name, command/status, and
+  concise result or error text. Full raw tool payloads are not dumped by
+  default.
+
+Keyboard controls:
+
+| Key | Action |
+|---|---|
+| `Up` / `Down`, `k` / `j` | Move selection in the sidebar. |
+| `Space` | Collapse or expand the selected orchestrator group. |
+| `Right` / `l` | Expand the selected orchestrator group. |
+| `Left` / `h` | Collapse the selected orchestrator group. |
+| `a` / `Tab` | Toggle between live orchestrators and archive history. |
+| Mouse wheel | Scroll the transcript pane one rendered row at a time when mouse capture is enabled. |
+| `m` | Toggle terminal mouse capture so native text selection can be used. |
+| `u` / `d`, `Ctrl-U` / `Ctrl-D` | Scroll the transcript pane by a half page. |
+| `PageUp` / `PageDown`, `Ctrl-B` / `Ctrl-F` | Scroll the transcript pane by a full page. |
+| `g` / `Home` | Jump to the oldest loaded transcript content. |
+| `G`, `Enter`, `End`, `Ctrl-E` | Return the transcript pane to auto-follow latest output. |
+| `q` / `Ctrl-C` | Quit. |
 
 For readable dashboard labels, pass metadata on `start_run` or `send_followup`:
 

--- a/package.json
+++ b/package.json
@@ -70,6 +70,10 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.12.1",
+    "ink": "^7.0.2",
+    "marked": "^15.0.12",
+    "marked-terminal": "^7.3.0",
+    "react": "^19.2.6",
     "ulid": "^2.4.0",
     "zod": "^3.25.76"
   },
@@ -77,7 +81,9 @@
     "@cursor/sdk": "^1.0.12"
   },
   "devDependencies": {
+    "@types/marked-terminal": "^6.1.1",
     "@types/node": "^22.15.18",
+    "@types/react": "^19.2.14",
     "typescript": "^5.9.3"
   },
   "overrides": {

--- a/plans/59-improve-watch/plan.md
+++ b/plans/59-improve-watch/plan.md
@@ -1,0 +1,10 @@
+# Plan Index
+
+Branch: `59-improve-watch`
+Updated: 2026-05-12
+
+## Sub-Plans
+
+| Plan | Scope | Status | File |
+|---|---|---|---|
+| Watch TUI Refactor | Refactor `watch` into an SSH-friendly live orchestrator/session monitor with grouped workers, transcript rendering, archive flow, tests, and docs. | completed | [plans/watch-tui-refactor.md](plans/watch-tui-refactor.md) |

--- a/plans/59-improve-watch/plans/watch-tui-refactor.md
+++ b/plans/59-improve-watch/plans/watch-tui-refactor.md
@@ -1,0 +1,107 @@
+# Watch TUI Refactor
+
+Branch: `59-improve-watch`
+Plan Slug: `watch-tui-refactor`
+Created: 2026-05-12
+Status: completed
+
+## Context
+
+- User objective: fully refactor the existing `watch` command into an SSH-friendly terminal UI focused on live orchestrator sessions and grouped workers, with archive access after orchestrators exit.
+- Repository instructions read: `AGENTS.md`.
+- Rules read: `.agents/rules/node-typescript.md`, `.agents/rules/ai-workspace-projections.md`, `.agents/rules/mcp-tool-configs.md`.
+- Relevant implementation read: `src/daemon/daemonCli.ts`, `src/daemon/observabilityFormat.ts`, `src/observability.ts`, `src/contract.ts`, `src/orchestratorService.ts`, `src/daemon/orchestratorRegistry.ts`, `src/daemon/orchestratorStatus.ts`, `src/runStore.ts`.
+- Relevant tests read: `src/__tests__/observabilityFormat.test.ts`, `src/__tests__/observability.test.ts`, `src/__tests__/orchestratorStatus.test.ts`, `src/__tests__/orchestratorRegistry.test.ts`.
+- Relevant docs read: `docs/reference.md`, `docs/development/mcp-tooling.md`, `README.md`.
+
+## Decisions
+
+| # | Decision | Choice | Rationale | Rejected Alternatives |
+|---|---|---|---|---|
+| D1 | Session model | Use existing live supervisor registry plus run `metadata.orchestrator_id`; add additive observability snapshot fields for live and archived orchestrator groups. | The daemon already owns supervisor lifecycle, aggregate status, and worker ownership. This avoids inventing a parallel session model. | Group by backend session ID only; infer orchestrators from titles. |
+| D2 | Command shape | Keep `agent-orchestrator watch` and retain non-TTY snapshot fallback. | Requirement keeps the command stable and preserves script/SSH fallback behavior. | Add a separate subcommand. |
+| D3 | UI implementation | Use Ink/React for the interactive TUI while keeping the non-TTY formatter dependency-free. | The finished watch experience needs stable two-pane layout, raw input handling, mouse-wheel support, and repaint behavior that are safer to maintain through Ink than bespoke ANSI rendering. | Continue extending the earlier hand-rolled dashboard renderer. |
+| D4 | Transcript source | Build transcript lines from prompt text, recent worker events, and final response summaries in oldest-to-newest order. | Existing run-store event logs are durable and already power progress APIs. | Dump raw JSON events or stdout/stderr logs by default. |
+| D5 | Tool rendering | Summarize tool calls/results by default, showing names, commands/previews, status, and concise errors. | Matches requirement to avoid raw noisy output while preserving progress and failure context. | Render full tool payloads inline. |
+
+## Scope
+
+### In Scope
+
+- Add observability data for live orchestrators and archived orchestrator groups.
+- Group workers under orchestrator sessions, including completed workers while the orchestrator is live.
+- Replace the old watch dashboard with a two-pane live/archive TUI state model.
+- Render transcript-like prompt, assistant, lifecycle, tool call/result, error, and final response blocks.
+- Preserve non-TTY `watch` fallback and existing `runs`/`status --verbose` human output.
+- Add focused tests and docs.
+
+### Out Of Scope
+
+- Changing worker start/cancel/follow-up MCP contracts beyond additive observability snapshot fields.
+- Persisting live supervisor registry across daemon restarts beyond existing sidecar behavior.
+- Changing release, publishing, secret, hook, or external-service behavior.
+
+## Risks And Edge Cases
+
+| # | Scenario | Mitigation | Covered By |
+|---|---|---|---|
+| R1 | Registered orchestrator disappears while selected. | Clamp selection by stable item id and fall back to first live/archive item. | Formatter/TUI tests. |
+| R2 | Completed workers should remain visible only while parent orchestrator remains live. | Live groups come from registry plus owned run metadata; archive groups come from historical run metadata after live registry membership is absent. | Observability tests. |
+| R3 | Transcript history exceeds terminal height. | Maintain per-selection scroll offset and auto-follow only when not manually scrolled up. | TUI state tests. |
+| R4 | Markdown text contains lists/code/basic emphasis. | Render simple terminal Markdown blocks, lists, code fences, and paragraph wrapping without raw fence/list artifacts where avoidable. | Transcript renderer tests. |
+| R5 | Tool result payloads are huge. | Summarize names/status/errors/text preview with bounded line length. | Transcript renderer tests. |
+
+## Implementation Tasks
+
+| Task ID | Title | Depends On | Status | Acceptance Criteria |
+|---|---|---|---|---|
+| W1 | Extend observability snapshot with orchestrator groups | none | completed | Snapshot includes live orchestrators from registry/status, owned workers by `metadata.orchestrator_id`, and archive groups for non-live historical orchestrator IDs. |
+| W2 | Build transcript rendering model | W1 | completed | Renderer produces oldest-to-newest blocks with prompt inspection, Markdown-ish message rendering, high-level tool summaries, and bounded output. |
+| W3 | Replace `watch` interactive state and rendering | W1, W2 | completed | TUI shows left sidebar collapsible live sessions/workers plus archive flow and main transcript pane; keyboard navigation handles arrows, Enter, Escape, Tab/archive toggle, and scroll/follow. |
+| W4 | Add focused tests | W1, W2, W3 | completed | Tests cover grouping, live/archive behavior, worker selection, transcript rendering, and navigation/real-time clamping. |
+| W5 | Update docs/help | W3 | completed | Docs describe new watch UX, keys, live/archive semantics, transcript/Markdown/tool rendering expectations. |
+| W6 | Verify and harden | W4, W5 | completed | Targeted tests and build pass; strongest appropriate repo checks are run or documented. |
+
+## Rule Candidates
+
+| # | Candidate | Scope | Create After |
+|---|---|---|---|
+| RC1 | Prefer existing orchestrator registry and run metadata for watch/session features. | Future observability changes. | After implementation proves the pattern. |
+
+## Quality Gates
+
+- [x] `pnpm build`
+- [x] `pnpm test`
+- [x] `pnpm verify`
+
+## Execution Log
+
+### W1: Extend observability snapshot with orchestrator groups
+- **Status:** completed
+- **Evidence:** `src/contract.ts` adds additive `orchestrators` snapshot data; `src/observability.ts` derives live groups from daemon-provided registry/status snapshots and archived groups from historical `metadata.orchestrator_id`; `src/orchestratorService.ts` passes live registry state into observability snapshots. Covered by `observability.test.ts`.
+- **Notes:** Existing `sessions` and `runs` snapshot fields remain intact.
+
+### W2: Build transcript rendering model
+- **Status:** completed
+- **Evidence:** `src/daemon/watchViewModel.ts` builds orchestrator overview and worker timeline blocks with prompt blocks, event boundaries, terminal Markdown rendering, and tool call/result summaries.
+- **Notes:** `watch` requests a larger default `--recent-events` window than other snapshot consumers.
+
+### W3: Replace `watch` interactive state and rendering
+- **Status:** completed
+- **Evidence:** `src/daemon/watchApp.tsx` now provides the Ink-based two-pane TUI for live/archive mode, selection, collapsing/expanding, arrow and j/k navigation, smooth scrollback, mouse-wheel support, text-selection toggle, scroll indicators, and follow mode.
+- **Notes:** Non-TTY `watch` fallback remains `formatSnapshot` in `src/daemon/observabilityFormat.ts`.
+
+### W4: Add focused tests
+- **Status:** completed
+- **Evidence:** `src/__tests__/observability.test.ts` covers live/archive orchestrator grouping; `src/__tests__/observabilityFormat.test.ts` covers non-TTY fallback formatting; `src/__tests__/watchViewModel.test.ts` covers grouped worker conversations, overview rows, worker transcripts, Markdown/final-response preservation, tool summaries, archive flow, selection clamping, mouse-wheel decoding, and scroll/follow state.
+- **Notes:** Targeted command passed: `pnpm build && node --test dist/__tests__/observability.test.js dist/__tests__/observabilityFormat.test.js`.
+
+### W5: Update docs/help
+- **Status:** completed
+- **Evidence:** `docs/reference.md` documents the new watch UX, live/archive behavior, keyboard controls, transcript behavior, Markdown rendering, mouse/text-selection behavior, and tool-call summaries. `src/cliRoot.ts` and `src/daemon/daemonCli.ts` document `--recent-events`.
+- **Notes:** No release, secret, hook, or external-service behavior changed.
+
+### W6: Verify and harden
+- **Status:** completed
+- **Evidence:** `pnpm build` passed. `pnpm test` passed 576 tests, 574 pass, 2 skipped, 0 failed. `pnpm verify` passed earlier for the branch after the initial refactor; rerun before PR for final evidence.
+- **Notes:** `pnpm install --frozen-lockfile` was run first because `node_modules` was absent and `tsc` was unavailable.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,18 @@ importers:
       '@modelcontextprotocol/sdk':
         specifier: ^1.12.1
         version: 1.29.0(zod@3.25.76)
+      ink:
+        specifier: ^7.0.2
+        version: 7.0.2(@types/react@19.2.14)(react@19.2.6)
+      marked:
+        specifier: ^15.0.12
+        version: 15.0.12
+      marked-terminal:
+        specifier: ^7.3.0
+        version: 7.3.0(marked@15.0.12)
+      react:
+        specifier: ^19.2.6
+        version: 19.2.6
       ulid:
         specifier: ^2.4.0
         version: 2.4.0
@@ -24,9 +36,15 @@ importers:
         specifier: ^3.25.76
         version: 3.25.76
     devDependencies:
+      '@types/marked-terminal':
+        specifier: ^6.1.1
+        version: 6.1.1
       '@types/node':
         specifier: ^22.15.18
         version: 22.19.17
+      '@types/react':
+        specifier: ^19.2.14
+        version: 19.2.14
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -37,8 +55,16 @@ importers:
 
 packages:
 
+  '@alcalzone/ansi-tokenize@0.3.0':
+    resolution: {integrity: sha512-p+CMKJ93HFmLkjXKlXiVGlMQEuRb6H0MokBSwUsX+S6BRX8eV5naFZpQJFfJHjRZY0Hmnqy1/r6UWl3x+19zYA==}
+    engines: {node: '>=18'}
+
   '@bufbuild/protobuf@1.10.0':
     resolution: {integrity: sha512-QDdVFLoN93Zjg36NoQPZfsVH9tZew7wKDKyV5qRdj8ntT4wQCOradQjRaTdwMhWUYsgKsvCINKKm87FdEk96Ag==}
+
+  '@colors/colors@1.5.0':
+    resolution: {integrity: sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==}
+    engines: {node: '>=0.1.90'}
 
   '@connectrpc/connect-node@1.7.0':
     resolution: {integrity: sha512-6vaPIkG/NyhxlYgytLoR9KYbPhczEboFB2OYWkA9qvUz1K7efXfeGrlRxoLtpa+r8VxyIOw73w5ktNe743nD+A==}
@@ -112,6 +138,10 @@ packages:
     engines: {node: '>=10'}
     deprecated: This functionality has been moved to @npmcli/fs
 
+  '@sindresorhus/is@4.6.0':
+    resolution: {integrity: sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==}
+    engines: {node: '>=10'}
+
   '@statsig/client-core@3.31.0':
     resolution: {integrity: sha512-SuxQD6TmVszPG7FoMKwTk/uyBuVFk7XnxI3T/E0uyb7PL7GNjONtfsoh+NqBBVUJVse0CUeSFfgJPoZy1ZOslQ==}
 
@@ -122,8 +152,17 @@ packages:
     resolution: {integrity: sha512-VyMVKRrpHTT8PnotUeV8L/mDaMwD5DaAKCFLP73zAqAtvF0FCqky+Ki7BYbFCYQmqFyTe9316Ed5zS70QUR9eg==}
     engines: {node: '>= 10'}
 
+  '@types/cardinal@2.1.1':
+    resolution: {integrity: sha512-/xCVwg8lWvahHsV2wXZt4i64H1sdL+sN1Uoq7fAc8/FA6uYHjuIveDwPwvGUYp4VZiv85dVl6J/Bum3NDAOm8g==}
+
+  '@types/marked-terminal@6.1.1':
+    resolution: {integrity: sha512-DfoUqkmFDCED7eBY9vFUhJ9fW8oZcMAK5EwRDQ9drjTbpQa+DnBTQQCwWhTFVf4WsZ6yYcJTI8D91wxTWXRZZQ==}
+
   '@types/node@22.19.17':
     resolution: {integrity: sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==}
+
+  '@types/react@19.2.14':
+    resolution: {integrity: sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==}
 
   abbrev@1.1.1:
     resolution: {integrity: sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==}
@@ -155,9 +194,28 @@ packages:
   ajv@8.20.0:
     resolution: {integrity: sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==}
 
+  ansi-escapes@7.3.0:
+    resolution: {integrity: sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==}
+    engines: {node: '>=18'}
+
   ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
     engines: {node: '>=8'}
+
+  ansi-regex@6.2.2:
+    resolution: {integrity: sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==}
+    engines: {node: '>=12'}
+
+  ansi-styles@4.3.0:
+    resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
+    engines: {node: '>=8'}
+
+  ansi-styles@6.2.3:
+    resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
+    engines: {node: '>=12'}
+
+  any-promise@1.3.0:
+    resolution: {integrity: sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==}
 
   aproba@2.1.0:
     resolution: {integrity: sha512-tLIEcj5GuR2RSTnxNKdkK0dJ/GrC7P38sUkiDmDuHfsHmbagTFAxDVIBltoklXEVIQ/f14IL8IMJ5pn9Hez1Ew==}
@@ -166,6 +224,10 @@ packages:
     resolution: {integrity: sha512-QZW4EDmGwlYur0Yyf/b2uGucHQMa8aFUP7eu9ddR73vvhFyt4V0Vl3QHPcTNJ8l6qYOBdxgXdnBXQrHilfRQBg==}
     engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
     deprecated: This package is no longer supported.
+
+  auto-bind@5.0.1:
+    resolution: {integrity: sha512-ooviqdwwgfIfNmDwo94wlshcdzfO64XV0Cg6oDsDYBJfITDz1EngD2z7DkbvCWn+XIMsIqW27sEVF6qcpJrRcg==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
@@ -205,6 +267,18 @@ packages:
     resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
     engines: {node: '>= 0.4'}
 
+  chalk@4.1.2:
+    resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
+    engines: {node: '>=10'}
+
+  chalk@5.6.2:
+    resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
+    engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
+
+  char-regex@1.0.2:
+    resolution: {integrity: sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==}
+    engines: {node: '>=10'}
+
   chownr@1.1.4:
     resolution: {integrity: sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==}
 
@@ -219,6 +293,41 @@ packages:
   clean-stack@2.2.0:
     resolution: {integrity: sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==}
     engines: {node: '>=6'}
+
+  cli-boxes@4.0.1:
+    resolution: {integrity: sha512-5IOn+jcCEHEraYolBPs/sT4BxYCe2nHg374OPiItB1O96KZFseS2gthU4twyYzeDcFew4DaUM/xwc5BQf08JJw==}
+    engines: {node: '>=18.20 <19 || >=20.10'}
+
+  cli-cursor@4.0.0:
+    resolution: {integrity: sha512-VGtlMu3x/4DOtIUwEkRezxUZ2lBacNJCHash0N0WeZDBS+7Ux1dm3XWAgWYxLJFMMdOeXMHXorshEFhbMSGelg==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  cli-highlight@2.1.11:
+    resolution: {integrity: sha512-9KDcoEVwyUXrjcJNvHD0NFc/hiwe/WPVYIleQh2O1N2Zro5gWJZ/K+3DGn8w8P/F6FxOgzyC5bxDyHIgCSPhGg==}
+    engines: {node: '>=8.0.0', npm: '>=5.0.0'}
+    hasBin: true
+
+  cli-table3@0.6.5:
+    resolution: {integrity: sha512-+W/5efTR7y5HRD7gACw9yQjqMVvEMLBHmboM/kPWam+H+Hmyrgjh6YncVKK122YZkXrLudzTuAukUw9FnMf7IQ==}
+    engines: {node: 10.* || >= 12.*}
+
+  cli-truncate@6.0.0:
+    resolution: {integrity: sha512-3+YKIUFsohD9MIoOFPFBldjAlnfCmCDcqe6aYGFqlDTRKg80p4wg35L+j83QQ63iOlKRccEkbn8IuM++HsgEjA==}
+    engines: {node: '>=22'}
+
+  cliui@7.0.4:
+    resolution: {integrity: sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==}
+
+  code-excerpt@4.0.0:
+    resolution: {integrity: sha512-xxodCmBen3iy2i0WtAK8FlFNrRzjUqjRsMfho58xT/wvZU1YTM3fCnRjcy1gJPMepaRlgm/0e6w8SpWHpn3/cA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  color-convert@2.0.1:
+    resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
+    engines: {node: '>=7.0.0'}
+
+  color-name@1.1.4:
+    resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
 
   color-support@1.1.3:
     resolution: {integrity: sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==}
@@ -238,6 +347,10 @@ packages:
     resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
     engines: {node: '>= 0.6'}
 
+  convert-to-spaces@2.0.1:
+    resolution: {integrity: sha512-rcQ1bsQO9799wq24uE5AM2tAILy4gXGIK/njFWcVQkGNZ96edlpY+A7bjwvzjYvLDyzmG1MmMLZhpcsb+klNMQ==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
   cookie-signature@1.2.2:
     resolution: {integrity: sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==}
     engines: {node: '>=6.6.0'}
@@ -253,6 +366,9 @@ packages:
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
+
+  csstype@3.2.3:
+    resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
@@ -292,6 +408,9 @@ packages:
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
 
+  emojilib@2.4.0:
+    resolution: {integrity: sha512-5U0rVMU5Y2n2+ykNLQqMoqklN9ICBT/KsvC1Gz6vqHbz2AXXGkG+Pm5rMWk/8Vjrr/mY9985Hi8DYzn1F09Nyw==}
+
   encodeurl@2.0.0:
     resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
     engines: {node: '>= 0.8'}
@@ -305,6 +424,10 @@ packages:
   env-paths@2.2.1:
     resolution: {integrity: sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==}
     engines: {node: '>=6'}
+
+  environment@1.1.0:
+    resolution: {integrity: sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==}
+    engines: {node: '>=18'}
 
   err-code@2.0.3:
     resolution: {integrity: sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA==}
@@ -321,8 +444,19 @@ packages:
     resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
     engines: {node: '>= 0.4'}
 
+  es-toolkit@1.46.1:
+    resolution: {integrity: sha512-5eNtXOs3tbfxXOj04tjjseeWkRWaoCjdEI+96DgwzZoe6c9juL49pXlzAFTI72aWC9Y8p7168g6XIKjh7k6pyQ==}
+
+  escalade@3.2.0:
+    resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
+    engines: {node: '>=6'}
+
   escape-html@1.0.3:
     resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
+
+  escape-string-regexp@2.0.0:
+    resolution: {integrity: sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==}
+    engines: {node: '>=8'}
 
   etag@1.8.1:
     resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
@@ -389,6 +523,14 @@ packages:
     engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
     deprecated: This package is no longer supported.
 
+  get-caller-file@2.0.5:
+    resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
+    engines: {node: 6.* || 8.* || >= 10.*}
+
+  get-east-asian-width@1.6.0:
+    resolution: {integrity: sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==}
+    engines: {node: '>=18'}
+
   get-intrinsic@1.3.0:
     resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
     engines: {node: '>= 0.4'}
@@ -411,6 +553,10 @@ packages:
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
 
+  has-flag@4.0.0:
+    resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
+    engines: {node: '>=8'}
+
   has-symbols@1.1.0:
     resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
     engines: {node: '>= 0.4'}
@@ -421,6 +567,9 @@ packages:
   hasown@2.0.3:
     resolution: {integrity: sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==}
     engines: {node: '>= 0.4'}
+
+  highlight.js@10.7.3:
+    resolution: {integrity: sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==}
 
   hono@4.12.18:
     resolution: {integrity: sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==}
@@ -463,6 +612,10 @@ packages:
     resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
     engines: {node: '>=8'}
 
+  indent-string@5.0.0:
+    resolution: {integrity: sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==}
+    engines: {node: '>=12'}
+
   infer-owner@1.0.4:
     resolution: {integrity: sha512-IClj+Xz94+d7irH5qRyfJonOdfTzuDaifE6ZPWfx0N0+/ATZCbuTPq2prFl526urkQd90WyUKIh1DfBQ2hMz9A==}
 
@@ -476,6 +629,19 @@ packages:
   ini@1.3.8:
     resolution: {integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==}
 
+  ink@7.0.2:
+    resolution: {integrity: sha512-cnkE2SsDC/gieJ+BD8+gWpXrZPMInv7agBYN5gcKVlQZYp+IKa/FKM5bp1OIuJFp3ZIuRK7ZNxY4MZR3tUzyfQ==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      '@types/react': '>=19.2.0'
+      react: '>=19.2.0'
+      react-devtools-core: '>=6.1.2'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      react-devtools-core:
+        optional: true
+
   ip-address@10.2.0:
     resolution: {integrity: sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==}
     engines: {node: '>= 12'}
@@ -487,6 +653,15 @@ packages:
   is-fullwidth-code-point@3.0.0:
     resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
     engines: {node: '>=8'}
+
+  is-fullwidth-code-point@5.1.0:
+    resolution: {integrity: sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==}
+    engines: {node: '>=18'}
+
+  is-in-ci@2.0.0:
+    resolution: {integrity: sha512-cFeerHriAnhrQSbpAxL37W1wcJKUUX07HyLWZCW1URJT/ra3GyUTzBgUnh24TMVfNTV2Hij2HLxkPHFZfOZy5w==}
+    engines: {node: '>=20'}
+    hasBin: true
 
   is-lambda@1.0.1:
     resolution: {integrity: sha512-z7CMFGNrENq5iFB9Bqo64Xk6Y9sg+epq1myIcdHaGnbMTYOxvzsEtdYqQUylB7LxfkvgrrjP32T6Ywciio9UIQ==}
@@ -514,6 +689,22 @@ packages:
     resolution: {integrity: sha512-+zopwDy7DNknmwPQplem5lAZX/eCOzSvSNNcSKm5eVwTkOBzoktEfXsa9L23J/GIRhxRsaxzkPEhrJEpE2F4Gg==}
     engines: {node: '>= 10'}
 
+  marked-terminal@7.3.0:
+    resolution: {integrity: sha512-t4rBvPsHc57uE/2nJOLmMbZCQ4tgAccAED3ngXQqW6g+TxA488JzJ+FK3lQkzBQOI1mRV/r/Kq+1ZlJ4D0owQw==}
+    engines: {node: '>=16.0.0'}
+    peerDependencies:
+      marked: '>=1 <16'
+
+  marked@11.2.0:
+    resolution: {integrity: sha512-HR0m3bvu0jAPYiIvLUUQtdg1g6D247//lvcekpHO1WMvbwDlwSkZAX9Lw4F4YHE1T0HaaNve0tuAWuV1UJ6vtw==}
+    engines: {node: '>= 18'}
+    hasBin: true
+
+  marked@15.0.12:
+    resolution: {integrity: sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==}
+    engines: {node: '>= 18'}
+    hasBin: true
+
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
@@ -533,6 +724,10 @@ packages:
   mime-types@3.0.2:
     resolution: {integrity: sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==}
     engines: {node: '>=18'}
+
+  mimic-fn@2.1.0:
+    resolution: {integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==}
+    engines: {node: '>=6'}
 
   mimic-response@3.1.0:
     resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
@@ -591,6 +786,9 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
+  mz@2.7.0:
+    resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
+
   napi-build-utils@2.0.0:
     resolution: {integrity: sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==}
 
@@ -608,6 +806,10 @@ packages:
 
   node-addon-api@7.1.1:
     resolution: {integrity: sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==}
+
+  node-emoji@2.2.0:
+    resolution: {integrity: sha512-Z3lTE9pLaJF47NyMhd4ww1yFTAP8YhYI8SleJiHzM46Fgpm5cnNzSl9XfzFNqbaz+VlJrIj3fXQ4DeN1Rjm6cw==}
+    engines: {node: '>=18'}
 
   node-gyp@8.4.1:
     resolution: {integrity: sha512-olTJRgUtAb/hOXG0E93wZDs5YiJlgbXxTwQAFHyNlRsXQnYzUaF2aGgujZbw+hR8aF4ZG/rST57bWMWD16jr9w==}
@@ -639,13 +841,30 @@ packages:
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
 
+  onetime@5.1.2:
+    resolution: {integrity: sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==}
+    engines: {node: '>=6'}
+
   p-map@4.0.0:
     resolution: {integrity: sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==}
     engines: {node: '>=10'}
 
+  parse5-htmlparser2-tree-adapter@6.0.1:
+    resolution: {integrity: sha512-qPuWvbLgvDGilKc5BoicRovlT4MtYT6JfJyBOMDsKoiT+GiuP5qyrPCnR9HcPECIJJmZh5jRndyNThnhhb/vlA==}
+
+  parse5@5.1.1:
+    resolution: {integrity: sha512-ugq4DFI0Ptb+WWjAdOK16+u/nHfiIrcE+sh8kZMaM0WllQKLI9rOUq6c2b7cwPkXdzfQESqvoqK6ug7U/Yyzug==}
+
+  parse5@6.0.1:
+    resolution: {integrity: sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==}
+
   parseurl@1.3.3:
     resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
     engines: {node: '>= 0.8'}
+
+  patch-console@2.0.0:
+    resolution: {integrity: sha512-0YNdUceMdaQwoKce1gatDScmMo5pu/tfABfnzEqeG0gtTmd7mh/WcwgUjtAeOU7N8nFFlbQBnFK2gXW5fGvmMA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   path-is-absolute@1.0.1:
     resolution: {integrity: sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==}
@@ -703,13 +922,31 @@ packages:
     resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
     hasBin: true
 
+  react-reconciler@0.33.0:
+    resolution: {integrity: sha512-KetWRytFv1epdpJc3J4G75I4WrplZE5jOL7Yq0p34+OVOKF4Se7WrdIdVC45XsSSmUTlht2FM/fM1FZb1mfQeA==}
+    engines: {node: '>=0.10.0'}
+    peerDependencies:
+      react: ^19.2.0
+
+  react@19.2.6:
+    resolution: {integrity: sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==}
+    engines: {node: '>=0.10.0'}
+
   readable-stream@3.6.2:
     resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
     engines: {node: '>= 6'}
 
+  require-directory@2.1.1:
+    resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
+    engines: {node: '>=0.10.0'}
+
   require-from-string@2.0.2:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
+
+  restore-cursor@4.0.0:
+    resolution: {integrity: sha512-I9fPXU9geO9bHOt9pHHOhOkYerIMsmVaWB0rA2AI9ERh/+x/i7MV5HKBNrg+ljO5eoPVgCcnFuRjJ9uH6I/3eg==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   retry@0.12.0:
     resolution: {integrity: sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==}
@@ -729,6 +966,9 @@ packages:
 
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
+  scheduler@0.27.0:
+    resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
 
   semver@7.7.4:
     resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
@@ -782,6 +1022,14 @@ packages:
   simple-get@4.0.1:
     resolution: {integrity: sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==}
 
+  skin-tone@2.0.0:
+    resolution: {integrity: sha512-kUMbT1oBJCpgrnKoSr0o6wPtvRWT9W9UKvGLwfJYO2WuahZRHOpEyL1ckyMGgMWh0UdpmaoFqKKD29WTomNEGA==}
+    engines: {node: '>=8'}
+
+  slice-ansi@9.0.0:
+    resolution: {integrity: sha512-SO/3iYL5S3W57LLEniscOGPZgOqZUPCx6d3dB+52B80yJ0XstzsC/eV8gnA4tM3MHDrKz+OCFSLNjswdSC+/bA==}
+    engines: {node: '>=22'}
+
   smart-buffer@4.2.0:
     resolution: {integrity: sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==}
     engines: {node: '>= 6.0.0', npm: '>= 3.0.0'}
@@ -801,6 +1049,10 @@ packages:
     resolution: {integrity: sha512-97qShzy1AiyxvPNIkLWoGua7xoQzzPjQ0HAH4B0rWKo7SZ6USuPcrUiAFrws0UH8RrbWmgq3LMTObhPIHbbBeQ==}
     engines: {node: '>= 8'}
 
+  stack-utils@2.0.6:
+    resolution: {integrity: sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==}
+    engines: {node: '>=10'}
+
   statuses@2.0.2:
     resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
     engines: {node: '>= 0.8'}
@@ -809,6 +1061,10 @@ packages:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
     engines: {node: '>=8'}
 
+  string-width@8.2.1:
+    resolution: {integrity: sha512-IIaP0g3iy9Cyy18w3M9YcaDudujEAVHKt3a3QJg1+sr/oX96TbaGUubG0hJyCjCBThFH+tFpcIyoUHUn1ogaLA==}
+    engines: {node: '>=20'}
+
   string_decoder@1.3.0:
     resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
 
@@ -816,9 +1072,25 @@ packages:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
     engines: {node: '>=8'}
 
+  strip-ansi@7.2.0:
+    resolution: {integrity: sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==}
+    engines: {node: '>=12'}
+
   strip-json-comments@2.0.1:
     resolution: {integrity: sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==}
     engines: {node: '>=0.10.0'}
+
+  supports-color@7.2.0:
+    resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
+    engines: {node: '>=8'}
+
+  supports-hyperlinks@3.2.0:
+    resolution: {integrity: sha512-zFObLMyZeEwzAoKCyu1B91U79K2t7ApXuQfo8OuxwXLDgcKxuwM+YvcbIhm6QWqz7mHUH1TVytR1PwVVjEuMig==}
+    engines: {node: '>=14.18'}
+
+  tagged-tag@1.0.0:
+    resolution: {integrity: sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==}
+    engines: {node: '>=20'}
 
   tar-fs@2.1.4:
     resolution: {integrity: sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==}
@@ -831,12 +1103,27 @@ packages:
     resolution: {integrity: sha512-tOG/7GyXpFevhXVh8jOPJrmtRpOTsYqUIkVdVooZYJS/z8WhfQUX8RJILmeuJNinGAMSu1veBr4asSHFt5/hng==}
     engines: {node: '>=18'}
 
+  terminal-size@4.0.1:
+    resolution: {integrity: sha512-avMLDQpUI9I5XFrklECw1ZEUPJhqzcwSWsyyI8blhRLT+8N1jLJWLWWYQpB2q2xthq8xDvjZPISVh53T/+CLYQ==}
+    engines: {node: '>=18'}
+
+  thenify-all@1.6.0:
+    resolution: {integrity: sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==}
+    engines: {node: '>=0.8'}
+
+  thenify@3.3.1:
+    resolution: {integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==}
+
   toidentifier@1.0.1:
     resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
     engines: {node: '>=0.6'}
 
   tunnel-agent@0.6.0:
     resolution: {integrity: sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==}
+
+  type-fest@5.6.0:
+    resolution: {integrity: sha512-8ZiHFm91orbSAe2PSAiSVBVko18pbhbiB3U9GglSzF/zCGkR+rxpHx6sEMCUm4kxY4LjDIUGgCfUMtwfZfjfUA==}
+    engines: {node: '>=20'}
 
   type-is@2.0.1:
     resolution: {integrity: sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==}
@@ -857,6 +1144,10 @@ packages:
   undici@6.25.0:
     resolution: {integrity: sha512-ZgpWDC5gmNiuY9CnLVXEH8rl50xhRCuLNA97fAUnKi8RRuV4E6KG31pDTsLVUKnohJE0I3XDrTeEydAXRw47xg==}
     engines: {node: '>=18.17'}
+
+  unicode-emoji-modifier-base@1.0.0:
+    resolution: {integrity: sha512-yLSH4py7oFH3oG/9K+XWrz1pSi3dfUrWEnInbxMfArOfc1+33BlGPQtLsOYwvdMy11AwUBetYuaRxSPqgkq+8g==}
+    engines: {node: '>=4'}
 
   unique-filename@1.1.1:
     resolution: {integrity: sha512-Vmp0jIp2ln35UTXuryvjzkjGdRyf9b2lTXuSYUiPmzRcl3FDtYqAwOnTJkAngD9SWhnoJzDbTKwaOrZ+STtxNQ==}
@@ -883,8 +1174,36 @@ packages:
   wide-align@1.1.5:
     resolution: {integrity: sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==}
 
+  widest-line@6.0.0:
+    resolution: {integrity: sha512-U89AsyEeAsyoF0zVJBkG9zBgekjgjK7yk9sje3F4IQpXBJ10TF6ByLlIfjMhcmHMJgHZI4KHt4rdNfktzxIAMA==}
+    engines: {node: '>=20'}
+
+  wrap-ansi@10.0.0:
+    resolution: {integrity: sha512-SGcvg80f0wUy2/fXES19feHMz8E0JoXv2uNgHOu4Dgi2OrCy1lqwFYEJz1BLbDI0exjPMe/ZdzZ/YpGECBG/aQ==}
+    engines: {node: '>=20'}
+
+  wrap-ansi@7.0.0:
+    resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
+    engines: {node: '>=10'}
+
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+
+  ws@8.20.0:
+    resolution: {integrity: sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
+  y18n@5.0.8:
+    resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
+    engines: {node: '>=10'}
 
   yallist@4.0.0:
     resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
@@ -892,6 +1211,17 @@ packages:
   yallist@5.0.0:
     resolution: {integrity: sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==}
     engines: {node: '>=18'}
+
+  yargs-parser@20.2.9:
+    resolution: {integrity: sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==}
+    engines: {node: '>=10'}
+
+  yargs@16.2.0:
+    resolution: {integrity: sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==}
+    engines: {node: '>=10'}
+
+  yoga-layout@3.2.1:
+    resolution: {integrity: sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ==}
 
   zod-to-json-schema@3.25.2:
     resolution: {integrity: sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==}
@@ -903,7 +1233,15 @@ packages:
 
 snapshots:
 
+  '@alcalzone/ansi-tokenize@0.3.0':
+    dependencies:
+      ansi-styles: 6.2.3
+      is-fullwidth-code-point: 5.1.0
+
   '@bufbuild/protobuf@1.10.0':
+    optional: true
+
+  '@colors/colors@1.5.0':
     optional: true
 
   '@connectrpc/connect-node@1.7.0(@bufbuild/protobuf@1.10.0)(@connectrpc/connect@1.7.0(@bufbuild/protobuf@1.10.0))':
@@ -998,6 +1336,8 @@ snapshots:
       rimraf: 3.0.2
     optional: true
 
+  '@sindresorhus/is@4.6.0': {}
+
   '@statsig/client-core@3.31.0':
     optional: true
 
@@ -1009,9 +1349,22 @@ snapshots:
   '@tootallnate/once@3.0.1':
     optional: true
 
+  '@types/cardinal@2.1.1': {}
+
+  '@types/marked-terminal@6.1.1':
+    dependencies:
+      '@types/cardinal': 2.1.1
+      '@types/node': 22.19.17
+      chalk: 5.6.2
+      marked: 11.2.0
+
   '@types/node@22.19.17':
     dependencies:
       undici-types: 6.21.0
+
+  '@types/react@19.2.14':
+    dependencies:
+      csstype: 3.2.3
 
   abbrev@1.1.1:
     optional: true
@@ -1050,8 +1403,21 @@ snapshots:
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
-  ansi-regex@5.0.1:
-    optional: true
+  ansi-escapes@7.3.0:
+    dependencies:
+      environment: 1.1.0
+
+  ansi-regex@5.0.1: {}
+
+  ansi-regex@6.2.2: {}
+
+  ansi-styles@4.3.0:
+    dependencies:
+      color-convert: 2.0.1
+
+  ansi-styles@6.2.3: {}
+
+  any-promise@1.3.0: {}
 
   aproba@2.1.0:
     optional: true
@@ -1061,6 +1427,8 @@ snapshots:
       delegates: 1.0.0
       readable-stream: 3.6.2
     optional: true
+
+  auto-bind@5.0.1: {}
 
   balanced-match@1.0.2:
     optional: true
@@ -1142,6 +1510,15 @@ snapshots:
       call-bind-apply-helpers: 1.0.2
       get-intrinsic: 1.3.0
 
+  chalk@4.1.2:
+    dependencies:
+      ansi-styles: 4.3.0
+      supports-color: 7.2.0
+
+  chalk@5.6.2: {}
+
+  char-regex@1.0.2: {}
+
   chownr@1.1.4:
     optional: true
 
@@ -1153,6 +1530,48 @@ snapshots:
 
   clean-stack@2.2.0:
     optional: true
+
+  cli-boxes@4.0.1: {}
+
+  cli-cursor@4.0.0:
+    dependencies:
+      restore-cursor: 4.0.0
+
+  cli-highlight@2.1.11:
+    dependencies:
+      chalk: 4.1.2
+      highlight.js: 10.7.3
+      mz: 2.7.0
+      parse5: 5.1.1
+      parse5-htmlparser2-tree-adapter: 6.0.1
+      yargs: 16.2.0
+
+  cli-table3@0.6.5:
+    dependencies:
+      string-width: 4.2.3
+    optionalDependencies:
+      '@colors/colors': 1.5.0
+
+  cli-truncate@6.0.0:
+    dependencies:
+      slice-ansi: 9.0.0
+      string-width: 8.2.1
+
+  cliui@7.0.4:
+    dependencies:
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+      wrap-ansi: 7.0.0
+
+  code-excerpt@4.0.0:
+    dependencies:
+      convert-to-spaces: 2.0.1
+
+  color-convert@2.0.1:
+    dependencies:
+      color-name: 1.1.4
+
+  color-name@1.1.4: {}
 
   color-support@1.1.3:
     optional: true
@@ -1166,6 +1585,8 @@ snapshots:
   content-disposition@1.1.0: {}
 
   content-type@1.0.5: {}
+
+  convert-to-spaces@2.0.1: {}
 
   cookie-signature@1.2.2: {}
 
@@ -1181,6 +1602,8 @@ snapshots:
       path-key: 3.1.1
       shebang-command: 2.0.0
       which: 2.0.2
+
+  csstype@3.2.3: {}
 
   debug@4.4.3:
     dependencies:
@@ -1210,8 +1633,9 @@ snapshots:
 
   ee-first@1.1.1: {}
 
-  emoji-regex@8.0.0:
-    optional: true
+  emoji-regex@8.0.0: {}
+
+  emojilib@2.4.0: {}
 
   encodeurl@2.0.0: {}
 
@@ -1228,6 +1652,8 @@ snapshots:
   env-paths@2.2.1:
     optional: true
 
+  environment@1.1.0: {}
+
   err-code@2.0.3:
     optional: true
 
@@ -1239,7 +1665,13 @@ snapshots:
     dependencies:
       es-errors: 1.3.0
 
+  es-toolkit@1.46.1: {}
+
+  escalade@3.2.0: {}
+
   escape-html@1.0.3: {}
+
+  escape-string-regexp@2.0.0: {}
 
   etag@1.8.1: {}
 
@@ -1337,6 +1769,10 @@ snapshots:
       wide-align: 1.1.5
     optional: true
 
+  get-caller-file@2.0.5: {}
+
+  get-east-asian-width@1.6.0: {}
+
   get-intrinsic@1.3.0:
     dependencies:
       call-bind-apply-helpers: 1.0.2
@@ -1373,6 +1809,8 @@ snapshots:
   graceful-fs@4.2.11:
     optional: true
 
+  has-flag@4.0.0: {}
+
   has-symbols@1.1.0: {}
 
   has-unicode@2.0.1:
@@ -1381,6 +1819,8 @@ snapshots:
   hasown@2.0.3:
     dependencies:
       function-bind: 1.1.2
+
+  highlight.js@10.7.3: {}
 
   hono@4.12.18: {}
 
@@ -1435,6 +1875,8 @@ snapshots:
   indent-string@4.0.0:
     optional: true
 
+  indent-string@5.0.0: {}
+
   infer-owner@1.0.4:
     optional: true
 
@@ -1449,12 +1891,51 @@ snapshots:
   ini@1.3.8:
     optional: true
 
+  ink@7.0.2(@types/react@19.2.14)(react@19.2.6):
+    dependencies:
+      '@alcalzone/ansi-tokenize': 0.3.0
+      ansi-escapes: 7.3.0
+      ansi-styles: 6.2.3
+      auto-bind: 5.0.1
+      chalk: 5.6.2
+      cli-boxes: 4.0.1
+      cli-cursor: 4.0.0
+      cli-truncate: 6.0.0
+      code-excerpt: 4.0.0
+      es-toolkit: 1.46.1
+      indent-string: 5.0.0
+      is-in-ci: 2.0.0
+      patch-console: 2.0.0
+      react: 19.2.6
+      react-reconciler: 0.33.0(react@19.2.6)
+      scheduler: 0.27.0
+      signal-exit: 3.0.7
+      slice-ansi: 9.0.0
+      stack-utils: 2.0.6
+      string-width: 8.2.1
+      terminal-size: 4.0.1
+      type-fest: 5.6.0
+      widest-line: 6.0.0
+      wrap-ansi: 10.0.0
+      ws: 8.20.0
+      yoga-layout: 3.2.1
+    optionalDependencies:
+      '@types/react': 19.2.14
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
   ip-address@10.2.0: {}
 
   ipaddr.js@1.9.1: {}
 
-  is-fullwidth-code-point@3.0.0:
-    optional: true
+  is-fullwidth-code-point@3.0.0: {}
+
+  is-fullwidth-code-point@5.1.0:
+    dependencies:
+      get-east-asian-width: 1.6.0
+
+  is-in-ci@2.0.0: {}
 
   is-lambda@1.0.1:
     optional: true
@@ -1497,6 +1978,21 @@ snapshots:
       - supports-color
     optional: true
 
+  marked-terminal@7.3.0(marked@15.0.12):
+    dependencies:
+      ansi-escapes: 7.3.0
+      ansi-regex: 6.2.2
+      chalk: 5.6.2
+      cli-highlight: 2.1.11
+      cli-table3: 0.6.5
+      marked: 15.0.12
+      node-emoji: 2.2.0
+      supports-hyperlinks: 3.2.0
+
+  marked@11.2.0: {}
+
+  marked@15.0.12: {}
+
   math-intrinsics@1.1.0: {}
 
   media-typer@1.1.0: {}
@@ -1508,6 +2004,8 @@ snapshots:
   mime-types@3.0.2:
     dependencies:
       mime-db: 1.54.0
+
+  mimic-fn@2.1.0: {}
 
   mimic-response@3.1.0:
     optional: true
@@ -1576,6 +2074,12 @@ snapshots:
 
   ms@2.1.3: {}
 
+  mz@2.7.0:
+    dependencies:
+      any-promise: 1.3.0
+      object-assign: 4.1.1
+      thenify-all: 1.6.0
+
   napi-build-utils@2.0.0:
     optional: true
 
@@ -1591,6 +2095,13 @@ snapshots:
 
   node-addon-api@7.1.1:
     optional: true
+
+  node-emoji@2.2.0:
+    dependencies:
+      '@sindresorhus/is': 4.6.0
+      char-regex: 1.0.2
+      emojilib: 2.4.0
+      skin-tone: 2.0.0
 
   node-gyp@8.4.1:
     dependencies:
@@ -1634,12 +2145,26 @@ snapshots:
     dependencies:
       wrappy: 1.0.2
 
+  onetime@5.1.2:
+    dependencies:
+      mimic-fn: 2.1.0
+
   p-map@4.0.0:
     dependencies:
       aggregate-error: 3.1.0
     optional: true
 
+  parse5-htmlparser2-tree-adapter@6.0.1:
+    dependencies:
+      parse5: 6.0.1
+
+  parse5@5.1.1: {}
+
+  parse5@6.0.1: {}
+
   parseurl@1.3.3: {}
+
+  patch-console@2.0.0: {}
 
   path-is-absolute@1.0.1:
     optional: true
@@ -1707,6 +2232,13 @@ snapshots:
       strip-json-comments: 2.0.1
     optional: true
 
+  react-reconciler@0.33.0(react@19.2.6):
+    dependencies:
+      react: 19.2.6
+      scheduler: 0.27.0
+
+  react@19.2.6: {}
+
   readable-stream@3.6.2:
     dependencies:
       inherits: 2.0.4
@@ -1714,7 +2246,14 @@ snapshots:
       util-deprecate: 1.0.2
     optional: true
 
+  require-directory@2.1.1: {}
+
   require-from-string@2.0.2: {}
+
+  restore-cursor@4.0.0:
+    dependencies:
+      onetime: 5.1.2
+      signal-exit: 3.0.7
 
   retry@0.12.0:
     optional: true
@@ -1738,6 +2277,8 @@ snapshots:
     optional: true
 
   safer-buffer@2.1.2: {}
+
+  scheduler@0.27.0: {}
 
   semver@7.7.4:
     optional: true
@@ -1806,8 +2347,7 @@ snapshots:
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
 
-  signal-exit@3.0.7:
-    optional: true
+  signal-exit@3.0.7: {}
 
   simple-concat@1.0.1:
     optional: true
@@ -1818,6 +2358,15 @@ snapshots:
       once: 1.4.0
       simple-concat: 1.0.1
     optional: true
+
+  skin-tone@2.0.0:
+    dependencies:
+      unicode-emoji-modifier-base: 1.0.0
+
+  slice-ansi@9.0.0:
+    dependencies:
+      ansi-styles: 6.2.3
+      is-fullwidth-code-point: 5.1.0
 
   smart-buffer@4.2.0:
     optional: true
@@ -1855,6 +2404,10 @@ snapshots:
       minipass: 3.3.6
     optional: true
 
+  stack-utils@2.0.6:
+    dependencies:
+      escape-string-regexp: 2.0.0
+
   statuses@2.0.2: {}
 
   string-width@4.2.3:
@@ -1862,7 +2415,11 @@ snapshots:
       emoji-regex: 8.0.0
       is-fullwidth-code-point: 3.0.0
       strip-ansi: 6.0.1
-    optional: true
+
+  string-width@8.2.1:
+    dependencies:
+      get-east-asian-width: 1.6.0
+      strip-ansi: 7.2.0
 
   string_decoder@1.3.0:
     dependencies:
@@ -1872,10 +2429,24 @@ snapshots:
   strip-ansi@6.0.1:
     dependencies:
       ansi-regex: 5.0.1
-    optional: true
+
+  strip-ansi@7.2.0:
+    dependencies:
+      ansi-regex: 6.2.2
 
   strip-json-comments@2.0.1:
     optional: true
+
+  supports-color@7.2.0:
+    dependencies:
+      has-flag: 4.0.0
+
+  supports-hyperlinks@3.2.0:
+    dependencies:
+      has-flag: 4.0.0
+      supports-color: 7.2.0
+
+  tagged-tag@1.0.0: {}
 
   tar-fs@2.1.4:
     dependencies:
@@ -1903,12 +2474,26 @@ snapshots:
       yallist: 5.0.0
     optional: true
 
+  terminal-size@4.0.1: {}
+
+  thenify-all@1.6.0:
+    dependencies:
+      thenify: 3.3.1
+
+  thenify@3.3.1:
+    dependencies:
+      any-promise: 1.3.0
+
   toidentifier@1.0.1: {}
 
   tunnel-agent@0.6.0:
     dependencies:
       safe-buffer: 5.2.1
     optional: true
+
+  type-fest@5.6.0:
+    dependencies:
+      tagged-tag: 1.0.0
 
   type-is@2.0.1:
     dependencies:
@@ -1924,6 +2509,8 @@ snapshots:
 
   undici@6.25.0:
     optional: true
+
+  unicode-emoji-modifier-base@1.0.0: {}
 
   unique-filename@1.1.1:
     dependencies:
@@ -1951,13 +2538,47 @@ snapshots:
       string-width: 4.2.3
     optional: true
 
+  widest-line@6.0.0:
+    dependencies:
+      string-width: 8.2.1
+
+  wrap-ansi@10.0.0:
+    dependencies:
+      ansi-styles: 6.2.3
+      string-width: 8.2.1
+      strip-ansi: 7.2.0
+
+  wrap-ansi@7.0.0:
+    dependencies:
+      ansi-styles: 4.3.0
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+
   wrappy@1.0.2: {}
+
+  ws@8.20.0: {}
+
+  y18n@5.0.8: {}
 
   yallist@4.0.0:
     optional: true
 
   yallist@5.0.0:
     optional: true
+
+  yargs-parser@20.2.9: {}
+
+  yargs@16.2.0:
+    dependencies:
+      cliui: 7.0.4
+      escalade: 3.2.0
+      get-caller-file: 2.0.5
+      require-directory: 2.1.1
+      string-width: 4.2.3
+      y18n: 5.0.8
+      yargs-parser: 20.2.9
+
+  yoga-layout@3.2.1: {}
 
   zod-to-json-schema@3.25.2(zod@3.25.76):
     dependencies:

--- a/src/__tests__/observability.test.ts
+++ b/src/__tests__/observability.test.ts
@@ -253,4 +253,76 @@ describe('observability snapshot builder', () => {
     assert.equal(snapshot.sessions[0]?.workspace.repository_name, 'agent-orchestrator');
     assert.equal(snapshot.sessions[0]?.workspace.label, 'agent-orchestrator:4-add-observability*');
   });
+
+  it('groups workers by live orchestrator id and archives historical orchestrators', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'agent-observe-'));
+    const store = new RunStore(root);
+    await store.createRun({
+      backend: 'codex',
+      cwd: root,
+      prompt: 'Implement the live watch pane.',
+      metadata: { orchestrator_id: 'orch-live' },
+      display: { session_title: 'Live watch', session_summary: null, prompt_title: 'Live worker', prompt_summary: null },
+    });
+    const completed = await store.createRun({
+      backend: 'codex',
+      cwd: root,
+      prompt: 'Write tests for live watch.',
+      metadata: { orchestrator_id: 'orch-live' },
+      display: { session_title: 'Live watch', session_summary: null, prompt_title: 'Completed worker', prompt_summary: null },
+    });
+    await store.markTerminal(completed.run_id, 'completed');
+    const archived = await store.createRun({
+      backend: 'claude',
+      cwd: root,
+      prompt: 'Old worker prompt.',
+      metadata: { orchestrator_id: 'orch-archived' },
+      display: { session_title: 'Archived watch', session_summary: null, prompt_title: 'Archived worker', prompt_summary: null },
+    });
+    await store.markTerminal(archived.run_id, 'completed');
+
+    const snapshot = await buildObservabilitySnapshot(store, {
+      limit: 50,
+      includePrompts: true,
+      recentEventLimit: 5,
+      daemonPid: null,
+      backendStatus: null,
+      liveOrchestrators: [{
+        record: {
+          id: 'orch-live',
+          client: 'claude',
+          label: 'Live watch',
+          cwd: root,
+          display: { tmux_pane: '%1', tmux_window_id: '@1', base_title: 'Live watch', host: 'host' },
+          registered_at: '2026-05-02T00:00:00.000Z',
+          last_supervisor_event_at: '2026-05-02T00:00:01.000Z',
+        },
+        status: {
+          state: 'in_progress',
+          supervisor_turn_active: true,
+          waiting_for_user: false,
+          running_child_count: 1,
+          failed_unacked_count: 0,
+        },
+      }],
+    });
+
+    const liveGroup = snapshot.orchestrators.find((group) => group.orchestrator_id === 'orch-live');
+    assert.ok(liveGroup);
+    assert.equal(liveGroup?.live, true);
+    assert.equal(liveGroup?.status?.state, 'in_progress');
+    assert.equal(liveGroup?.worker_count, 2);
+    assert.equal(liveGroup?.running_count, 1);
+    assert.deepStrictEqual(liveGroup?.workers.map((worker) => worker.title), ['Live worker', 'Completed worker']);
+    assert.equal(liveGroup?.workers.find((worker) => worker.run_id === completed.run_id)?.status, 'completed');
+
+    const archivedGroup = snapshot.orchestrators.find((group) => group.orchestrator_id === 'orch-archived');
+    assert.ok(archivedGroup);
+    assert.equal(archivedGroup?.live, false);
+    assert.equal(archivedGroup?.status, null);
+    assert.equal(archivedGroup?.label, 'Archived watch');
+    assert.equal(archivedGroup?.workers[0]?.title, 'Archived worker');
+
+    assert.equal(snapshot.orchestrators[0]?.orchestrator_id, 'orch-live');
+  });
 });

--- a/src/__tests__/observabilityFormat.test.ts
+++ b/src/__tests__/observabilityFormat.test.ts
@@ -1,299 +1,70 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { ObservabilitySnapshotSchema } from '../contract.js';
-import {
-  clampDashboardState,
-  formatSnapshot,
-  renderDashboard,
-  type SnapshotEnvelope,
-} from '../daemon/observabilityFormat.js';
+import { formatSnapshot, type SnapshotEnvelope } from '../daemon/observabilityFormat.js';
 
-describe('observability CLI formatting', () => {
-  it('renders session, model, run, and raw prompt metadata', () => {
-    const envelope = sampleEnvelope();
+describe('observability non-TTY formatting', () => {
+  it('preserves generated time and live/archive orchestrator summaries', () => {
+    const formatted = formatSnapshot(sampleEnvelope());
 
-    const formatted = formatSnapshot(envelope);
-    assert.match(formatted, /Terminal dashboard \[running\]/);
-    assert.match(formatted, /model=gpt-5\.2 \(explicit\)/);
-    assert.match(formatted, /effort=xhigh tier=fast/);
-    assert.match(formatted, /prompts=1 workspace=repo:main/);
-    assert.match(formatted, /session=session-1/);
-
-    const detail = renderDashboard(envelope, { view: 'detail', selectedSession: 0, selectedPrompt: 0 }, 120, 40);
-    assert.match(detail, /\x1b\[[0-9;]*m/);
-    const plain = stripAnsi(detail);
-    assert.match(plain, /View: Detail > Terminal dashboard > Open dashboard \| Prompt 1\/1/);
-    assert.match(plain, /Keys: Up\/Down switches prompt in Terminal dashboard/);
-    assert.match(plain, /Title: Open dashboard/);
-    assert.match(plain, /Model: gpt-5\.2 \(explicit\)/);
-    assert.match(plain, /Reasoning: xhigh/);
-    assert.match(plain, /Service Tier: fast/);
-    assert.match(plain, /Invocation: \/usr\/local\/bin\/codex exec --model gpt-5\.2 -/);
-    assert.match(plain, /Git: repo:main clean/);
-    assert.match(plain, /Activity: last=2026-05-02 00:00:01 source=backend_event idle=\d+s/);
-    assert.match(plain, /Timeouts: idle=1200s hard=none timeout_reason=none terminal_reason=none/);
-    assert.match(plain, /Latest Error: 429 rate limit exceeded \(category=rate_limit source=backend_event fatal=true retryable=true\)/);
-    assert.match(plain, /User Prompt/);
-    assert.match(plain, /Raw prompt body with details/);
-    assert.match(plain, /Final Response \[completed\]/);
-    assert.match(plain, /Final response body with outcome/);
-    assert.match(plain, /#1 2026-05-02 00:00:01 assistant_message/);
+    assert.match(formatted, /agent-orchestrator daemon: running pid=42/);
+    assert.match(formatted, /generated: 2026-05-02T00:00:00.000Z/);
+    assert.match(formatted, /live_orchestrators: 1 archived_orchestrators: 1 sessions: 0 runs: 0/);
+    assert.match(formatted, /Live orchestrators/);
+    assert.match(formatted, /Watch polish \[in_progress\]/);
+    assert.match(formatted, /Archived orchestrators/);
+    assert.match(formatted, /Stale session \[stale\]/);
   });
 
-  it('keeps dashboard list screens to one row per item', () => {
-    const envelope = sampleEnvelope();
+  it('prints daemon read errors without requiring an interactive TUI', () => {
+    const formatted = formatSnapshot({ ...sampleEnvelope(), running: false, error: 'daemon unavailable' });
 
-    const sessions = stripAnsi(renderDashboard(envelope, { view: 'sessions', selectedSession: 0, selectedPrompt: 0 }, 160, 40));
-    assert.match(sessions, /View: Sessions 1\/1/);
-    assert.match(sessions, /Keys: Up\/Down choose chat, Enter opens prompts/);
-    assert.match(sessions, /AGENT\s+STATUS\s+PROMPTS\s+MODEL\s+EFFORT\s+TIER\s+WORKSPACE\s+CHAT/);
-    assert.match(sessions, /> codex\s+running\s+1\s+gpt-5\.2\s+xhigh\s+fast\s+repo:main\s+Terminal dashboard/);
-    assert.doesNotMatch(sessions, /^  Inspect live worker prompts$/m);
-    assert.doesNotMatch(sessions, /^  session=session-1$/m);
-
-    const prompts = stripAnsi(renderDashboard(envelope, { view: 'prompts', selectedSession: 0, selectedPrompt: 0 }, 120, 40));
-    assert.match(prompts, /View: Sessions > Terminal dashboard \| Prompt 1\/1/);
-    assert.match(prompts, /Keys: Up\/Down choose prompt, Enter opens detail/);
-    assert.match(prompts, /STATUS\s+MODEL\s+EFFORT\s+TIER\s+LAST\s+PROMPT/);
-    assert.match(prompts, /> running\s+gpt-5\.2\s+xhigh\s+fast\s+2026-05-02 00:00:01 Open dashboard/);
-    assert.doesNotMatch(prompts, /^  Show the prompt detail view$/m);
-    assert.doesNotMatch(prompts, /^  Raw prompt body with details$/m);
-  });
-
-  it('shows latest prompt model and compacts worktree workspace labels', () => {
-    const envelope = sampleEnvelope();
-    const session = envelope.snapshot.sessions[0]!;
-    session.run_count = 2;
-    session.models = [
-      { name: 'gpt-5.2', source: 'explicit', requested_name: 'gpt-5.2', observed_name: null },
-      { name: 'gpt-5.5', source: 'explicit', requested_name: 'gpt-5.5', observed_name: null },
-    ];
-    session.settings = [
-      { reasoning_effort: 'low', service_tier: 'normal', mode: null, codex_network: null },
-      { reasoning_effort: 'xhigh', service_tier: 'fast', mode: null, codex_network: null },
-    ];
-    session.workspace = {
-      cwd: '/tmp/worktrees-agent-orchestrator/4-add-observability',
-      repository_root: '/tmp/worktrees-agent-orchestrator/4-add-observability',
-      repository_name: 'agent-orchestrator',
-      branch: '4-add-observability',
-      dirty_count: 3,
-      label: 'agent-orchestrator:4-add-observability*',
-    };
-    session.prompts.push({
-      run_id: 'run-2',
-      status: 'completed',
-      title: 'Second prompt',
-      summary: null,
-      preview: 'Second raw prompt',
-      model: { name: 'gpt-5.5', source: 'explicit', requested_name: 'gpt-5.5', observed_name: null },
-      settings: { reasoning_effort: 'xhigh', service_tier: 'fast', mode: null, codex_network: null },
-      created_at: '2026-05-02T00:00:02.000Z',
-      last_activity_at: '2026-05-02T00:00:03.000Z',
-    });
-
-    const sessions = stripAnsi(renderDashboard(envelope, { view: 'sessions', selectedSession: 0, selectedPrompt: 0 }, 160, 40));
-    assert.match(sessions, /> codex\s+running\s+2\s+gpt-5\.5\s+xhigh\s+fast\s+a-orchestrator:4-add-observabi\.\*\s+Terminal dashboard/);
-    assert.doesNotMatch(sessions, /gpt-5\.2 \+1/);
-
-    const prompts = stripAnsi(renderDashboard(envelope, { view: 'prompts', selectedSession: 0, selectedPrompt: 0 }, 160, 40));
-    assert.match(prompts, /prompts=2/);
-    assert.doesNotMatch(prompts, /shown=/);
-  });
-
-  it('renders limited prompt lists and observed model mismatches clearly', () => {
-    const envelope = sampleEnvelope();
-    const session = envelope.snapshot.sessions[0]!;
-    const run = envelope.snapshot.runs[0]!;
-    session.run_count = 3;
-    session.warnings = ['requested model gpt-5.2 but backend reported gpt-5.5'];
-    session.models = [{ name: 'gpt-5.5', source: 'explicit', requested_name: 'gpt-5.2', observed_name: 'gpt-5.5' }];
-    session.prompts[0]!.model = { name: 'gpt-5.5', source: 'explicit', requested_name: 'gpt-5.2', observed_name: 'gpt-5.5' };
-    run.model = { name: 'gpt-5.5', source: 'explicit', requested_name: 'gpt-5.2', observed_name: 'gpt-5.5' };
-
-    const prompts = stripAnsi(renderDashboard(envelope, { view: 'prompts', selectedSession: 0, selectedPrompt: 0 }, 160, 40));
-    assert.match(prompts, /prompts=3 shown=1/);
-    assert.match(prompts, /Warning: requested model gpt-5\.2 but backend reported gpt-5\.5/);
-
-    const detail = stripAnsi(renderDashboard(envelope, { view: 'detail', selectedSession: 0, selectedPrompt: 0 }, 160, 40));
-    assert.match(detail, /Model: gpt-5\.5 \(explicit, requested gpt-5\.2\)/);
-  });
-
-  it('clamps stale dashboard selections', () => {
-    const envelope = sampleEnvelope();
-    assert.deepStrictEqual(
-      clampDashboardState({ view: 'detail', selectedSession: 99, selectedPrompt: 99 }, envelope.snapshot),
-      { view: 'detail', selectedSession: 0, selectedPrompt: 0 },
-    );
-    assert.deepStrictEqual(
-      clampDashboardState({ view: 'prompts', selectedSession: 0, selectedPrompt: 0 }, {
-        ...envelope.snapshot,
-        sessions: [],
-      }),
-      { view: 'sessions', selectedSession: 0, selectedPrompt: 0 },
-    );
+    assert.match(formatted, /agent-orchestrator daemon: stopped/);
+    assert.match(formatted, /error: daemon unavailable/);
   });
 });
 
 function sampleEnvelope(): SnapshotEnvelope {
   const now = '2026-05-02T00:00:00.000Z';
-  const snapshot = ObservabilitySnapshotSchema.parse({
-    generated_at: now,
-    daemon_pid: 42,
-    store_root: '/tmp/agent-store',
-    backend_status: null,
-    sessions: [{
-      session_key: 'codex:session-1',
-      session_id: 'session-1',
-      root_run_id: 'run-1',
-      backend: 'codex',
-      cwd: '/tmp/repo',
-      workspace: {
-        cwd: '/tmp/repo',
-        repository_root: '/tmp/repo',
-        repository_name: 'repo',
-        branch: 'main',
-        dirty_count: 0,
-        label: 'repo:main',
-      },
-      title: 'Terminal dashboard',
-      summary: 'Inspect live worker prompts',
-      status: 'running',
-      created_at: now,
-      updated_at: '2026-05-02T00:00:01.000Z',
-      run_count: 1,
-      running_count: 1,
-      models: [{ name: 'gpt-5.2', source: 'explicit' }],
-      settings: [{ reasoning_effort: 'xhigh', service_tier: 'fast', mode: null, codex_network: null }],
-      warnings: [],
-      prompts: [{
-        run_id: 'run-1',
-        status: 'running',
-        title: 'Open dashboard',
-        summary: 'Show the prompt detail view',
-        preview: 'Raw prompt body with details',
-        model: { name: 'gpt-5.2', source: 'explicit' },
-        settings: { reasoning_effort: 'xhigh', service_tier: 'fast', mode: null, codex_network: null },
-        created_at: now,
-        last_activity_at: '2026-05-02T00:00:01.000Z',
-      }],
-    }],
-    runs: [{
-      run: {
-        run_id: 'run-1',
-        backend: 'codex',
-        status: 'running',
-        parent_run_id: null,
-        session_id: 'session-1',
-        model: 'gpt-5.2',
-        model_source: 'explicit',
-        requested_session_id: null,
-        observed_session_id: 'session-1',
-        display: {
-          session_title: 'Terminal dashboard',
-          session_summary: 'Inspect live worker prompts',
-          prompt_title: 'Open dashboard',
-          prompt_summary: 'Show the prompt detail view',
-        },
-        cwd: '/tmp/repo',
-        created_at: now,
-        started_at: now,
-        finished_at: null,
-        last_activity_at: '2026-05-02T00:00:01.000Z',
-        last_activity_source: 'backend_event',
-        worker_pid: 123,
-        worker_pgid: 123,
-        daemon_pid_at_spawn: 42,
-        worker_invocation: {
-          command: '/usr/local/bin/codex',
-          args: ['exec', '--model', 'gpt-5.2', '-'],
-        },
-        git_snapshot_status: 'captured',
-        git_snapshot: {
-          sha: '0123456789abcdef0123456789abcdef01234567',
-          root: '/tmp/repo',
-          branch: 'main',
-          dirty_count: 0,
-          dirty: [],
-          dirty_fingerprints: {},
-        },
-        model_settings: { reasoning_effort: 'xhigh', service_tier: 'fast', mode: null, codex_network: null },
-        idle_timeout_seconds: 1200,
-        execution_timeout_seconds: null,
-        timeout_reason: null,
-        terminal_reason: null,
-        terminal_context: null,
-        latest_error: {
-          message: '429 rate limit exceeded',
-          category: 'rate_limit',
-          source: 'backend_event',
-          backend: 'codex',
-          retryable: true,
-          fatal: true,
-        },
-        metadata: {},
-      },
-      prompt: {
-        title: 'Open dashboard',
-        summary: 'Show the prompt detail view',
-        preview: 'Raw prompt body with details',
-        text: 'Raw prompt body with details and enough context to inspect.',
-        path: '/tmp/agent-store/runs/run-1/prompt.txt',
-        bytes: 56,
-      },
-      response: {
-        status: 'completed',
-        summary: 'Final response body with outcome.',
-        path: '/tmp/agent-store/runs/run-1/result.json',
-        bytes: 128,
-      },
-      model: { name: 'gpt-5.2', source: 'explicit' },
-      settings: { reasoning_effort: 'xhigh', service_tier: 'fast', mode: null, codex_network: null },
-      session: {
-        requested_session_id: null,
-        observed_session_id: 'session-1',
-        effective_session_id: 'session-1',
-        status: 'new_session',
-        warnings: [],
-      },
-      activity: {
-        last_event_sequence: 1,
-        last_event_at: '2026-05-02T00:00:01.000Z',
-        last_event_type: 'assistant_message',
-        last_activity_at: '2026-05-02T00:00:01.000Z',
-        last_activity_source: 'backend_event',
-        idle_seconds: 1,
-        last_interaction_preview: 'Working on it.',
-        event_count: 1,
-        recent_errors: [],
-        recent_events: [{
-          seq: 1,
-          ts: '2026-05-02T00:00:01.000Z',
-          type: 'assistant_message',
-          payload: { text: 'Working on it.' },
-        }],
-        latest_error: {
-          message: '429 rate limit exceeded',
-          category: 'rate_limit',
-          source: 'backend_event',
-          backend: 'codex',
-          retryable: true,
-          fatal: true,
-        },
-      },
-      artifacts: [{
-        name: 'prompt.txt',
-        path: '/tmp/agent-store/runs/run-1/prompt.txt',
-        exists: true,
-        bytes: 56,
-      }],
-      duration_seconds: 1,
-    }],
-  });
-
-  return { running: true, snapshot };
+  return {
+    running: true,
+    snapshot: ObservabilitySnapshotSchema.parse({
+      generated_at: now,
+      daemon_pid: 42,
+      store_root: '/tmp/agent-store',
+      backend_status: null,
+      sessions: [],
+      runs: [],
+      orchestrators: [
+        orchestrator('orch-live', 'Watch polish', 'in_progress', true),
+        orchestrator('orch-stale', 'Stale session', 'stale', true),
+      ],
+    }),
+  };
 }
 
-function stripAnsi(value: string): string {
-  return value.replace(/\x1b\[[0-9;]*m/g, '');
+function orchestrator(orchestratorId: string, label: string, state: 'in_progress' | 'stale', live: boolean) {
+  const now = '2026-05-02T00:00:00.000Z';
+  return {
+    orchestrator_id: orchestratorId,
+    live,
+    client: 'claude',
+    label,
+    cwd: '/tmp/repo',
+    display: null,
+    status: {
+      state,
+      supervisor_turn_active: state === 'in_progress',
+      waiting_for_user: false,
+      running_child_count: state === 'in_progress' ? 1 : 0,
+      failed_unacked_count: 0,
+    },
+    registered_at: now,
+    last_supervisor_event_at: now,
+    created_at: now,
+    updated_at: now,
+    worker_count: state === 'in_progress' ? 1 : 0,
+    running_count: state === 'in_progress' ? 1 : 0,
+    workers: [],
+  };
 }

--- a/src/__tests__/watchViewModel.test.ts
+++ b/src/__tests__/watchViewModel.test.ts
@@ -1,0 +1,504 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import React from 'react';
+import { renderToString } from 'ink';
+import { ObservabilitySnapshotSchema } from '../contract.js';
+import type { SnapshotEnvelope } from '../daemon/observabilityFormat.js';
+import { WatchApp } from '../daemon/watchApp.js';
+import {
+  applyWatchInput,
+  applyWatchRawInput,
+  buildWatchViewModel,
+  clampWatchDashboardState,
+  createWatchDashboardState,
+  normalizeWatchEvent,
+  renderMarkdownToAnsi,
+  scrollWatchTranscript,
+  selectWatchSidebarItem,
+  selectedWatchTranscriptBlocks,
+  selectedWatchTranscriptLines,
+  watchMouseScrollDelta,
+  watchSidebarItems,
+} from '../daemon/watchViewModel.js';
+
+describe('watch view model', () => {
+  it('groups follow-up child runs into one worker conversation', () => {
+    const model = buildWatchViewModel(sampleEnvelope());
+
+    assert.equal(model.live.length, 1);
+    assert.equal(model.archive.length, 1);
+    const live = model.live[0]!;
+    assert.equal(live.conversations.length, 1);
+    assert.deepEqual(live.conversations[0]?.runIds, ['run-parent', 'run-child']);
+    assert.equal(live.conversations[0]?.status, 'running');
+    assert.equal(watchSidebarItems(model, createWatchDashboardState()).filter((item) => item.kind === 'conversation').length, 1);
+  });
+
+  it('uses backend session ids to group follow-ups when parents are outside the watch limit', () => {
+    const envelope = sampleEnvelope();
+    const live = envelope.snapshot.orchestrators[0]!;
+    const snapshot = ObservabilitySnapshotSchema.parse({
+      ...envelope.snapshot,
+      orchestrators: [{
+        ...live,
+        workers: [
+          worker('run-missing-a', 'missing-parent-a', 'completed', 'Follow-up A', 'First follow-up.'),
+          worker('run-missing-b', 'missing-parent-b', 'running', 'Follow-up B', 'Second follow-up.'),
+        ],
+      }],
+      runs: [
+        run('run-missing-a', 'missing-parent-a', 'completed', 'Follow-up A', 'First follow-up.', 'orch-live', [], 'Done.'),
+        run('run-missing-b', 'missing-parent-b', 'running', 'Follow-up B', 'Second follow-up.', 'orch-live', [], null),
+      ],
+    });
+    const model = buildWatchViewModel({ running: true, snapshot });
+
+    assert.equal(model.live[0]?.conversations.length, 1);
+    assert.deepEqual(model.live[0]?.conversations[0]?.runIds, ['run-missing-a', 'run-missing-b']);
+  });
+
+  it('renders actor-labeled supervisor follow-ups inside one readable transcript', () => {
+    const model = buildWatchViewModel(sampleEnvelope());
+    let state = clampWatchDashboardState(createWatchDashboardState(), model);
+    state = selectWatchSidebarItem(state, model, 1);
+
+    const blocks = selectedWatchTranscriptBlocks(model, state);
+    assert.deepEqual(blocks.map((block) => block.label), [
+      'Worker Chat',
+      'Run 1',
+      'Supervisor -> Worker',
+      'Worker message',
+      'Tool call',
+      'Tool result',
+      'Worker activity',
+      'Final response',
+      'Run 1',
+      'Run 2',
+      'Supervisor -> Worker',
+      'Worker message',
+    ]);
+
+    const plain = stripAnsi(selectedWatchTranscriptLines(model, state, 100).join('\n'));
+    assert.match(plain, /Supervisor -> Worker Supervisor prompt/);
+    assert.match(plain, /Supervisor -> Worker Supervisor follow-up/);
+    assert.match(plain, /Fix the failing watch refresh/);
+    assert.doesNotMatch(plain, /"type":"tool_use"/);
+    assert.doesNotMatch(plain, />>>/);
+    assert.doesNotMatch(plain, /Supervisor prompt \[completed\]/);
+    assert.doesNotMatch(plain, /Worker final message \[completed\]/);
+  });
+
+  it('gives workers stable names and renders the orchestrator selection as an overview', () => {
+    const model = buildWatchViewModel(sampleEnvelope());
+    const conversation = model.live[0]?.conversations[0];
+    assert.equal(conversation?.workerName, 'Worker 1');
+    assert.match(conversation?.purpose ?? '', /Build the \*\*watch\*\* TUI/);
+
+    const overviewState = clampWatchDashboardState(createWatchDashboardState(), model);
+    const blocks = selectedWatchTranscriptBlocks(model, overviewState);
+    assert.equal(blocks[0]?.label, 'Session');
+    assert.match(blocks[0]?.body ?? '', /Workers: 1 running \/ 1 total/);
+    assert.match(blocks[0]?.body ?? '', /Open:/);
+    assert.equal(blocks[1]?.label, 'Worker 1');
+    assert.match(blocks[1]?.title ?? '', /running for/);
+    assert.match(blocks[1]?.body ?? '', /Task: Build the watch TUI/);
+    assert.match(blocks[1]?.body ?? '', /Latest: Removed the once-per-second timestamp churn/);
+
+    const archiveState = clampWatchDashboardState({ ...createWatchDashboardState(), mode: 'archive' }, model);
+    const archiveBlocks = selectedWatchTranscriptBlocks(model, archiveState);
+    assert.match(archiveBlocks[1]?.title ?? '', /done after/);
+  });
+
+  it('uses only the latest worker run for overview duration labels', () => {
+    const envelope = sampleEnvelope();
+    const child = envelope.snapshot.runs.find((item) => item.run.run_id === 'run-child')!;
+    child.run.status = 'completed';
+    child.run.finished_at = '2026-05-02T00:00:06.000Z';
+    child.activity.last_event_at = '2026-05-02T00:00:06.000Z';
+    child.activity.last_activity_at = '2026-05-02T00:00:06.000Z';
+    child.response.status = 'completed';
+    child.response.summary = 'Child run complete.';
+
+    const model = buildWatchViewModel(envelope);
+    const overviewState = clampWatchDashboardState(createWatchDashboardState(), model);
+    const blocks = selectedWatchTranscriptBlocks(model, overviewState);
+
+    assert.match(blocks[1]?.title ?? '', /done after 2s/);
+    assert.doesNotMatch(blocks[1]?.title ?? '', /done after 6s/);
+  });
+
+  it('uses real terminal Markdown rendering for common Markdown blocks', () => {
+    const rendered = stripAnsi(renderMarkdownToAnsi([
+      '# Heading',
+      '',
+      '- one',
+      '- `two`',
+      '',
+      '```ts',
+      'const value = 1;',
+      '```',
+      '',
+      '| A | B |',
+      '|---|---|',
+      '| 1 | 2 |',
+    ].join('\n'), 100).join('\n'));
+
+    assert.match(rendered, /Heading/);
+    assert.match(rendered, /one/);
+    assert.match(rendered, /two/);
+    assert.match(rendered, /const value = 1/);
+    assert.match(rendered, /A/);
+    assert.match(rendered, /B/);
+    assert.doesNotMatch(rendered, /```/);
+  });
+
+  it('normalizes Claude and Codex tool events without raw payload dumps', () => {
+    const run = sampleEnvelope().snapshot.runs[0]!;
+    const codex = normalizeWatchEvent(run, {
+      seq: 10,
+      ts: '2026-05-02T00:00:04.000Z',
+      type: 'tool_use',
+      payload: { type: 'command_execution', command: 'pnpm build', duration_ms: 1250 },
+    });
+    const claude = normalizeWatchEvent(run, {
+      seq: 11,
+      ts: '2026-05-02T00:00:05.000Z',
+      type: 'tool_result',
+      payload: { name: 'Bash', status: 'success', text: '3 tests passed' },
+    });
+    const unknownLifecycle = normalizeWatchEvent(run, {
+      seq: 12,
+      ts: '2026-05-02T00:00:06.000Z',
+      type: 'lifecycle',
+      payload: { index: 42 },
+    });
+    const resultEvent = normalizeWatchEvent(run, {
+      seq: 13,
+      ts: '2026-05-02T00:00:07.000Z',
+      type: 'lifecycle',
+      payload: {
+        state: 'result_event',
+        raw: {
+          type: 'result',
+          subtype: 'success',
+          is_error: false,
+          duration_ms: 3191,
+          num_turns: 1,
+          result: 'c5\nSicilian Defense.',
+          stop_reason: 'end_turn',
+          session_id: 'session-with-a-very-long-id',
+        },
+      },
+    });
+
+    assert.match(codex?.title ?? '', /command_execution/);
+    assert.equal(codex?.body, 'pnpm build');
+    assert.match(claude?.title ?? '', /Bash result \[success\]/);
+    assert.equal(claude?.body, '3 tests passed');
+    assert.equal(unknownLifecycle?.title, 'Event');
+    assert.match(unknownLifecycle?.body ?? '', /"index":42/);
+    assert.equal(resultEvent?.title, 'Result event');
+    assert.match(resultEvent?.body ?? '', /status success/);
+    assert.match(resultEvent?.body ?? '', /duration 3\.2s/);
+    assert.doesNotMatch(resultEvent?.body ?? '', /Sicilian|session-with|\.{3}/);
+  });
+
+  it('filters empty lifecycle noise and does not duplicate status headings', () => {
+    const model = buildWatchViewModel(sampleEnvelope());
+    let state = clampWatchDashboardState(createWatchDashboardState(), model);
+    state = selectWatchSidebarItem(state, model, 1);
+
+    const plain = stripAnsi(selectedWatchTranscriptLines(model, state, 100).join('\n'));
+    assert.doesNotMatch(plain, /\(empty\)/);
+    assert.doesNotMatch(plain, /started/);
+    assert.doesNotMatch(plain, /Worker activity: reasoning reasoning/);
+    assert.match(plain, /Worker activity Reasoning/);
+    assert.match(plain, /input_tokens/);
+  });
+
+  it('labels duplicate worker summary as the final response once', () => {
+    const envelope = sampleEnvelope();
+    const parent = envelope.snapshot.runs[0]!;
+    parent.activity.recent_events = [
+      { seq: 1, ts: '2026-05-02T00:00:01.000Z', type: 'assistant_message', payload: { text: 'Initial TUI complete.' } },
+    ];
+    parent.response.summary = 'Initial TUI complete.';
+
+    const model = buildWatchViewModel(envelope);
+    let state = clampWatchDashboardState(createWatchDashboardState(), model);
+    state = selectWatchSidebarItem(state, model, 1);
+
+    const blocks = selectedWatchTranscriptBlocks(model, state);
+    assert.equal(blocks.filter((block) => block.label === 'Final response' && block.body === 'Initial TUI complete.').length, 1);
+    assert.equal(blocks.filter((block) => block.label === 'Worker message' && block.body === 'Initial TUI complete.').length, 0);
+  });
+
+  it('preserves final response markdown lines without compacting chess ellipses', () => {
+    const envelope = sampleEnvelope();
+    const parent = envelope.snapshot.runs[0]!;
+    parent.activity.recent_events = [];
+    parent.response.summary = 'Qb8\nSidestepping the Nc6 fork threat, queen safe on b8, planning ...Qb7 if knight invades.';
+
+    const model = buildWatchViewModel(envelope);
+    let state = clampWatchDashboardState(createWatchDashboardState(), model);
+    state = selectWatchSidebarItem(state, model, 1);
+
+    const plain = stripAnsi(selectedWatchTranscriptLines(model, state, 100).join('\n'));
+    assert.match(plain, /^  Qb8$/m);
+    assert.match(plain, /^  Sidestepping the Nc6 fork threat, queen safe on b8, planning \.\.\.Qb7 if knight invades\.$/m);
+  });
+
+  it('preserves scroll state on refresh while auto-follow can be restored', () => {
+    const model = buildWatchViewModel(sampleEnvelope());
+    let state = clampWatchDashboardState(createWatchDashboardState(), model);
+    state = selectWatchSidebarItem(state, model, 1);
+
+    const scrolled = scrollWatchTranscript(state, model, 90, 2, 5);
+    assert.equal(scrolled.follow, false);
+    assert.ok(scrolled.scrollOffset > 0);
+
+    const refreshed = buildWatchViewModel({
+      ...sampleEnvelope(),
+      snapshot: {
+        ...sampleEnvelope().snapshot,
+        generated_at: '2026-05-02T00:00:59.000Z',
+      },
+    });
+    const clamped = clampWatchDashboardState(scrolled, refreshed);
+    assert.equal(clamped.follow, false);
+    assert.equal(clamped.scrollOffset, scrolled.scrollOffset);
+  });
+
+  it('supports top/latest keys and mouse wheel transcript scrolling', () => {
+    const model = buildWatchViewModel(sampleEnvelope());
+    let state = clampWatchDashboardState(createWatchDashboardState(), model);
+    state = selectWatchSidebarItem(state, model, 1);
+
+    const wheelUp = applyWatchInput(state, model, '\x1b[<64;1;1M', {}, 90, 3).state;
+    assert.equal(wheelUp.follow, false);
+    assert.ok(wheelUp.scrollOffset > 0);
+    const arrowUp = applyWatchInput(state, model, '', { upArrow: true }, 90, 3).state;
+    assert.notEqual(arrowUp.selectedId, state.selectedId);
+    assert.equal(arrowUp.follow, true);
+    const rawArrowUp = applyWatchRawInput(state, model, '\x1b[A', 90, 3).state;
+    assert.equal(rawArrowUp.selectedId, arrowUp.selectedId);
+    const rawApplicationArrowUp = applyWatchRawInput(state, model, '\x1bOA', 90, 3).state;
+    assert.equal(rawApplicationArrowUp.selectedId, arrowUp.selectedId);
+    const rawArrowDown = applyWatchRawInput(rawArrowUp, model, '\x1b[B', 90, 3).state;
+    assert.equal(rawArrowDown.selectedId, state.selectedId);
+    assert.equal(rawArrowDown.follow, true);
+    assert.equal(applyWatchInput(state, model, 'm', {}, 90, 3).toggleMouseCapture, true);
+    assert.equal(applyWatchRawInput(state, model, 'm', 90, 3).toggleMouseCapture, true);
+    assert.equal(applyWatchRawInput(state, model, 'q', 90, 3).quit, true);
+    assert.equal(applyWatchRawInput(state, model, '\u0003', 90, 3).quit, true);
+    assert.equal(watchMouseScrollDelta('\x1b[<64;1;1M', 9), 1);
+    assert.equal(watchMouseScrollDelta('\x1b[<65;1;1M', 9), -1);
+    assert.equal(watchMouseScrollDelta('\x1b[<64;1;1M\x1b[<64;1;1M', 9), 2);
+    assert.equal(watchMouseScrollDelta(`\x1b[M${String.fromCharCode(96)}!!`, 9), 1);
+
+    const top = applyWatchInput(state, model, 'g', {}, 90, 3).state;
+    assert.equal(top.follow, false);
+    assert.ok(top.scrollOffset >= wheelUp.scrollOffset);
+
+    const latest = applyWatchInput(top, model, 'G', {}, 90, 3).state;
+    assert.equal(latest.follow, true);
+    assert.equal(latest.scrollOffset, 0);
+
+    const enter = applyWatchInput(top, model, '', { return: true }, 90, 3).state;
+    assert.equal(enter.follow, true);
+    assert.equal(enter.scrollOffset, 0);
+  });
+
+  it('renders the Ink watch app shell with the conversation sidebar', () => {
+    const output = stripAnsi(renderToString(React.createElement(WatchApp, {
+      initialEnvelope: sampleEnvelope(),
+      readSnapshot: async () => sampleEnvelope(),
+      intervalMs: 1000,
+    })));
+
+    assert.match(output, /agent-orchestrator watch/);
+    assert.match(output, /Live orchestrators/);
+    assert.match(output, /Worker 1/);
+    assert.match(output, /Build TUI/);
+    assert.match(output, /Overview/);
+  });
+});
+
+function sampleEnvelope(): SnapshotEnvelope {
+  const now = '2026-05-02T00:00:00.000Z';
+  const snapshot = ObservabilitySnapshotSchema.parse({
+    generated_at: now,
+    daemon_pid: 42,
+    store_root: '/tmp/agent-store',
+    backend_status: null,
+    sessions: [],
+    orchestrators: [
+      {
+        orchestrator_id: 'orch-live',
+        live: true,
+        client: 'claude',
+        label: 'Watch polish',
+        cwd: '/tmp/repo',
+        display: { tmux_pane: '%1', tmux_window_id: '@1', base_title: 'Watch polish', host: 'host' },
+        status: {
+          state: 'in_progress',
+          supervisor_turn_active: true,
+          waiting_for_user: false,
+          running_child_count: 1,
+          failed_unacked_count: 0,
+        },
+        registered_at: now,
+        last_supervisor_event_at: '2026-05-02T00:00:04.000Z',
+        created_at: now,
+        updated_at: '2026-05-02T00:00:04.000Z',
+        worker_count: 2,
+        running_count: 1,
+        workers: [
+          worker('run-parent', null, 'completed', 'Build TUI', 'Build the **watch** TUI.'),
+          worker('run-child', 'run-parent', 'running', 'Fix refresh', 'Fix the failing watch refresh.'),
+        ],
+      },
+      {
+        orchestrator_id: 'orch-stale',
+        live: true,
+        client: 'claude',
+        label: 'Stale session',
+        cwd: '/tmp/repo',
+        display: null,
+        status: {
+          state: 'stale',
+          supervisor_turn_active: false,
+          waiting_for_user: false,
+          running_child_count: 0,
+          failed_unacked_count: 0,
+        },
+        registered_at: now,
+        last_supervisor_event_at: now,
+        created_at: now,
+        updated_at: now,
+        worker_count: 1,
+        running_count: 0,
+        workers: [
+          worker('run-archive', null, 'completed', 'Archived', 'Past worker.'),
+        ],
+      },
+    ],
+    runs: [
+      run('run-parent', null, 'completed', 'Build TUI', 'Build the **watch** TUI.\n\n- grouped sessions\n- Markdown', 'orch-live', [
+        { seq: 1, ts: '2026-05-02T00:00:01.000Z', type: 'assistant_message', payload: { text: 'Implemented the **sidebar**.' } },
+        { seq: 2, ts: '2026-05-02T00:00:02.000Z', type: 'tool_use', payload: { name: 'Bash', input: { command: 'pnpm test' } } },
+        { seq: 3, ts: '2026-05-02T00:00:03.000Z', type: 'tool_result', payload: { name: 'Bash', status: 'success', text: '3 tests passed' } },
+        { seq: 4, ts: '2026-05-02T00:00:03.500Z', type: 'lifecycle', payload: { status: 'started' } },
+        { seq: 5, ts: '2026-05-02T00:00:03.750Z', type: 'lifecycle', payload: { status: 'reasoning', usage: { input_tokens: 10, output_tokens: 2 } } },
+      ], 'Initial TUI complete.'),
+      run('run-child', 'run-parent', 'running', 'Fix refresh', 'Fix the failing watch refresh.\n\n```ts\nrender();\n```', 'orch-live', [
+        { seq: 1, ts: '2026-05-02T00:00:04.000Z', type: 'assistant_message', payload: { text: 'Removed the once-per-second timestamp churn.' } },
+      ], null),
+      run('run-archive', null, 'completed', 'Archived', 'Past worker.', 'orch-stale', [], 'Done.'),
+    ],
+  });
+
+  return { running: true, snapshot };
+}
+
+function worker(runId: string, parentRunId: string | null, status: string, title: string, preview: string) {
+  return {
+    run_id: runId,
+    parent_run_id: parentRunId,
+    backend: 'codex',
+    status,
+    title,
+    summary: null,
+    preview,
+    model: { name: 'gpt-5.2', source: 'explicit' },
+    settings: { reasoning_effort: 'xhigh', service_tier: 'fast', mode: null, codex_network: null },
+    created_at: '2026-05-02T00:00:00.000Z',
+    last_activity_at: '2026-05-02T00:00:04.000Z',
+  };
+}
+
+function run(runId: string, parentRunId: string | null, status: string, title: string, prompt: string, orchestratorId: string, recentEvents: unknown[], responseSummary: string | null) {
+  return {
+    run: {
+      run_id: runId,
+      backend: 'codex',
+      status,
+      parent_run_id: parentRunId,
+      session_id: 'session-1',
+      model: 'gpt-5.2',
+      model_source: 'explicit',
+      requested_session_id: parentRunId ? 'session-1' : null,
+      observed_session_id: 'session-1',
+      observed_model: null,
+      display: {
+        session_title: 'Watch polish',
+        session_summary: 'Polish the watch TUI',
+        prompt_title: title,
+        prompt_summary: null,
+      },
+      cwd: '/tmp/repo',
+      created_at: parentRunId ? '2026-05-02T00:00:04.000Z' : '2026-05-02T00:00:00.000Z',
+      started_at: parentRunId ? '2026-05-02T00:00:04.000Z' : '2026-05-02T00:00:00.000Z',
+      finished_at: status === 'running' ? null : '2026-05-02T00:00:05.000Z',
+      last_activity_at: '2026-05-02T00:00:04.000Z',
+      last_activity_source: 'backend_event',
+      worker_pid: 123,
+      worker_pgid: 123,
+      daemon_pid_at_spawn: 42,
+      worker_invocation: { command: '/usr/local/bin/codex', args: ['exec', '--model', 'gpt-5.2', '-'] },
+      git_snapshot_status: 'captured',
+      git_snapshot: null,
+      git_snapshot_at_start: null,
+      model_settings: { reasoning_effort: 'xhigh', service_tier: 'fast', mode: null, codex_network: null },
+      idle_timeout_seconds: 1200,
+      execution_timeout_seconds: null,
+      timeout_reason: null,
+      terminal_reason: null,
+      terminal_context: null,
+      latest_error: null,
+      metadata: { orchestrator_id: orchestratorId },
+    },
+    prompt: {
+      title,
+      summary: null,
+      preview: prompt.replace(/\s+/g, ' ').trim(),
+      text: prompt,
+      path: `/tmp/agent-store/runs/${runId}/prompt.txt`,
+      bytes: prompt.length,
+    },
+    response: {
+      status: responseSummary ? 'completed' : null,
+      summary: responseSummary,
+      path: responseSummary ? `/tmp/agent-store/runs/${runId}/result.json` : null,
+      bytes: responseSummary?.length ?? null,
+    },
+    model: { name: 'gpt-5.2', source: 'explicit' },
+    settings: { reasoning_effort: 'xhigh', service_tier: 'fast', mode: null, codex_network: null },
+    session: {
+      requested_session_id: parentRunId ? 'session-1' : null,
+      observed_session_id: 'session-1',
+      effective_session_id: 'session-1',
+      status: parentRunId ? 'resumed' : 'new_session',
+      warnings: [],
+    },
+    activity: {
+      last_event_sequence: recentEvents.length,
+      last_event_at: recentEvents.length > 0 ? '2026-05-02T00:00:04.000Z' : null,
+      last_event_type: recentEvents.length > 0 ? 'assistant_message' : null,
+      last_activity_at: '2026-05-02T00:00:04.000Z',
+      last_activity_source: 'backend_event',
+      idle_seconds: status === 'running' ? 1 : null,
+      last_interaction_preview: null,
+      event_count: recentEvents.length,
+      recent_errors: [],
+      recent_events: recentEvents,
+      latest_error: null,
+    },
+    artifacts: [],
+    duration_seconds: 4,
+  };
+}
+
+function stripAnsi(value: string): string {
+  return value.replace(/\x1b\[[0-9;]*m/g, '');
+}

--- a/src/cliRoot.ts
+++ b/src/cliRoot.ts
@@ -18,7 +18,7 @@ Usage:
   agent-orchestrator status       Show daemon status
   agent-orchestrator status --json
   agent-orchestrator runs [--json] [--prompts]
-  agent-orchestrator watch [--interval-ms <ms>] [--limit <n>]
+  agent-orchestrator watch [--interval-ms <ms>] [--limit <n>] [--recent-events <n>]
   agent-orchestrator start
   agent-orchestrator stop [--force]
   agent-orchestrator restart [--force]
@@ -31,7 +31,7 @@ Standalone daemon alias:
   agent-orchestrator-daemon status --verbose
   agent-orchestrator-daemon status --json
   agent-orchestrator-daemon runs [--json] [--prompts]
-  agent-orchestrator-daemon watch [--interval-ms <ms>] [--limit <n>]
+  agent-orchestrator-daemon watch [--interval-ms <ms>] [--limit <n>] [--recent-events <n>]
   agent-orchestrator-daemon start
   agent-orchestrator-daemon stop [--force]
   agent-orchestrator-daemon restart [--force]

--- a/src/contract.ts
+++ b/src/contract.ts
@@ -564,7 +564,7 @@ export type PruneRunsInput = z.input<typeof PruneRunsInputSchema>;
 export const GetObservabilitySnapshotInputSchema = z.object({
   limit: z.number().int().positive().max(500).optional().default(50),
   include_prompts: z.boolean().optional().default(false),
-  recent_event_limit: z.number().int().nonnegative().max(50).optional().default(5),
+  recent_event_limit: z.number().int().nonnegative().max(500).optional().default(5),
   diagnostics: z.boolean().optional().default(false),
 });
 export type GetObservabilitySnapshotInput = z.input<typeof GetObservabilitySnapshotInputSchema>;
@@ -697,12 +697,57 @@ export const ObservabilitySessionSchema = z.object({
 });
 export type ObservabilitySession = z.infer<typeof ObservabilitySessionSchema>;
 
+export const ObservabilityOrchestratorWorkerSchema = z.object({
+  run_id: z.string(),
+  parent_run_id: z.string().nullable(),
+  backend: BackendSchema,
+  status: RunStatusSchema,
+  title: z.string(),
+  summary: z.string().nullable(),
+  preview: z.string(),
+  model: ObservabilityModelSchema,
+  settings: ObservabilityRunSettingsSchema,
+  created_at: z.string(),
+  last_activity_at: z.string().nullable(),
+});
+export type ObservabilityOrchestratorWorker = z.infer<typeof ObservabilityOrchestratorWorkerSchema>;
+
+export const ObservabilityOrchestratorGroupSchema = z.object({
+  orchestrator_id: z.string(),
+  live: z.boolean(),
+  client: z.enum(['claude']).nullable(),
+  label: z.string(),
+  cwd: z.string(),
+  display: z.object({
+    tmux_pane: z.string().nullable().optional().default(null),
+    tmux_window_id: z.string().nullable().optional().default(null),
+    base_title: z.string().nullable().optional().default(null),
+    host: z.string().nullable().optional().default(null),
+  }).nullable(),
+  status: z.object({
+    state: z.enum(['in_progress', 'waiting_for_user', 'idle', 'attention', 'stale']),
+    supervisor_turn_active: z.boolean(),
+    waiting_for_user: z.boolean(),
+    running_child_count: z.number().int().nonnegative(),
+    failed_unacked_count: z.number().int().nonnegative(),
+  }).nullable(),
+  registered_at: z.string().nullable(),
+  last_supervisor_event_at: z.string().nullable(),
+  created_at: z.string(),
+  updated_at: z.string(),
+  worker_count: z.number().int().nonnegative(),
+  running_count: z.number().int().nonnegative(),
+  workers: z.array(ObservabilityOrchestratorWorkerSchema),
+});
+export type ObservabilityOrchestratorGroup = z.infer<typeof ObservabilityOrchestratorGroupSchema>;
+
 export const ObservabilitySnapshotSchema = z.object({
   generated_at: z.string(),
   daemon_pid: z.number().int().nullable(),
   store_root: z.string(),
   sessions: z.array(ObservabilitySessionSchema),
   runs: z.array(ObservabilityRunSchema),
+  orchestrators: z.array(ObservabilityOrchestratorGroupSchema).optional().default([]),
   backend_status: BackendStatusReportSchema.nullable().optional().default(null),
 });
 export type ObservabilitySnapshot = z.infer<typeof ObservabilitySnapshotSchema>;

--- a/src/daemon/daemonCli.ts
+++ b/src/daemon/daemonCli.ts
@@ -11,13 +11,7 @@ import { formatVersionOutput, getPackageVersion } from '../packageMetadata.js';
 import { RunStore, type PruneRunsResult } from '../runStore.js';
 import { buildObservabilitySnapshot } from '../observability.js';
 import { getBackendStatus } from '../diagnostics.js';
-import {
-  clampDashboardState,
-  formatSnapshot,
-  renderDashboard,
-  type DashboardState,
-  type SnapshotEnvelope,
-} from './observabilityFormat.js';
+import { formatSnapshot, type SnapshotEnvelope } from './observabilityFormat.js';
 import type { ObservabilitySnapshot, OrchestratorError } from '../contract.js';
 
 const paths = daemonPaths();
@@ -74,8 +68,8 @@ export async function runDaemonCli(argv: readonly string[] = process.argv.slice(
 function daemonHelp(): string {
   return [
     'Usage:',
-    '  agent-orchestrator start | stop [--force] | restart [--force] | status [--verbose|--json] | runs [--json] [--prompts] | watch [--interval-ms <ms>] [--limit <n>] | prune --older-than-days <days> [--dry-run] | auth ...',
-    '  agent-orchestrator-daemon start | stop [--force] | restart [--force] | status [--verbose|--json] | runs [--json] [--prompts] | watch [--interval-ms <ms>] [--limit <n>] | prune --older-than-days <days> [--dry-run] | auth ...',
+    '  agent-orchestrator start | stop [--force] | restart [--force] | status [--verbose|--json] | runs [--json] [--prompts] | watch [--interval-ms <ms>] [--limit <n>] [--recent-events <n>] | prune --older-than-days <days> [--dry-run] | auth ...',
+    '  agent-orchestrator-daemon start | stop [--force] | restart [--force] | status [--verbose|--json] | runs [--json] [--prompts] | watch [--interval-ms <ms>] [--limit <n>] [--recent-events <n>] | prune --older-than-days <days> [--dry-run] | auth ...',
     '  agent-orchestrator-daemon --version [--json]',
     '',
   ].join('\n');
@@ -179,41 +173,12 @@ async function runs(argv: readonly string[]): Promise<void> {
 
 async function watch(argv: readonly string[]): Promise<void> {
   const intervalMs = readPositiveIntOption(argv, '--interval-ms') ?? 1_000;
-  const options = snapshotOptionsFromArgs(argv, { includePrompts: true });
-  if (!process.stdout.isTTY || !process.stdin.isTTY) {
-    process.stdout.write(formatSnapshot(await readSnapshotFromDaemonOrStore(options)));
-    return;
-  }
-
-  let envelope = await readSnapshotFromDaemonOrStore(options);
-  let state: DashboardState = { view: 'sessions', selectedSession: 0, selectedPrompt: 0 };
-  let stopped = false;
-  let refreshTimer: NodeJS.Timeout | null = null;
-  let resolveDone: (() => void) | null = null;
-
-  const finish = () => {
-    if (stopped) return;
-    stopped = true;
-    if (refreshTimer) clearTimeout(refreshTimer);
-    process.stdin.off('data', onKey);
-    if (process.stdin.isTTY) process.stdin.setRawMode(false);
-    process.stdin.pause();
-    process.stdout.write('\x1b[?25h\x1b[0m\n');
-    resolveDone?.();
-  };
-
-  const repaint = () => {
-    state = clampDashboardState(state, envelope.snapshot);
-    process.stdout.write('\x1b[?25l\x1b[H\x1b[2J');
-    process.stdout.write(renderDashboard(envelope, state, process.stdout.columns ?? 100, process.stdout.rows ?? 30));
-  };
-
-  const refresh = async () => {
-    if (stopped) return;
+  const options = snapshotOptionsFromArgs(argv, { includePrompts: true, limit: 200, recentEventLimit: 200 });
+  const readWatchSnapshot = async () => {
     try {
-      envelope = await readSnapshotFromDaemonOrStore(options);
+      return await readSnapshotFromDaemonOrStore(options);
     } catch (error) {
-      envelope = {
+      return {
         running: false,
         snapshot: {
           generated_at: new Date().toISOString(),
@@ -221,55 +186,28 @@ async function watch(argv: readonly string[]): Promise<void> {
           store_root: paths.home,
           sessions: [],
           runs: [],
+          orchestrators: [],
           backend_status: null,
         },
         error: error instanceof Error ? error.message : String(error),
-      };
-    }
-    if (stopped) return;
-    repaint();
-    refreshTimer = setTimeout(refresh, intervalMs);
-  };
-
-  const onKey = (chunk: Buffer) => {
-    const key = chunk.toString('utf8');
-    if (key === '\u0003' || key === 'q') {
-      finish();
-      return;
-    }
-    if (key === '\x1b[A') {
-      if (state.view === 'sessions') state.selectedSession -= 1;
-      if (state.view === 'prompts' || state.view === 'detail') state.selectedPrompt -= 1;
-      repaint();
-      return;
-    }
-    if (key === '\x1b[B') {
-      if (state.view === 'sessions') state.selectedSession += 1;
-      if (state.view === 'prompts' || state.view === 'detail') state.selectedPrompt += 1;
-      repaint();
-      return;
-    }
-    if (key === '\r' || key === '\n') {
-      if (state.view === 'sessions') state.view = 'prompts';
-      else if (state.view === 'prompts') state.view = 'detail';
-      repaint();
-      return;
-    }
-    if (key === '\x7f' || key === '\x1b') {
-      if (state.view === 'detail') state.view = 'prompts';
-      else if (state.view === 'prompts') state.view = 'sessions';
-      repaint();
+      } satisfies SnapshotEnvelope;
     }
   };
 
-  process.stdin.setRawMode(true);
-  process.stdin.resume();
-  process.stdin.on('data', onKey);
-  process.once('SIGINT', finish);
-  process.once('SIGTERM', finish);
-  const done = new Promise<void>((resolve) => { resolveDone = resolve; });
-  await refresh();
-  await done;
+  if (!process.stdout.isTTY || !process.stdin.isTTY) {
+    process.stdout.write(formatSnapshot(await readWatchSnapshot()));
+    return;
+  }
+
+  const { runWatchTui } = await import('./watchApp.js');
+  await runWatchTui({
+    initialEnvelope: await readWatchSnapshot(),
+    readSnapshot: readWatchSnapshot,
+    intervalMs,
+    stdin: process.stdin,
+    stdout: process.stdout,
+    stderr: process.stderr,
+  });
 }
 
 async function prune(argv: readonly string[]): Promise<void> {

--- a/src/daemon/observabilityFormat.ts
+++ b/src/daemon/observabilityFormat.ts
@@ -1,5 +1,11 @@
 import { basename, dirname } from 'node:path';
-import type { ObservabilityRun, ObservabilityRunSettings, ObservabilitySession, ObservabilitySnapshot } from '../contract.js';
+import type {
+  ObservabilityOrchestratorGroup,
+  ObservabilityRun,
+  ObservabilityRunSettings,
+  ObservabilitySession,
+  ObservabilitySnapshot,
+} from '../contract.js';
 
 export interface SnapshotEnvelope {
   running: boolean;
@@ -7,14 +13,10 @@ export interface SnapshotEnvelope {
   error?: string;
 }
 
-export interface DashboardState {
-  view: 'sessions' | 'prompts' | 'detail';
-  selectedSession: number;
-  selectedPrompt: number;
-}
-
 export function formatSnapshot(envelope: SnapshotEnvelope): string {
   const { snapshot } = envelope;
+  const live = liveOrchestrators(snapshot);
+  const archive = archiveOrchestrators(snapshot);
   const lines = [
     `agent-orchestrator daemon: ${envelope.running ? `running pid=${snapshot.daemon_pid ?? 'unknown'}` : 'stopped'}`,
     `store: ${snapshot.store_root}`,
@@ -22,7 +24,17 @@ export function formatSnapshot(envelope: SnapshotEnvelope): string {
   ];
   if (envelope.error) lines.push(`error: ${envelope.error}`);
 
-  lines.push('', `sessions: ${snapshot.sessions.length} runs: ${snapshot.runs.length}`, '');
+  lines.push('', `live_orchestrators: ${live.length} archived_orchestrators: ${archive.length} sessions: ${snapshot.sessions.length} runs: ${snapshot.runs.length}`, '');
+  if (live.length > 0) {
+    lines.push('Live orchestrators');
+    for (const group of live) lines.push(...formatOrchestratorSummary(group));
+    lines.push('');
+  }
+  if (archive.length > 0) {
+    lines.push('Archived orchestrators');
+    for (const group of archive.slice(0, 10)) lines.push(...formatOrchestratorSummary(group));
+    lines.push('');
+  }
   if (snapshot.sessions.length === 0) {
     lines.push('No runs recorded.');
     return `${lines.join('\n')}\n`;
@@ -34,175 +46,41 @@ export function formatSnapshot(envelope: SnapshotEnvelope): string {
     if (session.summary) lines.push(`  ${session.summary}`);
     if (session.session_id) lines.push(`  session=${session.session_id}`);
     for (const prompt of session.prompts.slice(-5)) {
-      lines.push(`  - ${prompt.title} [${prompt.status}] model=${formatModel(prompt.model)} effort=${formatSetting(prompt.settings.reasoning_effort)} tier=${formatTier(prompt.settings)} last=${prompt.last_activity_at ?? 'none'}`);
+      lines.push(`  - ${prompt.title} [${prompt.status}] model=${formatModel(prompt.model)} effort=${formatSetting(prompt.settings.reasoning_effort)} tier=${formatTier(prompt.settings)} last=${formatTimestamp(prompt.last_activity_at)}`);
     }
     for (const warning of session.warnings) lines.push(`  warning: ${warning}`);
   }
 
   lines.push('', 'Runs');
-  for (const run of snapshot.runs) {
-    lines.push(formatRunLine(run));
-  }
-
+  for (const run of snapshot.runs) lines.push(formatRunLine(run));
   return `${lines.join('\n')}\n`;
 }
 
-export function renderDashboard(envelope: SnapshotEnvelope, state: DashboardState, width: number, height: number): string {
-  const snapshot = envelope.snapshot;
+function formatOrchestratorSummary(group: ObservabilityOrchestratorGroup): string[] {
+  const status = group.status?.state ?? (group.live ? 'live' : 'archived');
   const lines = [
-    `${style.bold('agent-orchestrator')} ${style.dim(envelope.running ? `running pid=${snapshot.daemon_pid ?? 'unknown'}` : 'stopped')} | ${snapshot.sessions.length} sessions | ${snapshot.runs.length} runs | ${snapshot.generated_at}`,
-    renderViewState(snapshot, state),
-    style.dim(renderKeyHint(snapshot, state)),
-    '',
+    `- ${group.label} [${status}] id=${group.orchestrator_id} workers=${group.worker_count} running=${group.running_count} cwd=${compactPath(group.cwd)} updated=${group.updated_at}`,
   ];
-  if (envelope.error) lines.push(`error: ${envelope.error}`, '');
-
-  if (state.view === 'sessions') {
-    lines.push(...renderSessionList(snapshot.sessions, state.selectedSession));
-  } else if (state.view === 'prompts') {
-    lines.push(...renderPromptList(currentSession(snapshot, state), state.selectedPrompt));
-  } else {
-    lines.push(...renderRunDetail(currentRun(snapshot, state), width));
+  if (group.display?.tmux_pane || group.display?.tmux_window_id) {
+    lines.push(`  display=${[group.display.tmux_pane, group.display.tmux_window_id].filter(Boolean).join(' ')}`);
   }
-
-  return `${lines.slice(0, Math.max(1, height - 1)).map((line) => fit(line, width)).join('\n')}\n`;
-}
-
-export function clampDashboardState(state: DashboardState, snapshot: ObservabilitySnapshot): DashboardState {
-  const next = { ...state };
-  next.selectedSession = clamp(next.selectedSession, 0, Math.max(0, snapshot.sessions.length - 1));
-  const session = snapshot.sessions[next.selectedSession] ?? null;
-  next.selectedPrompt = clamp(next.selectedPrompt, 0, Math.max(0, (session?.prompts.length ?? 1) - 1));
-  if (!session && next.view !== 'sessions') next.view = 'sessions';
-  return next;
-}
-
-function renderSessionList(sessions: ObservabilitySession[], selected: number): string[] {
-  if (sessions.length === 0) return ['No runs recorded.'];
-  const lines = [
-    sectionTitle('Sessions'),
-    style.dim(`  ${pad('AGENT', 7)} ${pad('STATUS', 10)} ${pad('PROMPTS', 7)} ${pad('MODEL', 22)} ${pad('EFFORT', 8)} ${pad('TIER', 8)} ${pad('WORKSPACE', 32)} CHAT`),
-    style.dim(`  ${'-'.repeat(7)} ${'-'.repeat(10)} ${'-'.repeat(7)} ${'-'.repeat(22)} ${'-'.repeat(8)} ${'-'.repeat(8)} ${'-'.repeat(32)} ${'-'.repeat(20)}`),
-  ];
-  sessions.forEach((session, index) => {
-    lines.push(selectLine(index === selected, formatSessionRow(session)));
-  });
-  return lines;
-}
-
-function renderPromptList(session: ObservabilitySession | null, selected: number): string[] {
-  if (!session) return ['No session selected.'];
-  const shownText = session.prompts.length === session.run_count ? '' : ` shown=${session.prompts.length}`;
-  const lines = [
-    `Session: ${session.title} [${session.status}] prompts=${session.run_count}${shownText} workspace=${formatWorkspace(session)} updated=${session.updated_at}`,
-  ];
-  if (session.summary) lines.push(`Summary: ${session.summary}`);
-  if (session.session_id) lines.push(`Session ID: ${session.session_id}`);
-  for (const warning of session.warnings) lines.push(`Warning: ${warning}`);
-  lines.push(
-    '',
-    sectionTitle('Prompts'),
-    style.dim(`  ${pad('STATUS', 10)} ${pad('MODEL', 26)} ${pad('EFFORT', 8)} ${pad('TIER', 8)} ${pad('LAST', 19)} PROMPT`),
-    style.dim(`  ${'-'.repeat(10)} ${'-'.repeat(26)} ${'-'.repeat(8)} ${'-'.repeat(8)} ${'-'.repeat(19)} ${'-'.repeat(20)}`),
-  );
-  session.prompts.forEach((prompt, index) => {
-    lines.push(selectLine(index === selected, `${statusCell(prompt.status, 10)} ${modelCell(formatModelCompact(prompt.model), 26)} ${settingsCell(formatSetting(prompt.settings.reasoning_effort), 8)} ${settingsCell(formatTier(prompt.settings), 8)} ${pad(formatTimestamp(prompt.last_activity_at), 19)} ${prompt.title}`));
-  });
-  return lines;
-}
-
-function formatSessionRow(session: ObservabilitySession): string {
-  const warningText = session.warnings.length > 0 ? ` warnings=${session.warnings.length}` : '';
-  return `${agentCell(session.backend, 7)} ${statusCell(session.status, 10)} ${pad(String(session.run_count), 7)} ${modelCell(formatLatestModel(session), 22)} ${settingsCell(formatLatestEffort(session), 8)} ${settingsCell(formatLatestTier(session), 8)} ${workspaceCell(formatWorkspace(session), 32)} ${session.title}${warningText}`;
-}
-
-function renderRunDetail(run: ObservabilityRun | null, width: number): string[] {
-  if (!run) return ['No run selected.'];
-  const lines = [
-    sectionTitle('Prompt Detail'),
-    detailLine('Run', run.run.run_id),
-    detailLine('Title', run.prompt.title),
-    `${style.bold('Status')}: ${colorStatus(run.run.status)}`,
-    detailLine('Agent', run.run.backend),
-    detailLine('Model', formatModel(run.model)),
-    detailLine('Reasoning', formatSetting(run.settings.reasoning_effort)),
-    detailLine('Service Tier', formatTier(run.settings)),
-    detailLine('Invocation', formatInvocation(run)),
-    detailLine('Cwd', run.run.cwd),
-    detailLine('Git', formatRunGit(run)),
-    detailLine('Session', `requested=${run.session.requested_session_id ?? 'none'} observed=${run.session.observed_session_id ?? 'none'} effective=${run.session.effective_session_id ?? 'none'} audit=${run.session.status}`),
-    detailLine('Duration', `${run.duration_seconds === null ? 'unknown' : `${run.duration_seconds}s`} events=${run.activity.event_count}`),
-    detailLine('Activity', `last=${formatTimestamp(run.activity.last_activity_at)} source=${run.activity.last_activity_source ?? 'none'} idle=${run.activity.idle_seconds === null ? 'n/a' : `${run.activity.idle_seconds}s`}`),
-    detailLine('Timeouts', formatTimeoutPolicy(run)),
-  ];
-  if (run.activity.latest_error) lines.push(detailLine('Latest Error', formatLatestError(run)));
-  for (const warning of run.session.warnings) lines.push(`Warning: ${warning}`);
-  if (run.prompt.summary) lines.push(`Summary: ${run.prompt.summary}`);
-  lines.push('', sectionTitle('User Prompt'));
-  lines.push(...wrap((run.prompt.text ?? run.prompt.preview) || '(prompt not included)', Math.max(40, width - 2)).map((line) => `  ${line}`));
-  lines.push('', `${sectionTitle('Final Response')} ${colorResponseStatus(run.response.status ?? responseStateLabel(run))}`);
-  lines.push(...wrap(run.response.summary ?? responsePlaceholder(run), Math.max(40, width - 2)).map((line) => `  ${line}`));
-  lines.push('', sectionTitle('Recent Activity'));
-  if (run.activity.recent_events.length === 0) lines.push('  none');
-  for (const event of run.activity.recent_events) {
-    lines.push(`  ${style.dim(`#${event.seq}`)} ${formatTimestamp(event.ts)} ${event.type}`);
-  }
-  if (run.activity.recent_errors.length > 0) {
-    lines.push('', sectionTitle('Recent Errors'));
-    for (const error of run.activity.recent_errors) lines.push(`  ${error}`);
-  }
-  lines.push('', sectionTitle('Artifacts'));
-  for (const artifact of run.artifacts) {
-    lines.push(`  ${artifact.name} ${artifact.exists ? formatBytes(artifact.bytes ?? 0) : 'missing'} ${artifact.path}`);
+  for (const worker of group.workers.slice(-5)) {
+    lines.push(`  - ${worker.title} [${worker.status}] ${worker.run_id} last=${formatTimestamp(worker.last_activity_at)}`);
   }
   return lines;
 }
 
-function responseStateLabel(run: ObservabilityRun): string {
-  return run.run.status === 'running' ? 'pending' : 'missing';
+function liveOrchestrators(snapshot: ObservabilitySnapshot): ObservabilityOrchestratorGroup[] {
+  return snapshot.orchestrators.filter((group) => group.live && group.status?.state !== 'stale');
 }
 
-function responsePlaceholder(run: ObservabilityRun): string {
-  return run.run.status === 'running' ? '(response pending)' : '(no final response recorded)';
-}
-
-function currentSession(snapshot: ObservabilitySnapshot, state: DashboardState): ObservabilitySession | null {
-  return snapshot.sessions[state.selectedSession] ?? null;
-}
-
-function currentRun(snapshot: ObservabilitySnapshot, state: DashboardState): ObservabilityRun | null {
-  const session = currentSession(snapshot, state);
-  const prompt = session?.prompts[state.selectedPrompt];
-  if (!prompt) return null;
-  return snapshot.runs.find((run) => run.run.run_id === prompt.run_id) ?? null;
-}
-
-function renderViewState(snapshot: ObservabilitySnapshot, state: DashboardState): string {
-  const session = currentSession(snapshot, state);
-  const prompt = session?.prompts[state.selectedPrompt] ?? null;
-  if (state.view === 'sessions') {
-    return `${style.bold('View')}: Sessions ${position(state.selectedSession, snapshot.sessions.length)}`;
-  }
-  if (state.view === 'prompts') {
-    return `${style.bold('View')}: Sessions > ${session?.title ?? 'none'} | Prompt ${position(state.selectedPrompt, session?.prompts.length ?? 0)}`;
-  }
-  return `${style.bold('View')}: Detail > ${session?.title ?? 'none'} > ${prompt?.title ?? 'none'} | Prompt ${position(state.selectedPrompt, session?.prompts.length ?? 0)}`;
-}
-
-function renderKeyHint(snapshot: ObservabilitySnapshot, state: DashboardState): string {
-  const session = currentSession(snapshot, state);
-  if (state.view === 'sessions') return 'Keys: Up/Down choose chat, Enter opens prompts, q exits | PROMPTS=history length';
-  if (state.view === 'prompts') return 'Keys: Up/Down choose prompt, Enter opens detail, Esc/Backspace returns to chats, q exits';
-  return `Keys: Up/Down switches prompt in ${session?.title ?? 'this chat'}, Esc/Backspace returns to prompts, q exits`;
-}
-
-function position(index: number, count: number): string {
-  return count > 0 ? `${clamp(index, 0, count - 1) + 1}/${count}` : '0/0';
+function archiveOrchestrators(snapshot: ObservabilitySnapshot): ObservabilityOrchestratorGroup[] {
+  return snapshot.orchestrators.filter((group) => !group.live || group.status?.state === 'stale');
 }
 
 function formatRunLine(run: ObservabilityRun): string {
   const latestError = run.activity.latest_error ? ` latest_error=${run.activity.latest_error.category}:${run.activity.latest_error.message}` : '';
-  return `- ${run.prompt.title} [${run.run.status}] ${run.run.run_id} model=${formatModel(run.model)} effort=${formatSetting(run.settings.reasoning_effort)} tier=${formatTier(run.settings)} invocation=${formatInvocation(run)} session=${run.session.effective_session_id ?? 'none'} idle=${run.activity.idle_seconds === null ? 'n/a' : `${run.activity.idle_seconds}s`} events=${run.activity.event_count} size=${formatBytes(run.artifacts.reduce((sum, artifact) => sum + (artifact.bytes ?? 0), 0))}${latestError}`;
+  return `- ${run.prompt.title} [${run.run.status}] ${run.run.run_id} model=${formatModel(run.model)} effort=${formatSetting(run.settings.reasoning_effort)} tier=${formatTier(run.settings)} invocation=${formatInvocation(run)} session=${run.session.effective_session_id ?? 'none'} idle=${run.activity.idle_seconds === null ? 'n/a' : `${run.activity.idle_seconds}s`} events=${run.activity.event_count} response=${run.response.status ?? (run.run.status === 'running' ? 'pending' : 'missing')} size=${formatBytes(run.artifacts.reduce((sum, artifact) => sum + (artifact.bytes ?? 0), 0))}${latestError}`;
 }
 
 function formatModel(model: { name: string | null; source: string; requested_name?: string | null; observed_name?: string | null }): string {
@@ -213,246 +91,62 @@ function formatModel(model: { name: string | null; source: string; requested_nam
   return `${name} (${model.source})`;
 }
 
-function formatModelCompact(model: { name: string | null; source: string }): string {
-  return model.name ?? `default/${model.source}`;
-}
-
-function formatSessionModels(session: ObservabilitySession): string {
-  if (session.models.length === 0) return 'unknown';
-  const labels = session.models.map(formatModelCompact);
-  const [first, ...rest] = labels;
-  return rest.length === 0 ? first ?? 'unknown' : `${first ?? 'unknown'} +${rest.length}`;
-}
-
-function formatSessionEfforts(session: ObservabilitySession): string {
-  return formatUniqueSettings(session.settings.map((settings) => formatSetting(settings.reasoning_effort)));
-}
-
-function formatSessionTiers(session: ObservabilitySession): string {
-  return formatUniqueSettings(session.settings.map(formatTier));
-}
-
 function formatLatestModel(session: ObservabilitySession): string {
-  const prompt = latestPrompt(session);
-  return prompt ? formatModelCompact(prompt.model) : formatSessionModels(session);
+  return formatModel(session.models.at(-1) ?? { name: null, source: 'legacy_unknown' });
 }
 
 function formatLatestEffort(session: ObservabilitySession): string {
-  const prompt = latestPrompt(session);
-  return prompt ? formatSetting(prompt.settings.reasoning_effort) : formatSessionEfforts(session);
+  return formatSetting(session.settings.at(-1)?.reasoning_effort ?? null);
 }
 
 function formatLatestTier(session: ObservabilitySession): string {
-  const prompt = latestPrompt(session);
-  return prompt ? formatTier(prompt.settings) : formatSessionTiers(session);
-}
-
-function latestPrompt(session: ObservabilitySession) {
-  return session.prompts[session.prompts.length - 1] ?? null;
-}
-
-function formatWorkspace(session: ObservabilitySession): string {
-  const workspace = session.workspace;
-  if (!workspace) return compactFolder(session.cwd);
-  const dirty = workspace.dirty_count !== null && workspace.dirty_count > 0 ? '*' : '';
-  if (workspace.repository_name && workspace.branch) {
-    const repo = compactRepositoryName(workspace.repository_name);
-    return `${repo}:${compactBranchName(workspace.branch, Math.max(8, 31 - repo.length - dirty.length))}${dirty}`;
-  }
-  if (workspace.repository_name) {
-    return workspace.label.replace(workspace.repository_name, compactRepositoryName(workspace.repository_name));
-  }
-  return compactFolder(workspace.cwd);
-}
-
-function formatRunGit(run: ObservabilityRun): string {
-  const snapshot = run.run.git_snapshot;
-  if (!snapshot) return run.run.git_snapshot_status;
-  const repo = snapshot.root ? basename(snapshot.root) : null;
-  const target = repo && snapshot.branch
-    ? `${repo}:${snapshot.branch}`
-    : repo
-      ? `${repo}@${snapshot.sha.slice(0, 7)}`
-      : snapshot.sha.slice(0, 7);
-  const dirty = snapshot.dirty_count > 0 ? `dirty=${snapshot.dirty_count}` : 'clean';
-  return `${target} ${dirty}`;
-}
-
-function compactFolder(cwd: string): string {
-  const leaf = basename(cwd);
-  const rawParent = basename(dirname(cwd));
-  const parent = rawParent.startsWith('worktrees-') ? rawParent.slice('worktrees-'.length) : rawParent;
-  const compactParent = compactRepositoryName(parent);
-  if (parent && leaf && parent !== leaf && `${parent}/${leaf}`.length <= 32) return `${parent}/${leaf}`;
-  if (compactParent && leaf && compactParent !== leaf) return `${compactParent}/${leaf}`;
-  return leaf || cwd;
-}
-
-function compactRepositoryName(name: string): string {
-  if (name.length <= 14) return name;
-  const parts = name.split('-').filter(Boolean);
-  if (parts.length <= 1) return name.slice(0, 14);
-  const head = parts.slice(0, -1).map((part) => part[0]).join('');
-  return `${head}-${parts[parts.length - 1] ?? ''}`;
-}
-
-function compactBranchName(name: string, maxLength: number): string {
-  if (name.length <= maxLength) return name;
-  const parts = name.split('/').filter(Boolean);
-  const last = parts[parts.length - 1];
-  if (last && last.length <= maxLength) return last;
-  if (maxLength <= 1) return name.slice(0, maxLength);
-  return `${name.slice(0, maxLength - 1)}.`;
-}
-
-function formatUniqueSettings(values: string[]): string {
-  const unique = Array.from(new Set(values));
-  const [first, ...rest] = unique;
-  return rest.length === 0 ? first ?? 'default' : `${first ?? 'default'} +${rest.length}`;
+  return formatTier(session.settings.at(-1));
 }
 
 function formatSetting(value: string | null): string {
   return value ?? 'default';
 }
 
-function formatTier(settings: ObservabilityRunSettings): string {
-  return settings.service_tier ?? settings.mode ?? 'default';
+function formatTier(settings: ObservabilityRunSettings | null | undefined): string {
+  return settings?.service_tier ?? 'default';
+}
+
+function formatWorkspace(session: ObservabilitySession): string {
+  const workspace = session.workspace;
+  if (workspace.label) return workspace.label;
+  if (workspace.repository_name && workspace.branch) return `${workspace.repository_name}:${workspace.branch}`;
+  if (workspace.repository_name) return workspace.repository_name;
+  return compactFolder(workspace.cwd);
+}
+
+function compactPath(path: string): string {
+  return compactFolder(path);
+}
+
+function compactFolder(cwd: string): string {
+  const leaf = basename(cwd);
+  const parent = basename(dirname(cwd));
+  if (parent && leaf && parent !== leaf) return `${parent}/${leaf}`;
+  return leaf || cwd;
+}
+
+function formatTimestamp(value: string | null): string {
+  if (!value) return 'none';
+  return value.replace('T', ' ').replace(/\.\d{3}Z$/, 'Z');
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes}B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)}KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)}MB`;
 }
 
 function formatInvocation(run: ObservabilityRun): string {
   const invocation = run.run.worker_invocation;
-  if (!invocation) return 'not recorded';
+  if (!invocation) return 'unknown';
   return [invocation.command, ...invocation.args.map(shellQuote)].join(' ');
-}
-
-function formatTimeoutPolicy(run: ObservabilityRun): string {
-  return [
-    `idle=${run.run.idle_timeout_seconds === null ? 'none' : `${run.run.idle_timeout_seconds}s`}`,
-    `hard=${run.run.execution_timeout_seconds === null ? 'none' : `${run.run.execution_timeout_seconds}s`}`,
-    `timeout_reason=${run.run.timeout_reason ?? 'none'}`,
-    `terminal_reason=${run.run.terminal_reason ?? 'none'}`,
-  ].join(' ');
-}
-
-function formatLatestError(run: ObservabilityRun): string {
-  const error = run.activity.latest_error;
-  if (!error) return 'none';
-  const flags = [
-    `category=${error.category}`,
-    `source=${error.source}`,
-    `fatal=${error.fatal}`,
-    `retryable=${error.retryable}`,
-  ].join(' ');
-  return `${error.message} (${flags})`;
 }
 
 function shellQuote(value: string): string {
   return /^[A-Za-z0-9_./:=@+-]+$/.test(value) ? value : `'${value.replace(/'/g, `'\\''`)}'`;
 }
-
-function formatTimestamp(value: string | null): string {
-  return value ? value.replace('T', ' ').slice(0, 19) : 'none';
-}
-
-function formatBytes(bytes: number): string {
-  if (bytes < 1024) return `${bytes}B`;
-  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)}KiB`;
-  return `${(bytes / (1024 * 1024)).toFixed(1)}MiB`;
-}
-
-function detailLine(label: string, value: string): string {
-  return `${style.bold(label)}: ${value}`;
-}
-
-function sectionTitle(value: string): string {
-  return `\x1b[1;36m${value}\x1b[0m`;
-}
-
-function agentCell(value: string, width: number): string {
-  return style.magenta(pad(value, width));
-}
-
-function statusCell(value: string, width: number): string {
-  return colorStatus(pad(value, width), value);
-}
-
-function modelCell(value: string, width: number): string {
-  return style.cyan(pad(value, width));
-}
-
-function workspaceCell(value: string, width: number): string {
-  return style.dim(pad(value, width));
-}
-
-function settingsCell(value: string, width: number): string {
-  return value === 'default' ? style.dim(pad(value, width)) : style.yellow(pad(value, width));
-}
-
-function colorStatus(value: string, status = value): string {
-  if (status === 'running') return style.yellow(value);
-  if (status === 'completed') return style.green(value);
-  if (status === 'cancelled' || status === 'timed_out' || status === 'failed' || status === 'orphaned') return style.red(value);
-  return value;
-}
-
-function colorResponseStatus(status: string): string {
-  if (status === 'completed') return style.green(`[${status}]`);
-  if (status === 'pending' || status === 'needs_input') return style.yellow(`[${status}]`);
-  if (status === 'failed' || status === 'blocked' || status === 'missing') return style.red(`[${status}]`);
-  return `[${status}]`;
-}
-
-function pad(value: string, width: number): string {
-  if (value.length === width) return value;
-  if (value.length > width) return `${value.slice(0, Math.max(0, width - 1))}.`;
-  return `${value}${' '.repeat(width - value.length)}`;
-}
-
-function selectLine(selected: boolean, text: string): string {
-  return selected ? `\x1b[7m> ${text}\x1b[0m` : `  ${text}`;
-}
-
-function fit(line: string, width: number): string {
-  if (visibleLength(line) <= width) return line;
-  return `${stripAnsi(line).slice(0, Math.max(0, width - 3))}...`;
-}
-
-function wrap(text: string, width: number): string[] {
-  const words = text.split(/\s+/).filter(Boolean);
-  const lines: string[] = [];
-  let current = '';
-  for (const word of words) {
-    if (!current) {
-      current = word;
-    } else if (`${current} ${word}`.length <= width) {
-      current = `${current} ${word}`;
-    } else {
-      lines.push(current);
-      current = word;
-    }
-  }
-  if (current) lines.push(current);
-  return lines.length > 0 ? lines : [''];
-}
-
-function clamp(value: number, min: number, max: number): number {
-  return Math.min(Math.max(value, min), max);
-}
-
-function visibleLength(value: string): number {
-  return stripAnsi(value).length;
-}
-
-function stripAnsi(value: string): string {
-  return value.replace(/\x1b\[[0-9;]*m/g, '');
-}
-
-const style = {
-  bold: (value: string) => `\x1b[1m${value}\x1b[0m`,
-  dim: (value: string) => `\x1b[2m${value}\x1b[0m`,
-  cyan: (value: string) => `\x1b[36m${value}\x1b[0m`,
-  green: (value: string) => `\x1b[32m${value}\x1b[0m`,
-  yellow: (value: string) => `\x1b[33m${value}\x1b[0m`,
-  red: (value: string) => `\x1b[31m${value}\x1b[0m`,
-  magenta: (value: string) => `\x1b[35m${value}\x1b[0m`,
-};

--- a/src/daemon/watchApp.tsx
+++ b/src/daemon/watchApp.tsx
@@ -1,0 +1,738 @@
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import { Box, Text, render, useApp, useWindowSize, type Instance } from 'ink';
+import type { SnapshotEnvelope } from './observabilityFormat.js';
+import {
+  applyWatchRawInput,
+  buildWatchViewModel,
+  clampWatchDashboardState,
+  createWatchDashboardState,
+  renderMarkdownToAnsi,
+  selectedWatchSidebarItem,
+  selectedWatchTranscriptBlocks,
+  watchSidebarItems,
+  type WatchDashboardState,
+  type WatchSidebarItem,
+  type WatchTranscriptBlock,
+  type WatchViewModel,
+} from './watchViewModel.js';
+
+interface RunWatchTuiOptions {
+  initialEnvelope: SnapshotEnvelope;
+  readSnapshot: () => Promise<SnapshotEnvelope>;
+  intervalMs: number;
+  stdin?: NodeJS.ReadStream;
+  stdout?: NodeJS.WriteStream;
+  stderr?: NodeJS.WriteStream;
+}
+
+const MOUSE_ENABLE_SEQUENCE = '\x1b[?1000h\x1b[?1002h\x1b[?1006h\x1b[?1007h\x1b[?1015h';
+const MOUSE_DISABLE_SEQUENCE = '\x1b[?1015l\x1b[?1007l\x1b[?1006l\x1b[?1002l\x1b[?1000l';
+const SCREEN_ENTER_SEQUENCE = '\x1b[?1049h';
+const SCREEN_EXIT_SEQUENCE = '\x1b[?1049l';
+
+interface WatchAppProps {
+  initialEnvelope: SnapshotEnvelope;
+  readSnapshot: () => Promise<SnapshotEnvelope>;
+  intervalMs: number;
+  stdin?: NodeJS.ReadStream;
+  stdout?: NodeJS.WriteStream;
+  onQuit?: () => void;
+}
+
+export async function runWatchTui(options: RunWatchTuiOptions): Promise<void> {
+  let instance: Instance | null = null;
+  let quitRequested = false;
+  const stdin = options.stdin ?? process.stdin;
+  const stdout = options.stdout ?? process.stdout;
+  const stderr = options.stderr ?? process.stderr;
+  const mouseEnabled = Boolean(stdout.isTTY);
+  const rawModeSupported = Boolean(stdin.isTTY && typeof stdin.setRawMode === 'function');
+  const stdinWasRaw = Boolean(stdin.isRaw);
+  const requestQuit = () => {
+    if (quitRequested) return;
+    quitRequested = true;
+    instance?.unmount();
+  };
+  try {
+    if (rawModeSupported) {
+      stdin.setRawMode(true);
+      stdin.resume();
+    }
+    if (mouseEnabled) stdout.write(SCREEN_ENTER_SEQUENCE);
+    instance = render(
+      <WatchApp
+        initialEnvelope={options.initialEnvelope}
+        readSnapshot={options.readSnapshot}
+        intervalMs={options.intervalMs}
+        stdin={stdin}
+        stdout={stdout}
+        onQuit={requestQuit}
+      />,
+      {
+        stdin,
+        stdout,
+        stderr,
+        exitOnCtrlC: false,
+        incrementalRendering: true,
+        interactive: true,
+        maxFps: 60,
+      },
+    );
+    await instance.waitUntilExit();
+  } finally {
+    if (mouseEnabled) stdout.write(`${MOUSE_DISABLE_SEQUENCE}${SCREEN_EXIT_SEQUENCE}`);
+    if (rawModeSupported && !stdinWasRaw) stdin.setRawMode(false);
+    if (rawModeSupported) stdin.pause();
+    instance?.cleanup();
+  }
+}
+
+export function WatchApp({ initialEnvelope, readSnapshot, intervalMs, stdin, stdout, onQuit }: WatchAppProps): React.ReactElement {
+  const { exit } = useApp();
+  const { columns, rows } = useWindowSize();
+  const [envelope, setEnvelope] = useState(initialEnvelope);
+  const [state, setState] = useState<WatchDashboardState>(() => createWatchDashboardState());
+  const [mouseCapture, setMouseCapture] = useState(() => Boolean(stdout?.isTTY));
+  const model = useMemo(() => buildWatchViewModel(envelope), [envelope]);
+  const clamped = clampWatchDashboardState(state, model);
+  const stateRef = useRef(clamped);
+  const width = Math.max(60, columns || process.stdout.columns || 100);
+  const height = Math.max(12, rows || process.stdout.rows || 30);
+  const sidebarWidth = Math.min(46, Math.max(28, Math.floor(width * 0.34)));
+  const mainWidth = Math.max(30, width - sidebarWidth - 4);
+  const mainContentWidth = Math.max(20, mainWidth - 7);
+  const bodyHeight = Math.max(5, height - (model.error ? 4 : 3));
+  const transcriptHeight = Math.max(1, bodyHeight - 2);
+  const selectedItem = useMemo(() => selectedWatchSidebarItem(model, clamped), [model, clamped.mode, clamped.selectedId]);
+  const mainSurface = selectedItem?.kind === 'conversation' ? 'chat' : 'overview';
+  const transcriptBlocks = useMemo(() => selectedWatchTranscriptBlocks(model, clamped), [model, clamped.mode, clamped.selectedId]);
+  const transcriptRows = useMemo(() => transcriptRowsFromBlocks(transcriptBlocks, mainContentWidth, mainSurface), [transcriptBlocks, mainContentWidth, mainSurface]);
+  const transcriptMaxScroll = Math.max(0, transcriptRows.length - transcriptHeight);
+  const visibleTranscript = useMemo(
+    () => visibleRows(transcriptRows, clamped, transcriptHeight, mainSurface === 'chat'),
+    [transcriptRows, clamped.follow, clamped.scrollOffset, transcriptHeight, mainSurface],
+  );
+
+  useEffect(() => {
+    stateRef.current = clamped;
+  }, [clamped]);
+
+  useEffect(() => {
+    if (!stdout?.isTTY) return;
+    stdout.write(mouseCapture ? MOUSE_ENABLE_SEQUENCE : MOUSE_DISABLE_SEQUENCE);
+  }, [stdout, mouseCapture]);
+
+  useEffect(() => {
+    let cancelled = false;
+    let timer: NodeJS.Timeout | null = null;
+    const refresh = async () => {
+      try {
+        const next = await readSnapshot();
+        if (!cancelled) {
+          setEnvelope((current) => envelopeDisplayKey(current) === envelopeDisplayKey(next) ? current : next);
+        }
+      } finally {
+        if (!cancelled) timer = setTimeout(refresh, intervalMs);
+      }
+    };
+    timer = setTimeout(refresh, intervalMs);
+    return () => {
+      cancelled = true;
+      if (timer) clearTimeout(timer);
+    };
+  }, [intervalMs, readSnapshot]);
+
+  useEffect(() => {
+    const next = clampWatchDashboardState(state, model);
+    if (next.selectedId !== state.selectedId || next.follow !== state.follow || next.scrollOffset !== state.scrollOffset) {
+      setState(next);
+    }
+  }, [model, state]);
+
+  useEffect(() => {
+    if (!stdin?.isTTY) return;
+    const inputStream = stdin;
+    const onData = (chunk: Buffer | string) => {
+      const input = chunk.toString();
+      const result = applyWatchRawInput(stateRef.current, model, input, mainWidth - 2, transcriptHeight, transcriptMaxScroll);
+      stateRef.current = result.state;
+      if (result.quit) {
+        exit();
+        onQuit?.();
+        return;
+      }
+      if (result.toggleMouseCapture) setMouseCapture((current) => !current);
+      setState(result.state);
+    };
+    inputStream.on('data', onData);
+    return () => {
+      inputStream.off('data', onData);
+    };
+  }, [stdin, exit, onQuit, model, mainWidth, transcriptHeight, transcriptMaxScroll]);
+
+  return (
+    <Box flexDirection="column" width={width} height={height}>
+      <Header model={model} state={clamped} />
+      {model.error ? <Text color="red">error: {model.error}</Text> : null}
+      <Box flexDirection="row" height={bodyHeight}>
+        <Sidebar model={model} state={clamped} width={sidebarWidth} height={bodyHeight} />
+        <MainPane rows={visibleTranscript} width={mainWidth} contentWidth={mainContentWidth} height={bodyHeight} state={clamped} totalRows={transcriptRows.length} surface={mainSurface} selected={selectedItem} />
+      </Box>
+      <Footer state={clamped} mouseCapture={mouseCapture} />
+    </Box>
+  );
+}
+
+function Header({ model, state }: { model: WatchViewModel; state: WatchDashboardState }): React.ReactElement {
+  const modeCount = state.mode === 'live' ? model.live.length : model.archive.length;
+  return (
+    <Box>
+      <Text bold color="cyan">agent-orchestrator watch</Text>
+      <Text color={model.running ? 'green' : 'yellow'}> {model.running ? 'running' : 'stopped'}</Text>
+      <Text dimColor>  live </Text>
+      <Text color="green">{model.live.length}</Text>
+      <Text dimColor>  archive </Text>
+      <Text color="yellow">{model.archive.length}</Text>
+      <Text dimColor>  {state.mode} </Text>
+      <Text>{modeCount}</Text>
+    </Box>
+  );
+}
+
+function Sidebar({ model, state, width, height }: { model: WatchViewModel; state: WatchDashboardState; width: number; height: number }): React.ReactElement {
+  const items = watchSidebarItems(model, state);
+  const rows = items.slice(0, height - 2);
+  const title = state.mode === 'live' ? 'Live orchestrators' : 'Archive';
+  return (
+    <Box flexDirection="column" width={width} height={height} borderStyle="single" borderColor="gray" paddingX={1}>
+      <Text bold color={state.mode === 'live' ? 'green' : 'yellow'}>{title}</Text>
+      {rows.length === 0 ? <Text dimColor>{state.mode === 'live' ? 'No live sessions.' : 'No archived sessions.'}</Text> : null}
+      {rows.map((item) => <SidebarRow key={item.id} item={item} selected={item.id === state.selectedId} state={state} />)}
+    </Box>
+  );
+}
+
+function SidebarRow({ item, selected, state }: { item: WatchSidebarItem; selected: boolean; state: WatchDashboardState }): React.ReactElement {
+  if (item.kind === 'orchestrator') {
+    const expanded = state.expanded[item.orchestrator.id] ?? true;
+    return (
+      <SelectedText selected={selected}>
+        {selected ? '>' : ' '} {expanded ? 'v' : '+'} {statusLabel(item.orchestrator.status)} {item.orchestrator.runningCount}/{item.orchestrator.workerCount} {plainSidebarText(item.orchestrator.label)}
+      </SelectedText>
+    );
+  }
+
+  const conversation = item.conversation!;
+  return (
+    <Box flexDirection="column">
+      <SelectedText selected={selected}>
+        {'  '}{selected ? '>' : ' '} {statusLabel(conversation.status)} {conversation.workerName}
+      </SelectedText>
+      <SelectedText selected={selected} dim={!selected}>
+        {'      '}{plainSidebarText(conversation.title)}
+      </SelectedText>
+    </Box>
+  );
+}
+
+function SelectedText({ selected, dim, children }: { selected: boolean; dim?: boolean; children: React.ReactNode }): React.ReactElement {
+  return (
+    <Text color={selected ? 'black' : undefined} backgroundColor={selected ? 'cyan' : undefined} bold={selected} dimColor={dim} wrap="truncate">
+      {children}
+    </Text>
+  );
+}
+
+function plainSidebarText(value: string): string {
+  return stripAnsiForDisplay(value)
+    .replaceAll(/\[([^\]]+)\]\([^)]+\)/g, '$1')
+    .replaceAll(/`([^`]*)`/g, '$1')
+    .replaceAll(/\*\*([^*]+)\*\*/g, '$1')
+    .replaceAll(/\*([^*]+)\*/g, '$1')
+    .replaceAll(/__([^_]+)__/g, '$1')
+    .replaceAll(/_([^_]+)_/g, '$1')
+    .replaceAll(/[>#]/g, '')
+    .replaceAll(/\s+/g, ' ')
+    .trim();
+}
+
+function stripAnsiForDisplay(value: string): string {
+  return value.replaceAll(/\x1b\[[0-9;]*m/g, '');
+}
+
+function MainPane({
+  rows,
+  width,
+  contentWidth,
+  height,
+  state,
+  totalRows,
+  surface,
+  selected,
+}: {
+  rows: TranscriptRow[];
+  width: number;
+  contentWidth: number;
+  height: number;
+  state: WatchDashboardState;
+  totalRows: number;
+  surface: 'overview' | 'chat';
+  selected: WatchSidebarItem | null;
+}): React.ReactElement {
+  const followColor = state.follow ? 'green' : 'yellow';
+  const borderColor = surface === 'overview' ? 'blue' : followColor;
+  const viewportRows = Math.max(1, rows.length);
+  const scroll = scrollMetrics(state, totalRows, viewportRows, surface === 'chat');
+  const title = surface === 'overview'
+    ? 'Overview'
+    : `Timeline${selected?.conversation ? `: ${selected.conversation.workerName}` : ''}`;
+  const status = surface === 'overview' ? 'DASHBOARD' : state.follow ? 'FOLLOW latest' : `SCROLLED +${state.scrollOffset}`;
+  const header = `${title}  ${status}  ${scroll.label}  ${totalRows} rows`;
+  const contentHeight = Math.max(1, height - 2);
+  return (
+    <Box flexDirection="column" width={width} height={height} borderStyle={surface === 'overview' ? 'double' : 'single'} borderColor={borderColor} paddingX={1}>
+      <Box width={contentWidth} height={1}>
+        <Text bold color={surface === 'overview' ? 'blue' : 'cyan'} wrap="truncate">{header}</Text>
+      </Box>
+      <Box flexDirection="row" height={contentHeight}>
+        <Box flexDirection="column" width={contentWidth}>
+          <Text> </Text>
+          {rows.map((row) => (
+            <TranscriptRowView key={row.id} row={row} surface={surface} />
+          ))}
+        </Box>
+        <ScrollIndicator height={viewportRows} metrics={scroll} activeColor={followColor} />
+      </Box>
+    </Box>
+  );
+}
+
+function Footer({ state, mouseCapture }: { state: WatchDashboardState; mouseCapture: boolean }): React.ReactElement {
+  return (
+    <Text dimColor>
+      Up/Down j/k select | wheel/u/d scroll | m {mouseCapture ? 'text' : 'wheel'} | Space | Tab {state.mode === 'live' ? 'archive' : 'live'} | q quit
+    </Text>
+  );
+}
+
+type TranscriptRow =
+  | { id: string; kind: 'pad' }
+  | { id: string; kind: 'spacer' }
+  | { id: string; kind: 'chatHeader'; block: WatchTranscriptBlock; text: string }
+  | { id: string; kind: 'chatBody'; block: WatchTranscriptBlock; text: string }
+  | { id: string; kind: 'overviewTitle'; block: WatchTranscriptBlock; title: string; status: string | null }
+  | { id: string; kind: 'overviewMetric'; block: WatchTranscriptBlock; metrics: string[] }
+  | { id: string; kind: 'overviewSection'; text: string }
+  | { id: string; kind: 'overviewWorker'; block: WatchTranscriptBlock; name: string; status: string; meta: string }
+  | { id: string; kind: 'overviewField'; block: WatchTranscriptBlock; label: string; text: string }
+  | { id: string; kind: 'overviewMeta'; block: WatchTranscriptBlock; text: string };
+
+function TranscriptRowView({ row, surface }: { row: TranscriptRow; surface: 'overview' | 'chat' }): React.ReactElement {
+  if (row.kind === 'pad' || row.kind === 'spacer') return <Text> </Text>;
+  if (surface === 'overview') return <OverviewRowView row={row} />;
+
+  return <ChatRowView row={row} />;
+}
+
+function ChatRowView({ row }: { row: TranscriptRow }): React.ReactElement {
+  if (row.kind !== 'chatHeader' && row.kind !== 'chatBody') return <Text> </Text>;
+
+  const color = transcriptColor(row.block);
+  const railColor = runRailColor(row.block);
+  if (row.kind === 'chatHeader') {
+    const badge = chatBadge(row.block);
+    return (
+      <Text wrap="wrap">
+        <Text color={railColor}>┃</Text>
+        <Text> </Text>
+        <Text color="black" backgroundColor={color} bold>{badge}</Text>
+        <Text color={color} bold> {row.text}</Text>
+      </Text>
+    );
+  }
+
+  return (
+    <Text wrap="wrap">
+      <Text color={railColor}>┃</Text>
+      <Text color={color} dimColor> │ </Text>
+      <Text color={row.block.tone === 'result' ? 'white' : row.block.subtle ? 'gray' : undefined} bold={row.block.tone === 'result'}>{row.text}</Text>
+    </Text>
+  );
+}
+
+function OverviewRowView({ row }: { row: TranscriptRow }): React.ReactElement {
+  if (row.kind === 'overviewSection') {
+    return (
+      <Text wrap="truncate">
+        <Text color="gray">─ </Text>
+        <Text color="blue" bold>{row.text}</Text>
+        <Text color="gray"> </Text>
+      </Text>
+    );
+  }
+  if (
+    row.kind !== 'overviewTitle'
+    && row.kind !== 'overviewMetric'
+    && row.kind !== 'overviewWorker'
+    && row.kind !== 'overviewField'
+    && row.kind !== 'overviewMeta'
+  ) {
+    return <Text> </Text>;
+  }
+
+  if (row.kind === 'overviewTitle') {
+    return (
+      <Text wrap="truncate">
+        <Text color={transcriptColor(row.block)} bold>● </Text>
+        <Text bold>{row.title}</Text>
+        {row.status ? <Text color={transcriptColor(row.block)} bold>  {row.status}</Text> : null}
+      </Text>
+    );
+  }
+
+  if (row.kind === 'overviewMetric') {
+    return (
+      <Text wrap="truncate">
+        <Text color="gray">  </Text>
+        {row.metrics.map((metric, index) => (
+          <React.Fragment key={`${row.id}:${index}`}>
+            {index > 0 ? <Text color="gray">  ·  </Text> : null}
+            <Text color="cyan">{metricLabel(metric)}</Text>
+            <Text>{metricValue(metric)}</Text>
+          </React.Fragment>
+        ))}
+      </Text>
+    );
+  }
+
+  if (row.kind === 'overviewWorker') {
+    const color = transcriptColor(row.block);
+    return (
+      <Text wrap="truncate">
+        <Text color={color} bold>{statusDot(row.block)} </Text>
+        <Text bold>{row.name}</Text>
+        <Text color={color} bold>  {row.status}</Text>
+        {row.meta ? <Text color="gray">  {row.meta}</Text> : null}
+      </Text>
+    );
+  }
+
+  if (row.kind === 'overviewField') {
+    const label = row.label ? `${row.label}:`.padEnd(11, ' ') : ''.padEnd(11, ' ');
+    return (
+      <Text wrap="truncate">
+        <Text color="gray">  │ </Text>
+        <Text color="cyan" bold>{label}</Text>
+        <Text>{row.text}</Text>
+      </Text>
+    );
+  }
+
+  return (
+    <Text wrap="truncate">
+      <Text color="gray">    {row.text}</Text>
+    </Text>
+  );
+}
+
+function transcriptRowsFromBlocks(blocks: WatchTranscriptBlock[], width: number, surface: 'overview' | 'chat'): TranscriptRow[] {
+  if (surface === 'overview') return overviewRowsFromBlocks(blocks, width);
+  return chatRowsFromBlocks(blocks, width);
+}
+
+function chatRowsFromBlocks(blocks: WatchTranscriptBlock[], width: number): TranscriptRow[] {
+  const rows: TranscriptRow[] = [];
+  const bodyWidth = Math.max(1, width - 4);
+  for (const [blockIndex, block] of blocks.entries()) {
+    if (blockIndex > 0) rows.push({ id: `${block.id}:spacer`, kind: 'spacer' });
+    const headerWidth = Math.max(1, width - displayWidth(`┃ ${chatBadge(block)} `));
+    const headerLines = wrapPlainLine(transcriptHeaderText(block), headerWidth);
+    for (const [lineIndex, line] of headerLines.entries()) {
+      rows.push({ id: `${block.id}:header:${lineIndex}`, kind: 'chatHeader', block, text: line });
+    }
+    const bodyLines = renderMarkdownToAnsi(block.body, Math.max(20, bodyWidth));
+    for (const [lineIndex, line] of bodyLines.entries()) {
+      const wrapped = wrapPlainLine(stripAnsiForDisplay(line), bodyWidth);
+      for (const [wrapIndex, wrappedLine] of wrapped.entries()) {
+        rows.push({ id: `${block.id}:body:${lineIndex}:${wrapIndex}`, kind: 'chatBody', block, text: wrappedLine });
+      }
+    }
+  }
+  return rows.length > 0 ? rows : [{ id: 'empty', kind: 'pad' }];
+}
+
+function overviewRowsFromBlocks(blocks: WatchTranscriptBlock[], width: number): TranscriptRow[] {
+  const rows: TranscriptRow[] = [];
+  const [session, ...workers] = blocks;
+  if (!session) return [{ id: 'empty', kind: 'pad' }];
+
+  rows.push({
+    id: `${session.id}:title`,
+    kind: 'overviewTitle',
+    block: session,
+    title: session.title || session.label,
+    status: session.status,
+  });
+
+  const sessionFields = overviewFieldMap(session.body);
+  const metrics = [
+    overviewMetricText('Workers', sessionFields),
+    overviewMetricText('Open', sessionFields),
+    overviewMetricText('Last update', sessionFields),
+  ].filter((value): value is string => Boolean(value));
+  for (const [index, metric] of metrics.entries()) {
+    rows.push({ id: `${session.id}:metrics:${index}`, kind: 'overviewMetric', block: session, metrics: [metric] });
+  }
+  const workspace = sessionFields.get('Workspace');
+  if (workspace) appendOverviewFieldRows(rows, session, 'Workspace', workspace, width);
+
+  rows.push({ id: `${session.id}:spacer`, kind: 'spacer' });
+  rows.push({ id: `${session.id}:workers`, kind: 'overviewSection', text: 'Workers' });
+  rows.push({ id: `${session.id}:workers:spacer`, kind: 'spacer' });
+
+  for (const [index, worker] of workers.entries()) {
+    const fields = overviewFieldMap(worker.body);
+    const runs = fields.get('Runs');
+    const meta = [...worker.metadata, runs ? formatRunCount(runs) : null].filter((value): value is string => Boolean(value)).join('  ·  ');
+    if (index > 0) rows.push({ id: `${worker.id}:spacer`, kind: 'spacer' });
+    rows.push({
+      id: `${worker.id}:worker`,
+      kind: 'overviewWorker',
+      block: worker,
+      name: worker.label,
+      status: worker.title,
+      meta: '',
+    });
+    if (meta) appendOverviewMetaRows(rows, worker, meta, width);
+    const task = fields.get('Task');
+    if (task) appendOverviewFieldRows(rows, worker, 'Task', task, width);
+    const latest = fields.get('Latest');
+    if (latest) appendOverviewFieldRows(rows, worker, 'Now', latest, width);
+  }
+
+  return rows.length > 0 ? rows : [{ id: 'empty', kind: 'pad' }];
+}
+
+function appendOverviewFieldRows(rows: TranscriptRow[], block: WatchTranscriptBlock, label: string, value: string, width: number): void {
+  const bodyWidth = Math.max(10, width - 16);
+  const lines = wrapPlainLine(value, bodyWidth);
+  for (const [index, line] of lines.entries()) {
+    rows.push({
+      id: `${block.id}:field:${label}:${index}`,
+      kind: 'overviewField',
+      block,
+      label: index === 0 ? label : '',
+      text: line,
+    });
+  }
+}
+
+function appendOverviewMetaRows(rows: TranscriptRow[], block: WatchTranscriptBlock, value: string, width: number): void {
+  const bodyWidth = Math.max(10, width - 8);
+  const lines = wrapPlainLine(value, bodyWidth);
+  for (const [index, line] of lines.entries()) {
+    rows.push({
+      id: `${block.id}:meta:${index}`,
+      kind: 'overviewMeta',
+      block,
+      text: line,
+    });
+  }
+}
+
+function overviewFieldMap(body: string): Map<string, string> {
+  const fields = new Map<string, string>();
+  for (const line of body.split('\n')) {
+    const match = /^([^:]+):\s*(.*)$/.exec(line.trim());
+    if (!match) continue;
+    fields.set(match[1]!, match[2] ?? '');
+  }
+  return fields;
+}
+
+function overviewMetricText(label: string, fields: Map<string, string>): string | null {
+  const value = fields.get(label);
+  return value ? `${label}: ${value}` : null;
+}
+
+function formatRunCount(value: string): string {
+  const count = Number(value);
+  if (!Number.isFinite(count)) return `${value} runs`;
+  return count === 1 ? '1 run' : `${count} runs`;
+}
+
+function transcriptHeaderText(block: WatchTranscriptBlock): string {
+  const timestamp = block.timestamp ? shortTimestamp(block.timestamp) : null;
+  const title = block.title && block.title !== block.label ? block.title : null;
+  return [
+    title ?? block.label,
+    block.status,
+    block.round ? `Run ${block.round}` : null,
+    ...block.metadata,
+    timestamp,
+  ].filter((value): value is string => Boolean(value)).join('  ');
+}
+
+function chatBadge(block: WatchTranscriptBlock): string {
+  if (block.actor === 'supervisor') return ' SUPERVISOR → WORKER ';
+  if (block.actor === 'worker') return ' WORKER MESSAGE ';
+  if (block.actor === 'result') return ' FINAL RESPONSE ';
+  if (block.actor === 'tool') return ' TOOL ';
+  if (block.actor === 'run') return ' RUN ';
+  if (block.actor === 'status') return ' ACTIVITY ';
+  if (block.actor === 'error') return ' ERROR ';
+  return ' INFO ';
+}
+
+function statusDot(block: WatchTranscriptBlock): string {
+  if (block.tone === 'running') return '●';
+  if (block.tone === 'success') return '✓';
+  if (block.tone === 'error') return '!';
+  if (block.tone === 'result') return '◆';
+  return '•';
+}
+
+function metricLabel(metric: string): string {
+  const index = metric.indexOf(':');
+  return index === -1 ? '' : `${metric.slice(0, index)}: `;
+}
+
+function metricValue(metric: string): string {
+  const index = metric.indexOf(':');
+  return index === -1 ? metric : metric.slice(index + 1).trimStart();
+}
+
+function wrapPlainLine(line: string, width: number): string[] {
+  const maxWidth = Math.max(1, width);
+  if (displayWidth(line) <= maxWidth) return [line];
+
+  const rows: string[] = [];
+  let remaining = line;
+  while (displayWidth(remaining) > maxWidth) {
+    const breakAt = wrapIndex(remaining, maxWidth);
+    rows.push(remaining.slice(0, breakAt).trimEnd());
+    remaining = remaining.slice(breakAt).replace(/^\s+/, '');
+  }
+  rows.push(remaining);
+  return rows;
+}
+
+function wrapIndex(value: string, width: number): number {
+  let visible = 0;
+  let index = 0;
+  let lastSpace = -1;
+  for (const char of value) {
+    const next = visible + charWidth(char);
+    if (next > width) break;
+    if (char === ' ' && visible > 0) lastSpace = index + char.length;
+    visible = next;
+    index += char.length;
+  }
+  if (index >= value.length) return value.length;
+  if (lastSpace > 0) return lastSpace;
+  return Math.max(1, index);
+}
+
+function displayWidth(value: string): number {
+  let width = 0;
+  for (const char of value) width += charWidth(char);
+  return width;
+}
+
+function charWidth(char: string): number {
+  if (/[\u0000-\u001f\u007f]/.test(char)) return 0;
+  return 1;
+}
+
+function visibleRows(rows: TranscriptRow[], state: WatchDashboardState, height: number, alignBottom: boolean): TranscriptRow[] {
+  const visibleHeight = Math.max(1, height);
+  const maxStart = Math.max(0, rows.length - visibleHeight);
+  const start = alignBottom
+    ? state.follow ? maxStart : Math.max(0, maxStart - state.scrollOffset)
+    : state.follow ? 0 : Math.min(maxStart, state.scrollOffset);
+  const visible = rows.slice(start, start + visibleHeight);
+  const padCount = Math.max(0, visibleHeight - visible.length);
+  const padding = Array.from({ length: padCount }, (_, index) => ({ id: `pad:${index}`, kind: 'pad' as const }));
+  return alignBottom ? [...padding, ...visible] : [...visible, ...padding];
+}
+
+interface ScrollMetrics {
+  maxScroll: number;
+  start: number;
+  thumbStart: number;
+  thumbSize: number;
+  label: string;
+}
+
+function scrollMetrics(state: WatchDashboardState, totalRows: number, viewportRows: number, alignBottom: boolean): ScrollMetrics {
+  const visibleRowsCount = Math.max(1, viewportRows);
+  const maxScroll = Math.max(0, totalRows - visibleRowsCount);
+  const start = alignBottom
+    ? state.follow ? maxScroll : Math.max(0, maxScroll - state.scrollOffset)
+    : state.follow ? 0 : Math.min(maxScroll, state.scrollOffset);
+  const trackRows = visibleRowsCount;
+  const thumbSize = totalRows <= visibleRowsCount
+    ? trackRows
+    : Math.max(1, Math.floor(trackRows * visibleRowsCount / Math.max(1, totalRows)));
+  const thumbStart = maxScroll === 0
+    ? 0
+    : Math.round((trackRows - thumbSize) * (start / maxScroll));
+  const percent = maxScroll === 0 ? 100 : Math.round((start / maxScroll) * 100);
+  const end = Math.min(totalRows, start + visibleRowsCount);
+  const position = maxScroll === 0
+    ? 'all'
+    : start === 0
+      ? 'top'
+      : start >= maxScroll
+        ? 'bottom'
+        : `${percent}%`;
+  const label = `${position} ${start + 1}-${end}/${totalRows}`;
+  return { maxScroll, start, thumbStart, thumbSize, label };
+}
+
+function ScrollIndicator({ height, metrics, activeColor }: { height: number; metrics: ScrollMetrics; activeColor: string }): React.ReactElement {
+  const rows = Array.from({ length: Math.max(1, height) }, (_, index) => {
+    const active = index >= metrics.thumbStart && index < metrics.thumbStart + metrics.thumbSize;
+    return (
+      <Text key={index} backgroundColor={active ? activeColor : undefined} color={active ? activeColor : 'gray'}>
+        {active ? ' ' : '|'}
+      </Text>
+    );
+  });
+  return <Box flexDirection="column" width={1}>{rows}</Box>;
+}
+
+function transcriptColor(block: WatchTranscriptBlock): string {
+  if (block.tone === 'supervisor') return 'cyan';
+  if (block.tone === 'worker') return 'green';
+  if (block.tone === 'tool') return 'yellow';
+  if (block.tone === 'success') return 'green';
+  if (block.tone === 'running') return 'blue';
+  if (block.tone === 'error') return 'red';
+  if (block.tone === 'result') return 'magenta';
+  return 'gray';
+}
+
+function runRailColor(block: WatchTranscriptBlock): string {
+  if (block.round === null) return 'gray';
+  const colors = ['cyan', 'magenta', 'green', 'yellow', 'blue'];
+  return colors[(block.round - 1) % colors.length]!;
+}
+
+function statusLabel(status: string): string {
+  if (status === 'running' || status === 'in_progress') return '[run]';
+  if (status === 'completed' || status === 'idle') return '[ok]';
+  if (status === 'waiting_for_user') return '[wait]';
+  if (status === 'failed' || status === 'timed_out' || status === 'cancelled' || status === 'orphaned' || status === 'attention' || status === 'stale') return '[err]';
+  return `[${status}]`;
+}
+
+function shortTimestamp(value: string): string {
+  const match = /\b\d{2}:\d{2}:\d{2}/.exec(value);
+  return match?.[0] ?? value;
+}
+
+function envelopeDisplayKey(envelope: SnapshotEnvelope): string {
+  const { generated_at: _generatedAt, ...snapshot } = envelope.snapshot;
+  return JSON.stringify({ running: envelope.running, error: envelope.error ?? null, snapshot });
+}

--- a/src/daemon/watchViewModel.ts
+++ b/src/daemon/watchViewModel.ts
@@ -1,0 +1,1375 @@
+import { Marked, type MarkedOptions } from 'marked';
+import TerminalRenderer from 'marked-terminal';
+import type {
+  ObservabilityOrchestratorGroup,
+  ObservabilityOrchestratorWorker,
+  ObservabilityRun,
+  ObservabilityRunSettings,
+  ObservabilitySnapshot,
+  RunStatus,
+  WorkerEvent,
+} from '../contract.js';
+import type { SnapshotEnvelope } from './observabilityFormat.js';
+
+export interface WatchViewModel {
+  running: boolean;
+  error?: string;
+  live: WatchOrchestrator[];
+  archive: WatchOrchestrator[];
+}
+
+export interface WatchOrchestrator {
+  id: string;
+  live: boolean;
+  label: string;
+  cwd: string;
+  status: string;
+  workerCount: number;
+  runningCount: number;
+  createdAt: string;
+  updatedAt: string;
+  generatedAt: string;
+  conversations: WatchConversation[];
+}
+
+export interface WatchConversation {
+  id: string;
+  orchestratorId: string;
+  rootRunId: string;
+  runIds: string[];
+  workerName: string;
+  workerOrdinal: number;
+  backend: string;
+  status: RunStatus;
+  title: string;
+  purpose: string;
+  summary: string | null;
+  model: string;
+  settings: ObservabilityRunSettings;
+  createdAt: string;
+  updatedAt: string;
+  latestRunStartedAt: string;
+  latestRunEndedAt: string | null;
+  turns: WatchTranscriptEvent[];
+}
+
+export type WatchTranscriptEventKind =
+  | 'run_start'
+  | 'run_end'
+  | 'prompt'
+  | 'assistant'
+  | 'tool_call'
+  | 'tool_result'
+  | 'status'
+  | 'error'
+  | 'final';
+
+export interface WatchTranscriptEvent {
+  id: string;
+  runId: string;
+  seq: number | null;
+  ts: string | null;
+  kind: WatchTranscriptEventKind;
+  title: string;
+  body: string;
+  status?: string | null;
+  accent?: 'supervisor' | 'assistant' | 'tool' | 'error' | 'status';
+  round: number;
+}
+
+export type WatchTranscriptActor =
+  | 'run'
+  | 'supervisor'
+  | 'worker'
+  | 'tool'
+  | 'status'
+  | 'result'
+  | 'error'
+  | 'system';
+
+export type WatchTranscriptTone =
+  | 'supervisor'
+  | 'worker'
+  | 'tool'
+  | 'success'
+  | 'running'
+  | 'error'
+  | 'status'
+  | 'result';
+
+export interface WatchTranscriptBlock {
+  id: string;
+  actor: WatchTranscriptActor;
+  label: string;
+  title: string;
+  timestamp: string | null;
+  status: string | null;
+  body: string;
+  round: number | null;
+  tone: WatchTranscriptTone;
+  subtle: boolean;
+  metadata: string[];
+}
+
+export interface WatchDashboardState {
+  mode: 'live' | 'archive';
+  selectedId: string | null;
+  expanded: Record<string, boolean>;
+  follow: boolean;
+  scrollOffset: number;
+}
+
+export interface WatchSidebarItem {
+  id: string;
+  kind: 'orchestrator' | 'conversation';
+  orchestrator: WatchOrchestrator;
+  conversation?: WatchConversation;
+}
+
+export interface WatchInputKey {
+  upArrow?: boolean;
+  downArrow?: boolean;
+  leftArrow?: boolean;
+  rightArrow?: boolean;
+  pageUp?: boolean;
+  pageDown?: boolean;
+  home?: boolean;
+  end?: boolean;
+  return?: boolean;
+  escape?: boolean;
+  ctrl?: boolean;
+  tab?: boolean;
+  backspace?: boolean;
+}
+
+export interface WatchInputResult {
+  state: WatchDashboardState;
+  quit: boolean;
+  toggleMouseCapture?: boolean;
+}
+
+interface WatchInputEvent {
+  input: string;
+  key: WatchInputKey;
+}
+
+interface ConversationDraft {
+  id: string;
+  orchestratorId: string;
+  rootRunId: string;
+  runs: ObservabilityRun[];
+  placeholderWorkers: ObservabilityOrchestratorWorker[];
+}
+
+interface RunDurationWindow {
+  status: string;
+  startedAt: string;
+  endedAt: string | null;
+}
+
+export function buildWatchViewModel(envelope: SnapshotEnvelope): WatchViewModel {
+  const snapshot = envelope.snapshot;
+  const groups = snapshot.orchestrators;
+  return {
+    running: envelope.running,
+    error: envelope.error,
+    live: groups.filter(isLiveOrchestrator).map((group) => buildWatchOrchestrator(snapshot, group)),
+    archive: groups.filter((group) => !isLiveOrchestrator(group)).map((group) => buildWatchOrchestrator(snapshot, group)),
+  };
+}
+
+export function createWatchDashboardState(): WatchDashboardState {
+  return {
+    mode: 'live',
+    selectedId: null,
+    expanded: {},
+    follow: true,
+    scrollOffset: 0,
+  };
+}
+
+export function clampWatchDashboardState(state: WatchDashboardState, model: WatchViewModel): WatchDashboardState {
+  const items = watchSidebarItems(model, state);
+  const selectedStillExists = state.selectedId !== null && items.some((item) => item.id === state.selectedId);
+  return {
+    ...state,
+    selectedId: selectedStillExists ? state.selectedId : items[0]?.id ?? null,
+    scrollOffset: Math.max(0, state.scrollOffset),
+    follow: selectedStillExists ? state.follow : true,
+  };
+}
+
+export function selectWatchSidebarItem(state: WatchDashboardState, model: WatchViewModel, delta: number): WatchDashboardState {
+  const clamped = clampWatchDashboardState(state, model);
+  const items = watchSidebarItems(model, clamped);
+  if (items.length === 0) return clamped;
+  const currentIndex = Math.max(0, items.findIndex((item) => item.id === clamped.selectedId));
+  const next = items[clamp(currentIndex + delta, 0, items.length - 1)]!;
+  if (next.id === clamped.selectedId) return clamped;
+  return { ...clamped, selectedId: next.id, follow: true, scrollOffset: 0 };
+}
+
+export function toggleWatchMode(state: WatchDashboardState, model: WatchViewModel): WatchDashboardState {
+  return clampWatchDashboardState({
+    ...state,
+    mode: state.mode === 'live' ? 'archive' : 'live',
+    selectedId: null,
+    follow: true,
+    scrollOffset: 0,
+  }, model);
+}
+
+export function toggleWatchExpanded(state: WatchDashboardState, model: WatchViewModel, expanded?: boolean): WatchDashboardState {
+  const item = selectedWatchSidebarItem(model, state);
+  if (!item || item.kind !== 'orchestrator') return state;
+  return {
+    ...state,
+    expanded: {
+      ...state.expanded,
+      [item.orchestrator.id]: expanded ?? !isExpanded(item.orchestrator, state),
+    },
+  };
+}
+
+export function followWatchTranscript(state: WatchDashboardState, model: WatchViewModel): WatchDashboardState {
+  return { ...clampWatchDashboardState(state, model), follow: true, scrollOffset: 0 };
+}
+
+export function scrollWatchTranscript(
+  state: WatchDashboardState,
+  model: WatchViewModel,
+  width: number,
+  height: number,
+  delta: number,
+  maxScrollOverride?: number,
+): WatchDashboardState {
+  const clamped = clampWatchDashboardState(state, model);
+  const maxScroll = maxScrollOverride ?? maxWatchTranscriptScroll(model, clamped, width, height);
+  const topAnchored = isOverviewSelected(model, clamped);
+  const nextOffset = topAnchored
+    ? clamp(clamped.scrollOffset - delta, 0, maxScroll)
+    : clamp(clamped.scrollOffset + delta, 0, maxScroll);
+  return {
+    ...clamped,
+    follow: nextOffset === 0,
+    scrollOffset: nextOffset,
+  };
+}
+
+export function scrollWatchTranscriptToTop(
+  state: WatchDashboardState,
+  model: WatchViewModel,
+  width: number,
+  height: number,
+  maxScrollOverride?: number,
+): WatchDashboardState {
+  const clamped = clampWatchDashboardState(state, model);
+  const maxScroll = maxScrollOverride ?? maxWatchTranscriptScroll(model, clamped, width, height);
+  if (isOverviewSelected(model, clamped)) {
+    return {
+      ...clamped,
+      follow: true,
+      scrollOffset: 0,
+    };
+  }
+  return {
+    ...clamped,
+    follow: maxScroll === 0,
+    scrollOffset: maxScroll,
+  };
+}
+
+function isOverviewSelected(model: WatchViewModel, state: WatchDashboardState): boolean {
+  return selectedWatchSidebarItem(model, state)?.kind !== 'conversation';
+}
+
+export function watchMouseScrollDelta(input: string, pageSize: number): number | null {
+  void pageSize;
+  const step = 1;
+  let delta = 0;
+
+  for (const match of input.matchAll(/\x1b\[<(\d+);\d+;\d+([mM])/g)) {
+    if (match[2] === 'm') continue;
+    delta += mouseButtonScrollDelta(Number(match[1]), step);
+  }
+
+  for (const match of input.matchAll(/\x1b\[(\d+);\d+;\d+M/g)) {
+    delta += mouseButtonScrollDelta(Number(match[1]), step);
+  }
+
+  for (const match of input.matchAll(/\x1b\[M([\s\S]{3})/g)) {
+    const button = match[1]!.charCodeAt(0) - 32;
+    delta += mouseButtonScrollDelta(button, step);
+  }
+
+  return delta === 0 ? null : delta;
+}
+
+export function applyWatchRawInput(
+  state: WatchDashboardState,
+  model: WatchViewModel,
+  rawInput: string,
+  width: number,
+  height: number,
+  maxScrollOverride?: number,
+): WatchInputResult {
+  const pageSize = Math.max(1, height);
+  let nextState = state;
+  let toggleMouseCapture = false;
+  const mouseDelta = watchMouseScrollDelta(rawInput, pageSize);
+  if (mouseDelta !== null) {
+    nextState = scrollWatchTranscript(nextState, model, width, height, mouseDelta, maxScrollOverride);
+  }
+
+  for (const event of rawWatchInputEvents(rawInput)) {
+    const result = applyWatchInput(nextState, model, event.input, event.key, width, height, maxScrollOverride);
+    nextState = result.state;
+    toggleMouseCapture = toggleMouseCapture || Boolean(result.toggleMouseCapture);
+    if (result.quit) return { state: nextState, quit: true, toggleMouseCapture };
+  }
+
+  return { state: nextState, quit: false, toggleMouseCapture };
+}
+
+export function applyWatchInput(
+  state: WatchDashboardState,
+  model: WatchViewModel,
+  input: string,
+  key: WatchInputKey,
+  width: number,
+  height: number,
+  maxScrollOverride?: number,
+): WatchInputResult {
+  if ((key.ctrl && input === 'c') || input === 'q') return { state, quit: true };
+  if (input === 'm') return { state, quit: false, toggleMouseCapture: true };
+
+  const pageSize = Math.max(1, height);
+  const halfPage = Math.max(1, Math.ceil(pageSize / 2));
+  const mouseDelta = watchMouseScrollDelta(input, pageSize);
+  if (mouseDelta !== null) return { state: scrollWatchTranscript(state, model, width, height, mouseDelta, maxScrollOverride), quit: false };
+
+  if (key.upArrow) return { state: selectWatchSidebarItem(state, model, -1), quit: false };
+  if (key.downArrow) return { state: selectWatchSidebarItem(state, model, 1), quit: false };
+  if (input === 'k') return { state: selectWatchSidebarItem(state, model, -1), quit: false };
+  if (input === 'j') return { state: selectWatchSidebarItem(state, model, 1), quit: false };
+  if (input === ' ') return { state: toggleWatchExpanded(state, model), quit: false };
+  if (key.rightArrow || input === 'l') return { state: toggleWatchExpanded(state, model, true), quit: false };
+  if (key.leftArrow || input === 'h') return { state: toggleWatchExpanded(state, model, false), quit: false };
+  if (key.tab || input === 'a') return { state: toggleWatchMode(state, model), quit: false };
+
+  if (key.pageUp || (input === 'b' && key.ctrl) || input === '\u0002') {
+    return { state: scrollWatchTranscript(state, model, width, height, pageSize, maxScrollOverride), quit: false };
+  }
+  if (key.pageDown || (input === 'f' && key.ctrl) || input === '\u0006') {
+    return { state: scrollWatchTranscript(state, model, width, height, -pageSize, maxScrollOverride), quit: false };
+  }
+  if (input === 'u' || (input === 'u' && key.ctrl) || input === '\u0015') {
+    return { state: scrollWatchTranscript(state, model, width, height, halfPage, maxScrollOverride), quit: false };
+  }
+  if (input === 'd' || (input === 'd' && key.ctrl) || input === '\u0004') {
+    return { state: scrollWatchTranscript(state, model, width, height, -halfPage, maxScrollOverride), quit: false };
+  }
+  if (key.home || input === 'g') return { state: scrollWatchTranscriptToTop(state, model, width, height, maxScrollOverride), quit: false };
+  if (key.return || key.end || input === 'G' || (input === 'e' && key.ctrl) || input === '\u0005') {
+    return { state: followWatchTranscript(state, model), quit: false };
+  }
+  if (key.escape || key.backspace) {
+    return { state: state.mode === 'archive' ? toggleWatchMode(state, model) : state, quit: false };
+  }
+
+  return { state, quit: false };
+}
+
+function rawWatchInputEvents(rawInput: string): WatchInputEvent[] {
+  const input = stripMouseSequences(rawInput);
+  const events: WatchInputEvent[] = [];
+  let index = 0;
+  while (index < input.length) {
+    const remaining = input.slice(index);
+    const csiArrow = /^\x1b\[(?:\d+(?:;[2-8])?)?([ABCDHF])/.exec(remaining);
+    if (csiArrow) {
+      events.push(rawArrowEvent(csiArrow[1]!));
+      index += csiArrow[0].length;
+      continue;
+    }
+
+    const appArrow = /^\x1bO([ABCDHF])/.exec(remaining);
+    if (appArrow) {
+      events.push(rawArrowEvent(appArrow[1]!));
+      index += appArrow[0].length;
+      continue;
+    }
+
+    const csiTilde = /^\x1b\[(\d+)~/.exec(remaining);
+    if (csiTilde) {
+      const event = rawTildeEvent(csiTilde[1]!);
+      if (event) events.push(event);
+      index += csiTilde[0].length;
+      continue;
+    }
+
+    const char = input[index]!;
+    const event = rawCharEvent(char);
+    if (event) events.push(event);
+    index += 1;
+  }
+  return events;
+}
+
+function stripMouseSequences(input: string): string {
+  return input
+    .replaceAll(/\x1b\[<\d+;\d+;\d+[mM]/g, '')
+    .replaceAll(/\x1b\[\d+;\d+;\d+M/g, '')
+    .replaceAll(/\x1b\[M[\s\S]{3}/g, '');
+}
+
+function rawArrowEvent(code: string): WatchInputEvent {
+  if (code === 'A') return { input: '', key: { upArrow: true } };
+  if (code === 'B') return { input: '', key: { downArrow: true } };
+  if (code === 'C') return { input: '', key: { rightArrow: true } };
+  if (code === 'D') return { input: '', key: { leftArrow: true } };
+  if (code === 'H') return { input: '', key: { home: true } };
+  return { input: '', key: { end: true } };
+}
+
+function rawTildeEvent(code: string): WatchInputEvent | null {
+  if (code === '1' || code === '7') return { input: '', key: { home: true } };
+  if (code === '4' || code === '8') return { input: '', key: { end: true } };
+  if (code === '5') return { input: '', key: { pageUp: true } };
+  if (code === '6') return { input: '', key: { pageDown: true } };
+  return null;
+}
+
+function rawCharEvent(char: string): WatchInputEvent | null {
+  if (char === '\u0003') return { input: 'c', key: { ctrl: true } };
+  if (char === '\u0002') return { input: '\u0002', key: { ctrl: true } };
+  if (char === '\u0004') return { input: '\u0004', key: { ctrl: true } };
+  if (char === '\u0005') return { input: '\u0005', key: { ctrl: true } };
+  if (char === '\u0006') return { input: '\u0006', key: { ctrl: true } };
+  if (char === '\u0015') return { input: '\u0015', key: { ctrl: true } };
+  if (char === '\t') return { input: '', key: { tab: true } };
+  if (char === '\r' || char === '\n') return { input: '', key: { return: true } };
+  if (char === '\u001b') return { input: '', key: { escape: true } };
+  if (char === '\u007f' || char === '\b') return { input: '', key: { backspace: true } };
+  if (char >= ' ') return { input: char, key: {} };
+  return null;
+}
+
+export function watchSidebarItems(model: WatchViewModel, state: WatchDashboardState): WatchSidebarItem[] {
+  const groups = state.mode === 'live' ? model.live : model.archive;
+  const items: WatchSidebarItem[] = [];
+  for (const orchestrator of groups) {
+    items.push({ id: orchestratorItemId(orchestrator), kind: 'orchestrator', orchestrator });
+    if (!isExpanded(orchestrator, state)) continue;
+    for (const conversation of orchestrator.conversations) {
+      items.push({ id: conversationItemId(conversation), kind: 'conversation', orchestrator, conversation });
+    }
+  }
+  return items;
+}
+
+export function selectedWatchSidebarItem(model: WatchViewModel, state: WatchDashboardState): WatchSidebarItem | null {
+  const clamped = clampWatchDashboardState(state, model);
+  return watchSidebarItems(model, clamped).find((item) => item.id === clamped.selectedId) ?? null;
+}
+
+export function selectedWatchTranscriptLines(model: WatchViewModel, state: WatchDashboardState, width: number): string[] {
+  const item = selectedWatchSidebarItem(model, state);
+  if (!item) return renderTranscriptBlocks([emptyTranscriptBlock()], width);
+  return renderTranscriptBlocks(selectedWatchTranscriptBlocks(model, state), width);
+}
+
+export function selectedWatchTranscriptBlocks(model: WatchViewModel, state: WatchDashboardState): WatchTranscriptBlock[] {
+  const item = selectedWatchSidebarItem(model, state);
+  if (!item) return [emptyTranscriptBlock()];
+  if (item.kind === 'orchestrator') return renderOrchestratorOverviewBlocks(item.orchestrator);
+  return renderConversationTranscriptBlocks(item.conversation!);
+}
+
+export function renderMarkdownToAnsi(markdown: string, width: number): string[] {
+  const text = markdown.trim();
+  if (!text) return [];
+  const parser = new Marked();
+  parser.setOptions({
+    gfm: true,
+    breaks: true,
+    renderer: new TerminalRenderer({
+      width: Math.max(20, width),
+      reflowText: true,
+      showSectionPrefix: false,
+    }) as unknown as MarkedOptions['renderer'],
+  });
+  const rendered = parser.parse(text, { async: false }) as string;
+  return rendered.replace(/\n+$/g, '').split('\n');
+}
+
+export function normalizeWatchEvent(run: ObservabilityRun, event: WorkerEvent, round = 1): WatchTranscriptEvent | null {
+  const base = {
+    id: `${run.run.run_id}:${event.seq}`,
+    runId: run.run.run_id,
+    seq: event.seq,
+    ts: event.ts,
+    round,
+  };
+
+  if (event.type === 'assistant_message') {
+    const text = stringFromRecord(event.payload, 'text') ?? stringFromRecord(event.payload, 'message') ?? '';
+    if (!text) return null;
+    return {
+      ...base,
+      kind: 'assistant',
+      title: 'Assistant',
+      body: text,
+      accent: 'assistant',
+    };
+  }
+
+  if (event.type === 'tool_use') {
+    const summary = summarizeToolUse(event.payload);
+    return {
+      ...base,
+      kind: 'tool_call',
+      title: summary.title,
+      body: summary.body,
+      accent: 'tool',
+    };
+  }
+
+  if (event.type === 'tool_result') {
+    const summary = summarizeToolResult(event.payload);
+    return {
+      ...base,
+      kind: 'tool_result',
+      title: summary.title,
+      body: summary.body,
+      status: summary.status,
+      accent: summary.status === 'failed' || summary.status === 'error' ? 'error' : 'tool',
+    };
+  }
+
+  if (event.type === 'error') {
+    const message = stringFromRecord(event.payload, 'message') ?? stringFromRecord(event.payload, 'text') ?? compactJson(event.payload, 500);
+    return {
+      ...base,
+      kind: 'error',
+      title: 'Error',
+      body: message || 'Worker error',
+      status: 'error',
+      accent: 'error',
+    };
+  }
+
+  const status = lifecycleStatus(event.payload);
+  const body = lifecycleBody(event.payload);
+  if (!status) {
+    const summary = compactLifecyclePayload(event.payload);
+    if (!summary) return null;
+    return {
+      ...base,
+      kind: 'status',
+      title: event.payload.state === 'result_event' ? 'Result event' : 'Event',
+      body: summary,
+      status: null,
+      accent: 'status',
+    };
+  }
+  if (!isUsefulLifecycleStatus(status, body)) return null;
+  return {
+    ...base,
+    kind: 'status',
+    title: 'Status',
+    body,
+    status,
+    accent: 'status',
+  };
+}
+
+function buildWatchOrchestrator(snapshot: ObservabilitySnapshot, group: ObservabilityOrchestratorGroup): WatchOrchestrator {
+  const conversations = buildConversations(snapshot, group);
+  return {
+    id: group.orchestrator_id,
+    live: isLiveOrchestrator(group),
+    label: group.label,
+    cwd: group.cwd,
+    status: group.status?.state ?? (group.live ? 'live' : 'archived'),
+    workerCount: conversations.length,
+    runningCount: conversations.filter((conversation) => conversation.status === 'running').length,
+    createdAt: group.created_at,
+    updatedAt: maxIso([group.updated_at, ...conversations.map((conversation) => conversation.updatedAt)]),
+    generatedAt: snapshot.generated_at,
+    conversations,
+  };
+}
+
+function buildConversations(snapshot: ObservabilitySnapshot, group: ObservabilityOrchestratorGroup): WatchConversation[] {
+  const runs = snapshot.runs
+    .filter((run) => orchestratorIdFromMetadata(run.run.metadata) === group.orchestrator_id)
+    .sort(compareRunCreatedAt);
+  const runsById = new Map(runs.map((run) => [run.run.run_id, run]));
+  const drafts = new Map<string, ConversationDraft>();
+
+  for (const run of runs) {
+    const key = conversationKey(run, runsById);
+    const draft = drafts.get(key) ?? {
+      id: key,
+      orchestratorId: group.orchestrator_id,
+      rootRunId: rootRun(run, runsById).run.run_id,
+      runs: [],
+      placeholderWorkers: [],
+    };
+    draft.runs.push(run);
+    drafts.set(key, draft);
+  }
+
+  for (const worker of group.workers) {
+    if (Array.from(drafts.values()).some((draft) => draft.runs.some((run) => run.run.run_id === worker.run_id))) continue;
+    const key = `conversation:${group.orchestrator_id}:${worker.parent_run_id ?? worker.run_id}`;
+    const draft = drafts.get(key) ?? {
+      id: key,
+      orchestratorId: group.orchestrator_id,
+      rootRunId: worker.parent_run_id ?? worker.run_id,
+      runs: [],
+      placeholderWorkers: [],
+    };
+    draft.placeholderWorkers.push(worker);
+    drafts.set(key, draft);
+  }
+
+  return Array.from(drafts.values())
+    .map(conversationFromDraft)
+    .sort((a, b) => a.createdAt.localeCompare(b.createdAt))
+    .map(withWorkerIdentity)
+    .sort((a, b) => b.updatedAt.localeCompare(a.updatedAt));
+}
+
+function conversationFromDraft(draft: ConversationDraft): WatchConversation {
+  const runs = draft.runs.sort(compareRunCreatedAt);
+  const root = runs.find((run) => run.run.run_id === draft.rootRunId) ?? runs[0] ?? null;
+  const latest = runs.slice().sort((a, b) => latestObservedAt(b).localeCompare(latestObservedAt(a)))[0] ?? null;
+  const placeholder = draft.placeholderWorkers[0] ?? null;
+  const turns = runs.flatMap((run, index) => turnsForRun(run, index > 0 || run.run.parent_run_id !== null, index + 1));
+
+  for (const [index, worker] of draft.placeholderWorkers.entries()) {
+    turns.push({
+      id: `${worker.run_id}:prompt`,
+      runId: worker.run_id,
+      seq: null,
+      ts: worker.created_at,
+      kind: 'prompt',
+      title: worker.parent_run_id ? 'Supervisor follow-up' : 'Supervisor prompt',
+      body: worker.preview || worker.title,
+      status: worker.status,
+      accent: 'supervisor',
+      round: runs.length + index + 1,
+    });
+  }
+
+  const status = runs.some((run) => run.run.status === 'running')
+    ? 'running'
+    : latest?.run.status ?? placeholder?.status ?? 'completed';
+  const durationWindow = latestRunDurationWindow(runs, draft.placeholderWorkers, status);
+
+  return {
+    id: draft.id,
+    orchestratorId: draft.orchestratorId,
+    rootRunId: draft.rootRunId,
+    runIds: [...runs.map((run) => run.run.run_id), ...draft.placeholderWorkers.map((worker) => worker.run_id)],
+    workerName: 'Worker',
+    workerOrdinal: 0,
+    backend: root?.run.backend ?? placeholder?.backend ?? 'codex',
+    status,
+    title: root?.prompt.title ?? placeholder?.title ?? draft.rootRunId,
+    purpose: compactText(root?.prompt.summary ?? placeholder?.summary ?? root?.prompt.preview ?? placeholder?.preview ?? draft.rootRunId, 140),
+    summary: root?.prompt.summary ?? placeholder?.summary ?? null,
+    model: root ? formatModelName(root) : formatModelLike(placeholder?.model.name ?? null),
+    settings: root?.settings ?? placeholder?.settings ?? { reasoning_effort: null, service_tier: null, mode: null, codex_network: null },
+    createdAt: root?.run.created_at ?? placeholder?.created_at ?? '',
+    updatedAt: maxIso([
+      ...runs.map(latestObservedAt),
+      ...draft.placeholderWorkers.map((worker) => worker.last_activity_at ?? worker.created_at),
+    ]),
+    latestRunStartedAt: durationWindow.startedAt,
+    latestRunEndedAt: durationWindow.endedAt,
+    turns,
+  };
+}
+
+function withWorkerIdentity(conversation: WatchConversation, index: number): WatchConversation {
+  return {
+    ...conversation,
+    workerName: `Worker ${index + 1}`,
+    workerOrdinal: index + 1,
+    purpose: conversation.purpose || conversation.title,
+  };
+}
+
+function latestRunDurationWindow(
+  runs: ObservabilityRun[],
+  placeholderWorkers: ObservabilityOrchestratorWorker[],
+  status: RunStatus,
+): RunDurationWindow {
+  const windows = [
+    ...runs.map(runDurationWindow),
+    ...placeholderWorkers.map(workerDurationWindow),
+  ].filter((window) => window.startedAt);
+  if (windows.length === 0) return { status, startedAt: '', endedAt: null };
+
+  const candidates = status === 'running'
+    ? windows.filter((window) => window.status === 'running')
+    : windows;
+  return (candidates.length > 0 ? candidates : windows)
+    .slice()
+    .sort((a, b) => a.startedAt.localeCompare(b.startedAt))
+    .at(-1)!;
+}
+
+function runDurationWindow(run: ObservabilityRun): RunDurationWindow {
+  return {
+    status: run.run.status,
+    startedAt: run.run.started_at ?? run.run.created_at,
+    endedAt: isTerminalRunStatus(run.run.status)
+      ? run.run.finished_at ?? run.activity.last_event_at ?? run.activity.last_activity_at ?? latestObservedAt(run)
+      : null,
+  };
+}
+
+function workerDurationWindow(worker: ObservabilityOrchestratorWorker): RunDurationWindow {
+  return {
+    status: worker.status,
+    startedAt: worker.created_at,
+    endedAt: isTerminalRunStatus(worker.status) ? worker.last_activity_at ?? worker.created_at : null,
+  };
+}
+
+function turnsForRun(run: ObservabilityRun, followUp: boolean, round: number): WatchTranscriptEvent[] {
+  const turns: WatchTranscriptEvent[] = [{
+    id: `${run.run.run_id}:run-start`,
+    runId: run.run.run_id,
+    seq: null,
+    ts: run.run.started_at ?? run.run.created_at,
+    kind: 'run_start',
+    title: `Run ${round} started`,
+    body: `Worker run ${run.run.run_id}`,
+    status: null,
+    accent: 'status',
+    round,
+  }, {
+    id: `${run.run.run_id}:prompt`,
+    runId: run.run.run_id,
+    seq: null,
+    ts: run.run.created_at,
+    kind: 'prompt',
+    title: followUp ? 'Supervisor follow-up' : 'Supervisor prompt',
+    body: run.prompt.text ?? run.prompt.preview,
+    status: null,
+    accent: 'supervisor',
+    round,
+  }];
+
+  const events = run.activity.recent_events.slice().sort((a, b) => a.seq - b.seq);
+  for (const event of events) {
+    const normalized = normalizeWatchEvent(run, event, round);
+    if (normalized) turns.push(normalized);
+  }
+
+  if (run.response.summary) {
+    const duplicateAssistantIndex = duplicateLastAssistantIndex(turns, run.response.summary);
+    if (duplicateAssistantIndex !== -1) turns.splice(duplicateAssistantIndex, 1);
+    turns.push({
+      id: `${run.run.run_id}:final`,
+      runId: run.run.run_id,
+      seq: null,
+      ts: run.run.finished_at ?? run.activity.last_event_at ?? run.activity.last_activity_at,
+      kind: 'final',
+      title: 'Worker final message',
+      body: run.response.summary,
+      status: null,
+      accent: 'assistant',
+      round,
+    });
+  }
+
+  if (isTerminalRunStatus(run.run.status)) {
+    turns.push({
+      id: `${run.run.run_id}:run-end`,
+      runId: run.run.run_id,
+      seq: null,
+      ts: run.run.finished_at ?? run.activity.last_event_at ?? run.activity.last_activity_at,
+      kind: 'run_end',
+      title: `Run ${round} ended`,
+      body: run.run.terminal_reason ? `Reason: ${run.run.terminal_reason}` : '',
+      status: run.run.status,
+      accent: run.run.status === 'completed' ? 'status' : 'error',
+      round,
+    });
+  }
+
+  return turns;
+}
+
+function renderConversationTranscriptBlocks(conversation: WatchConversation): WatchTranscriptBlock[] {
+  const blocks: WatchTranscriptBlock[] = [{
+    id: `${conversation.id}:summary`,
+    actor: 'system',
+    label: 'Worker Chat',
+    title: `${conversation.workerName} timeline`,
+    timestamp: conversation.updatedAt || null,
+    status: conversation.status,
+    body: `Runs: ${conversation.runIds.length}\nTurns: ${conversation.turns.length}`,
+    round: null,
+    tone: transcriptToneForStatus(conversation.status),
+    subtle: true,
+    metadata: [conversation.backend, conversation.model],
+  }];
+  blocks.push(...conversation.turns.map(transcriptBlockFromTurn));
+  return blocks;
+}
+
+function renderOrchestratorOverviewBlocks(orchestrator: WatchOrchestrator): WatchTranscriptBlock[] {
+  const generatedAt = maxIso([orchestrator.generatedAt, orchestrator.updatedAt]);
+  const blocks: WatchTranscriptBlock[] = [{
+    id: `${orchestrator.id}:overview`,
+    actor: 'system',
+    label: 'Session',
+    title: orchestrator.label,
+    timestamp: orchestrator.updatedAt || null,
+    status: orchestrator.status,
+    body: [
+      `Workers: ${orchestrator.runningCount} running / ${orchestrator.conversations.length} total`,
+      `Open: ${formatDurationBetween(orchestrator.createdAt, generatedAt)}`,
+      `Last update: ${formatRelativeTime(orchestrator.updatedAt, generatedAt)}`,
+      `Workspace: ${orchestrator.cwd}`,
+    ].join('\n'),
+    round: null,
+    tone: transcriptToneForStatus(orchestrator.status),
+    subtle: true,
+    metadata: [],
+  }];
+
+  if (orchestrator.conversations.length === 0) {
+    blocks.push({
+      id: `${orchestrator.id}:empty`,
+      actor: 'system',
+      label: 'Workers',
+      title: 'No worker conversations yet',
+      timestamp: null,
+      status: null,
+      body: 'No worker conversations are recorded for this orchestrator yet.',
+      round: null,
+      tone: 'status',
+      subtle: true,
+      metadata: [],
+    });
+    return blocks;
+  }
+
+  for (const conversation of orchestrator.conversations) {
+    const task = overviewDigestText(conversation.purpose || conversation.title, 110);
+    const latestText = overviewLatestText(conversation);
+    const durationEnd = isTerminalRunStatus(conversation.status)
+      ? conversation.latestRunEndedAt ?? conversation.updatedAt
+      : generatedAt;
+    const duration = formatDurationBetween(conversation.latestRunStartedAt || conversation.createdAt, durationEnd);
+    blocks.push({
+      id: `${conversation.id}:overview`,
+      actor: conversation.status === 'running' ? 'worker' : 'result',
+      label: conversation.workerName,
+      title: overviewStatusTitle(conversation.status, duration),
+      timestamp: conversation.updatedAt || null,
+      status: null,
+      body: [
+        `Task: ${task}`,
+        latestText ? `Latest: ${latestText}` : null,
+        `Runs: ${conversation.runIds.length}`,
+      ].filter((value): value is string => Boolean(value)).join('\n'),
+      round: null,
+      tone: transcriptToneForStatus(conversation.status),
+      subtle: false,
+      metadata: [`last ${formatRelativeTime(conversation.updatedAt, generatedAt)}`, conversation.backend, conversation.model],
+    });
+  }
+
+  return blocks;
+}
+
+function latestMeaningfulTurn(conversation: WatchConversation): WatchTranscriptEvent | null {
+  return conversation.turns.slice().reverse().find((turn) => {
+    if (turn.kind === 'run_start' || turn.kind === 'run_end') return false;
+    return Boolean((turn.body || turn.title).trim());
+  }) ?? null;
+}
+
+function overviewLatestText(conversation: WatchConversation): string {
+  const preferred = conversation.turns.slice().reverse().find((turn) => {
+    if (turn.kind === 'run_start' || turn.kind === 'run_end' || turn.kind === 'status') return false;
+    return Boolean((turn.body || turn.title).trim());
+  });
+  if (preferred) return overviewDigestText(preferred.body || preferred.title, 130);
+
+  const latest = latestMeaningfulTurn(conversation);
+  if (!latest) return '';
+  if (latest.kind === 'status') {
+    const status = latest.status ? titleCaseStatus(latest.status) : latest.title;
+    const body = latest.body.trim();
+    if (!body || body.startsWith('{') || body.startsWith('[')) return status;
+    return overviewDigestText(`${status}: ${body}`, 130);
+  }
+  return overviewDigestText(latest.body || latest.title, 130);
+}
+
+function overviewStatusLabel(status: string): string {
+  if (status === 'running' || status === 'in_progress') return 'running';
+  if (status === 'completed' || status === 'idle') return 'done';
+  if (status === 'waiting_for_user') return 'waiting';
+  if (status === 'failed' || status === 'timed_out' || status === 'cancelled' || status === 'orphaned') return status.replaceAll('_', ' ');
+  return status;
+}
+
+function overviewStatusTitle(status: string, duration: string): string {
+  const label = overviewStatusLabel(status);
+  if (status === 'running' || status === 'in_progress' || status === 'waiting_for_user') return `${label} for ${duration}`;
+  if (isTerminalRunStatus(status) || status === 'idle' || status === 'completed') return `${label} after ${duration}`;
+  return `${label} for ${duration}`;
+}
+
+function plainOverviewText(value: string): string {
+  return value
+    .replaceAll(/\[([^\]]+)\]\([^)]+\)/g, '$1')
+    .replaceAll(/`([^`]*)`/g, '$1')
+    .replaceAll(/\*\*([^*]+)\*\*/g, '$1')
+    .replaceAll(/\*([^*]+)\*/g, '$1')
+    .replaceAll(/__([^_]+)__/g, '$1')
+    .replaceAll(/_([^_]+)_/g, '$1')
+    .replaceAll(/^\s{0,3}#{1,6}\s+/gm, '')
+    .replaceAll(/\s+/g, ' ')
+    .trim();
+}
+
+function overviewDigestText(value: string, limit: number): string {
+  let text = plainOverviewText(value)
+    .replace(/\s+Move history:.*$/i, '')
+    .replace(/\s+I am the game master\b.*$/i, '')
+    .replace(/\s+Your move as\b.*$/i, '')
+    .trim();
+  if (!text) text = plainOverviewText(value);
+  return compactText(text, limit);
+}
+
+function formatDurationBetween(start: string | null, end: string | null): string {
+  const startMs = start ? Date.parse(start) : Number.NaN;
+  const endMs = end ? Date.parse(end) : Number.NaN;
+  if (!Number.isFinite(startMs) || !Number.isFinite(endMs) || endMs < startMs) return 'unknown';
+  return formatDurationMs(endMs - startMs);
+}
+
+function formatRelativeTime(value: string | null, reference: string | null): string {
+  const valueMs = value ? Date.parse(value) : Number.NaN;
+  const referenceMs = reference ? Date.parse(reference) : Number.NaN;
+  if (!Number.isFinite(valueMs) || !Number.isFinite(referenceMs)) return 'unknown';
+  const delta = Math.max(0, referenceMs - valueMs);
+  if (delta < 5_000) return 'now';
+  return `${formatDurationMs(delta)} ago`;
+}
+
+function formatDurationMs(ms: number): string {
+  const seconds = Math.max(0, Math.floor(ms / 1000));
+  if (seconds < 60) return `${seconds}s`;
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m`;
+  const hours = Math.floor(minutes / 60);
+  const remainingMinutes = minutes % 60;
+  if (hours < 24) return remainingMinutes === 0 ? `${hours}h` : `${hours}h ${remainingMinutes}m`;
+  const days = Math.floor(hours / 24);
+  const remainingHours = hours % 24;
+  return remainingHours === 0 ? `${days}d` : `${days}d ${remainingHours}h`;
+}
+
+function transcriptBlockFromTurn(turn: WatchTranscriptEvent): WatchTranscriptBlock {
+  const base = {
+    id: turn.id,
+    title: turn.title,
+    timestamp: turn.ts ? formatTimestamp(turn.ts) : null,
+    status: turn.status ?? null,
+    body: turn.body,
+    round: turn.round,
+    subtle: false,
+    metadata: [],
+  };
+
+  if (turn.kind === 'run_start') {
+    return { ...base, actor: 'run', label: `Run ${turn.round}`, title: 'Started', tone: 'running', subtle: true };
+  }
+  if (turn.kind === 'run_end') {
+    return { ...base, actor: 'run', label: `Run ${turn.round}`, title: 'Ended', tone: transcriptToneForStatus(turn.status ?? 'status'), subtle: true };
+  }
+  if (turn.kind === 'prompt') {
+    return { ...base, actor: 'supervisor', label: 'Supervisor -> Worker', tone: 'supervisor' };
+  }
+  if (turn.kind === 'assistant') {
+    return { ...base, actor: 'worker', label: 'Worker message', title: 'Assistant message', tone: 'worker' };
+  }
+  if (turn.kind === 'tool_call') {
+    return { ...base, actor: 'tool', label: 'Tool call', tone: 'tool' };
+  }
+  if (turn.kind === 'tool_result') {
+    return {
+      ...base,
+      actor: 'tool',
+      label: 'Tool result',
+      tone: turn.status === 'failed' || turn.status === 'error' ? 'error' : 'success',
+    };
+  }
+  if (turn.kind === 'error') {
+    return { ...base, actor: 'error', label: 'Error', tone: 'error' };
+  }
+  if (turn.kind === 'final') {
+    return { ...base, actor: 'result', label: 'Final response', tone: 'result' };
+  }
+  return {
+    ...base,
+    actor: 'status',
+    label: 'Worker activity',
+    title: turn.status ? titleCaseStatus(turn.status) : turn.title,
+    status: null,
+    tone: transcriptToneForStatus(turn.status ?? 'status'),
+    subtle: true,
+  };
+}
+
+function renderTranscriptBlocks(blocks: WatchTranscriptBlock[], width: number): string[] {
+  const lines: string[] = [];
+  for (const block of blocks) {
+    if (lines.length > 0) lines.push('');
+    const title = block.title && block.title !== block.label ? ` ${block.title}` : '';
+    const status = block.status ? ` [${block.status}]` : '';
+    const timestamp = block.timestamp ? ` @ ${block.timestamp}` : '';
+    const metadata = block.metadata.length > 0 ? ` (${block.metadata.join(' | ')})` : '';
+    lines.push(`${block.label}${title}${status}${timestamp}${metadata}`);
+    const bodyLines = renderMarkdownToAnsi(block.body, Math.max(20, width - 4));
+    for (const line of bodyLines) lines.push(`  ${line}`);
+  }
+  return lines.length > 0 ? lines : [''];
+}
+
+function emptyTranscriptBlock(): WatchTranscriptBlock {
+  return {
+    id: 'empty',
+    actor: 'system',
+    label: 'Watch',
+    title: 'No sessions',
+    timestamp: null,
+    status: null,
+    body: 'No orchestrator sessions are available.',
+    round: null,
+    tone: 'status',
+    subtle: true,
+    metadata: [],
+  };
+}
+
+function maxWatchTranscriptScroll(model: WatchViewModel, state: WatchDashboardState, width: number, height: number): number {
+  return Math.max(0, selectedWatchTranscriptLines(model, state, width).length - Math.max(1, height));
+}
+
+function duplicateLastAssistantIndex(turns: WatchTranscriptEvent[], summary: string): number {
+  const normalizedSummary = normalizeComparableText(summary);
+  if (!normalizedSummary) return -1;
+  for (let index = turns.length - 1; index >= 0; index -= 1) {
+    const turn = turns[index]!;
+    if (turn.kind !== 'assistant') continue;
+    return normalizeComparableText(turn.body) === normalizedSummary ? index : -1;
+  }
+  return -1;
+}
+
+function transcriptToneForStatus(status: string): WatchTranscriptTone {
+  const normalized = status.toLowerCase();
+  if (['failed', 'error', 'timed_out', 'cancelled', 'orphaned', 'attention', 'stale'].includes(normalized)) return 'error';
+  if (['running', 'in_progress', 'waiting_for_user', 'reasoning', 'queued'].includes(normalized)) return 'running';
+  if (['completed', 'complete', 'success', 'succeeded', 'done', 'idle'].includes(normalized)) return 'success';
+  return 'status';
+}
+
+function titleCaseStatus(status: string): string {
+  return status
+    .replaceAll('_', ' ')
+    .replaceAll(/\b\w/g, (char) => char.toUpperCase());
+}
+
+function isTerminalRunStatus(status: string): boolean {
+  return ['completed', 'failed', 'timed_out', 'cancelled', 'orphaned'].includes(status);
+}
+
+function mouseButtonScrollDelta(button: number, step: number): number {
+  if ((button & 64) !== 64) return 0;
+  const direction = button & 3;
+  if (direction === 0) return step;
+  if (direction === 1) return -step;
+  return 0;
+}
+
+function summarizeToolUse(payload: Record<string, unknown>): { title: string; body: string } {
+  const name = toolName(payload);
+  const action = toolAction(payload);
+  const target = toolTarget(payload);
+  const duration = durationText(payload);
+  return {
+    title: `${name}${action ? `: ${action}` : ''}${duration ? ` (${duration})` : ''}`,
+    body: target || compactJson(payload.input ?? payload, 500) || '(tool call)',
+  };
+}
+
+function summarizeToolResult(payload: Record<string, unknown>): { title: string; body: string; status: string | null } {
+  const name = toolName(payload);
+  const status = toolStatus(payload);
+  const duration = durationText(payload);
+  const errors = errorsFromPayload(payload);
+  const text = errors[0]
+    ?? stringFromRecord(payload, 'text')
+    ?? stringFromRecord(payload, 'message')
+    ?? stringFromRecord(payload, 'output')
+    ?? stringFromRecord(payload, 'result')
+    ?? textFromContent(payload.content)
+    ?? textFromContent(getRecord(payload.message)?.content)
+    ?? compactJson(payload, 500);
+  return {
+    title: `${name} result${status ? ` [${status}]` : ''}${duration ? ` (${duration})` : ''}`,
+    body: compactText(text || '(no output)', 1000),
+    status,
+  };
+}
+
+function toolName(payload: Record<string, unknown>): string {
+  return stringFromRecord(payload, 'name')
+    ?? stringFromRecord(payload, 'tool_name')
+    ?? stringFromRecord(payload, 'toolName')
+    ?? stringFromRecord(payload, 'tool')
+    ?? stringFromRecord(payload, 'type')
+    ?? 'tool';
+}
+
+function toolAction(payload: Record<string, unknown>): string | null {
+  const input = getRecord(payload.input) ?? getRecord(payload.arguments) ?? getRecord(payload.args);
+  return stringFromRecord(payload, 'command')
+    ?? stringFromRecord(input, 'command')
+    ?? stringFromRecord(input, 'cmd')
+    ?? stringFromRecord(input, 'file_path')
+    ?? stringFromRecord(input, 'path')
+    ?? stringFromRecord(payload, 'command')
+    ?? null;
+}
+
+function toolTarget(payload: Record<string, unknown>): string | null {
+  const input = getRecord(payload.input) ?? getRecord(payload.arguments) ?? getRecord(payload.args);
+  const command = stringFromRecord(input, 'command') ?? stringFromRecord(payload, 'command');
+  if (command) return command;
+  const path = stringFromRecord(input, 'file_path') ?? stringFromRecord(input, 'path') ?? stringFromRecord(payload, 'path');
+  if (path) return path;
+  return stringFromRecord(input, 'description') ?? stringFromRecord(payload, 'description');
+}
+
+function toolStatus(payload: Record<string, unknown>): string | null {
+  if (payload.is_error === true || payload.error === true) return 'error';
+  return stringFromRecord(payload, 'status') ?? stringFromRecord(payload, 'state') ?? stringFromRecord(payload, 'outcome');
+}
+
+function durationText(payload: Record<string, unknown>): string | null {
+  const raw = numberFromRecord(payload, 'duration_ms') ?? numberFromRecord(payload, 'durationMs') ?? numberFromRecord(payload, 'elapsed_ms');
+  if (raw === null) return null;
+  return raw >= 1000 ? `${(raw / 1000).toFixed(1)}s` : `${raw}ms`;
+}
+
+function lifecycleStatus(payload: Record<string, unknown>): string | null {
+  const raw = stringFromRecord(payload, 'status')
+    ?? stringFromRecord(payload, 'state')
+    ?? stringFromRecord(payload, 'subtype')
+    ?? stringFromRecord(payload, 'type');
+  if (!raw || raw === 'result_event') return null;
+  if (raw === 'thinking' || raw === 'reasoning') return 'reasoning';
+  return raw;
+}
+
+function lifecycleBody(payload: Record<string, unknown>): string {
+  const resultEvent = resultEventLifecycleBody(payload);
+  if (resultEvent) return resultEvent;
+  const message = stringFromRecord(payload, 'message') ?? stringFromRecord(payload, 'summary') ?? stringFromRecord(payload, 'warning');
+  if (message) return message;
+  const usage = getRecord(payload.usage) ?? getRecord(payload.modelUsage);
+  if (usage) return compactJson(usage, 500);
+  return '';
+}
+
+function compactLifecyclePayload(payload: Record<string, unknown>): string {
+  const resultEvent = resultEventLifecycleBody(payload);
+  if (resultEvent) return resultEvent;
+  const summary = compactJson(payload, 300);
+  return summary === '{}' ? '' : summary;
+}
+
+function resultEventLifecycleBody(payload: Record<string, unknown>): string | null {
+  if (payload.state !== 'result_event') return null;
+  const raw = getRecord(payload.raw);
+  if (!raw) return null;
+  const subtype = stringFromRecord(raw, 'subtype') ?? stringFromRecord(raw, 'type');
+  const duration = durationText(raw);
+  const turns = numberFromRecord(raw, 'num_turns');
+  const stop = stringFromRecord(raw, 'stop_reason') ?? stringFromRecord(raw, 'stopReason');
+  const status = raw.is_error === true ? 'error' : subtype;
+  return [
+    status ? `status ${status}` : null,
+    duration ? `duration ${duration}` : null,
+    turns !== null ? `${turns} ${turns === 1 ? 'turn' : 'turns'}` : null,
+    stop ? `stop ${stop}` : null,
+  ].filter((value): value is string => Boolean(value)).join(' · ') || null;
+}
+
+function isUsefulLifecycleStatus(status: string, body: string): boolean {
+  if (body.trim()) return true;
+  const noisy = new Set(['started', 'running', 'completed', 'complete', 'initialized', 'init', 'result_event']);
+  return !noisy.has(status.toLowerCase());
+}
+
+function conversationKey(run: ObservabilityRun, runsById: Map<string, ObservabilityRun>): string {
+  const orchestratorId = orchestratorIdFromMetadata(run.run.metadata) ?? 'none';
+  const root = rootRun(run, runsById);
+  if (root.run.run_id !== run.run.run_id || !run.run.parent_run_id) return `conversation:${orchestratorId}:${root.run.run_id}`;
+  const session = run.session.effective_session_id ?? run.run.observed_session_id ?? run.run.requested_session_id ?? run.run.session_id;
+  if (session) return `conversation:${orchestratorId}:${run.run.backend}:session:${session}`;
+  if (run.run.parent_run_id) return `conversation:${orchestratorId}:${run.run.parent_run_id}`;
+  return `conversation:${orchestratorId}:${run.run.run_id}`;
+}
+
+function rootRun(run: ObservabilityRun, runsById: Map<string, ObservabilityRun>): ObservabilityRun {
+  let current = run;
+  const seen = new Set<string>();
+  while (current.run.parent_run_id && !seen.has(current.run.run_id)) {
+    seen.add(current.run.run_id);
+    const parent = runsById.get(current.run.parent_run_id);
+    if (!parent) break;
+    current = parent;
+  }
+  return current;
+}
+
+function isLiveOrchestrator(group: ObservabilityOrchestratorGroup): boolean {
+  return group.live && group.status?.state !== 'stale';
+}
+
+function isExpanded(orchestrator: WatchOrchestrator, state: WatchDashboardState): boolean {
+  return state.expanded[orchestrator.id] ?? true;
+}
+
+function orchestratorItemId(orchestrator: WatchOrchestrator): string {
+  return `orchestrator:${orchestrator.id}`;
+}
+
+function conversationItemId(conversation: WatchConversation): string {
+  return `conversation:${conversation.orchestratorId}:${conversation.rootRunId}`;
+}
+
+function compareRunCreatedAt(a: ObservabilityRun, b: ObservabilityRun): number {
+  return a.run.created_at.localeCompare(b.run.created_at);
+}
+
+function latestObservedAt(run: ObservabilityRun): string {
+  return maxIso([
+    run.activity.last_activity_at,
+    run.activity.last_event_at,
+    run.run.finished_at,
+    run.run.started_at,
+    run.run.created_at,
+  ].filter((value): value is string => typeof value === 'string'));
+}
+
+function maxIso(values: string[]): string {
+  return values.filter(Boolean).sort().at(-1) ?? '';
+}
+
+function orchestratorIdFromMetadata(metadata: Record<string, unknown> | undefined): string | null {
+  const value = metadata?.orchestrator_id;
+  return typeof value === 'string' && value.trim() ? value : null;
+}
+
+function formatModelName(run: ObservabilityRun): string {
+  return formatModelLike(run.model.name);
+}
+
+function formatModelLike(value: string | null): string {
+  return value ?? 'default';
+}
+
+function formatTimestamp(value: string): string {
+  return value.replace('T', ' ').replace(/\.\d{3}Z$/, 'Z');
+}
+
+function textFromContent(value: unknown): string | null {
+  if (typeof value === 'string') return value.trim() || null;
+  if (!Array.isArray(value)) return null;
+  const parts: string[] = [];
+  for (const item of value) {
+    if (typeof item === 'string') {
+      parts.push(item);
+      continue;
+    }
+    const rec = getRecord(item);
+    const text = stringFromRecord(rec, 'text') ?? stringFromRecord(rec, 'content');
+    if (text) parts.push(text);
+  }
+  return parts.join('\n').trim() || null;
+}
+
+function errorsFromPayload(payload: Record<string, unknown>): string[] {
+  const raw = payload.errors;
+  if (!Array.isArray(raw)) return [];
+  const errors: string[] = [];
+  for (const item of raw) {
+    if (typeof item === 'string') errors.push(item);
+    else {
+      const rec = getRecord(item);
+      const message = stringFromRecord(rec, 'message') ?? stringFromRecord(rec, 'text');
+      if (message) errors.push(message);
+    }
+  }
+  return errors;
+}
+
+function getRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === 'object' ? value as Record<string, unknown> : null;
+}
+
+function stringFromRecord(value: unknown, key: string): string | null {
+  const rec = getRecord(value);
+  const raw = rec?.[key];
+  return typeof raw === 'string' && raw.trim() ? raw.trim() : null;
+}
+
+function numberFromRecord(value: unknown, key: string): number | null {
+  const rec = getRecord(value);
+  const raw = rec?.[key];
+  return typeof raw === 'number' && Number.isFinite(raw) ? raw : null;
+}
+
+function compactJson(value: unknown, maxLength: number): string {
+  try {
+    return compactText(JSON.stringify(value), maxLength);
+  } catch {
+    return '';
+  }
+}
+
+function compactText(value: string, maxLength: number): string {
+  const compact = value.replace(/\s+/g, ' ').trim();
+  return compact.length > maxLength ? `${compact.slice(0, Math.max(0, maxLength - 3))}...` : compact;
+}
+
+function normalizeComparableText(value: string): string {
+  return stripAnsi(value).replace(/\s+/g, ' ').trim().toLowerCase();
+}
+
+function stripAnsi(value: string): string {
+  return value.replace(/\x1b\[[0-9;]*m/g, '');
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(Math.max(value, min), max);
+}

--- a/src/observability.ts
+++ b/src/observability.ts
@@ -7,6 +7,8 @@ import {
   type ObservabilityActivity,
   type ObservabilityArtifact,
   type ObservabilityModel,
+  type ObservabilityOrchestratorGroup,
+  type ObservabilityOrchestratorWorker,
   type ObservabilityPrompt,
   type ObservabilityResponse,
   type ObservabilityRun,
@@ -17,6 +19,8 @@ import {
   type ObservabilityWorkspace,
   type RunMeta,
   type RunStatus,
+  type OrchestratorRecord,
+  type OrchestratorStatusSnapshot,
 } from './contract.js';
 import type { RunStore } from './runStore.js';
 
@@ -32,6 +36,12 @@ export interface BuildObservabilitySnapshotOptions {
   recentEventLimit: number;
   daemonPid?: number | null;
   backendStatus?: BackendStatusReport | null;
+  liveOrchestrators?: readonly LiveOrchestratorSnapshot[];
+}
+
+export interface LiveOrchestratorSnapshot {
+  record: OrchestratorRecord;
+  status: OrchestratorStatusSnapshot;
 }
 
 export async function buildObservabilitySnapshot(
@@ -58,12 +68,14 @@ export async function buildObservabilitySnapshot(
   }
 
   const sessions = buildSessions(runs, allMetas);
+  const orchestrators = buildOrchestratorGroups(runs, allMetas, options.liveOrchestrators ?? []);
   return ObservabilitySnapshotSchema.parse({
     generated_at: new Date().toISOString(),
     daemon_pid: options.daemonPid ?? null,
     store_root: store.root,
     sessions,
     runs,
+    orchestrators,
     backend_status: options.backendStatus ?? null,
   });
 }
@@ -282,6 +294,126 @@ function buildWorkspace(root: ObservabilityRun): ObservabilityWorkspace {
   };
 }
 
+function buildOrchestratorGroups(
+  runs: ObservabilityRun[],
+  allMetas: RunMeta[],
+  liveOrchestrators: readonly LiveOrchestratorSnapshot[],
+): ObservabilityOrchestratorGroup[] {
+  const detailedRunsByOrchestrator = new Map<string, ObservabilityRun[]>();
+  for (const run of runs) {
+    const orchestratorId = orchestratorIdFromMetadata(run.run.metadata);
+    if (!orchestratorId) continue;
+    const group = detailedRunsByOrchestrator.get(orchestratorId) ?? [];
+    group.push(run);
+    detailedRunsByOrchestrator.set(orchestratorId, group);
+  }
+
+  const metasByOrchestrator = new Map<string, RunMeta[]>();
+  for (const meta of allMetas) {
+    const orchestratorId = orchestratorIdFromMetadata(meta.metadata);
+    if (!orchestratorId) continue;
+    const group = metasByOrchestrator.get(orchestratorId) ?? [];
+    group.push(meta);
+    metasByOrchestrator.set(orchestratorId, group);
+  }
+
+  const liveIds = new Set(liveOrchestrators.map((orchestrator) => orchestrator.record.id));
+  const liveGroups = liveOrchestrators.map((orchestrator) => {
+    const detailedRuns = sortRunsChronologically(detailedRunsByOrchestrator.get(orchestrator.record.id) ?? []);
+    const metas = metasByOrchestrator.get(orchestrator.record.id) ?? [];
+    const updatedAt = maxIso([
+      orchestrator.record.last_supervisor_event_at,
+      ...detailedRuns.map(latestObservedAt),
+      ...metas.map(latestMetaObservedAt),
+      orchestrator.record.registered_at,
+    ].filter((value): value is string => typeof value === 'string'));
+    return {
+      orchestrator_id: orchestrator.record.id,
+      live: true,
+      client: orchestrator.record.client,
+      label: orchestrator.record.label,
+      cwd: orchestrator.record.cwd,
+      display: orchestrator.record.display,
+      status: orchestrator.status,
+      registered_at: orchestrator.record.registered_at,
+      last_supervisor_event_at: orchestrator.record.last_supervisor_event_at,
+      created_at: orchestrator.record.registered_at,
+      updated_at: updatedAt,
+      worker_count: metas.length,
+      running_count: orchestrator.status.running_child_count,
+      workers: detailedRuns.map(orchestratorWorker),
+    } satisfies ObservabilityOrchestratorGroup;
+  });
+
+  const archiveGroups: ObservabilityOrchestratorGroup[] = [];
+  for (const [orchestratorId, metas] of metasByOrchestrator) {
+    if (liveIds.has(orchestratorId)) continue;
+    const detailedRuns = sortRunsChronologically(detailedRunsByOrchestrator.get(orchestratorId) ?? []);
+    if (detailedRuns.length === 0) continue;
+    archiveGroups.push({
+      orchestrator_id: orchestratorId,
+      live: false,
+      client: null,
+      label: archivedOrchestratorLabel(detailedRuns, orchestratorId),
+      cwd: detailedRuns[0]?.run.cwd ?? metas[0]?.cwd ?? '',
+      display: null,
+      status: null,
+      registered_at: null,
+      last_supervisor_event_at: null,
+      created_at: minIso(metas.map((meta) => meta.created_at)),
+      updated_at: maxIso(metas.map(latestMetaObservedAt)),
+      worker_count: metas.length,
+      running_count: metas.filter((meta) => !isTerminalStatus(meta.status)).length,
+      workers: detailedRuns.map(orchestratorWorker),
+    });
+  }
+
+  return [
+    ...liveGroups.sort((a, b) => b.updated_at.localeCompare(a.updated_at)),
+    ...archiveGroups.sort((a, b) => b.updated_at.localeCompare(a.updated_at)),
+  ];
+}
+
+function orchestratorWorker(run: ObservabilityRun): ObservabilityOrchestratorWorker {
+  return {
+    run_id: run.run.run_id,
+    parent_run_id: run.run.parent_run_id,
+    backend: run.run.backend,
+    status: run.run.status,
+    title: run.prompt.title,
+    summary: run.prompt.summary,
+    preview: run.prompt.preview,
+    model: run.model,
+    settings: run.settings,
+    created_at: run.run.created_at,
+    last_activity_at: latestObservedAt(run),
+  };
+}
+
+function sortRunsChronologically(runs: ObservabilityRun[]): ObservabilityRun[] {
+  return runs.slice().sort((a, b) => a.run.created_at.localeCompare(b.run.created_at));
+}
+
+function archivedOrchestratorLabel(runs: ObservabilityRun[], orchestratorId: string): string {
+  const titles = runs.map((run) => run.run.display.session_title ?? run.prompt.title).filter((title) => title.trim());
+  const title = lastNonNull(titles);
+  return title ?? `orchestrator ${orchestratorId.slice(0, 8)}`;
+}
+
+function orchestratorIdFromMetadata(metadata: Record<string, unknown> | undefined): string | null {
+  const value = metadata?.orchestrator_id;
+  return typeof value === 'string' && value.trim() ? value : null;
+}
+
+function latestMetaObservedAt(meta: RunMeta): string {
+  return maxIso([
+    meta.last_activity_at,
+    meta.finished_at,
+    meta.started_at,
+    meta.created_at,
+  ].filter((value): value is string => typeof value === 'string'));
+}
+
 function compactFolder(cwd: string): string {
   const leaf = basename(cwd);
   const parent = basename(dirname(cwd));
@@ -431,7 +563,7 @@ function lastAssistantMessage(events: ObservabilityActivity['recent_events']): s
   for (let index = events.length - 1; index >= 0; index -= 1) {
     const event = events[index]!;
     if (event.type !== 'assistant_message') continue;
-    const text = compactText(stringFromRecord(event.payload, 'text') ?? stringFromRecord(event.payload, 'message') ?? '', 4000);
+    const text = stringFromRecord(event.payload, 'text') ?? stringFromRecord(event.payload, 'message') ?? '';
     if (text) return text;
   }
   return null;
@@ -508,4 +640,8 @@ function lastNonNull<T>(values: (T | null | undefined)[]): T | null {
 
 function maxIso(values: string[]): string {
   return values.reduce((current, value) => value.localeCompare(current) > 0 ? value : current, values[0] ?? new Date(0).toISOString());
+}
+
+function minIso(values: string[]): string {
+  return values.reduce((current, value) => value.localeCompare(current) < 0 ? value : current, values[0] ?? new Date(0).toISOString());
 }

--- a/src/orchestratorService.ts
+++ b/src/orchestratorService.ts
@@ -1455,6 +1455,10 @@ export class OrchestratorService {
   async getObservabilitySnapshot(params: unknown, context: OrchestratorDispatchContext = {}): Promise<ToolResult> {
     const parsed = GetObservabilitySnapshotInputSchema.safeParse(params);
     if (!parsed.success) return invalidInput(parsed.error.message);
+    const liveOrchestrators = await Promise.all(this.orchestratorRegistry.list().map(async (state) => ({
+      record: state.record,
+      status: computeOrchestratorStatusSnapshot(state, await this.collectOwnedRunSnapshot(state.record.id)),
+    })));
     return wrapOk({
       snapshot: await buildObservabilitySnapshot(this.store, {
         limit: parsed.data.limit,
@@ -1466,6 +1470,7 @@ export class OrchestratorService {
           daemonVersion: getPackageVersion(),
           daemonPid: process.pid,
         }) : null,
+        liveOrchestrators,
       }),
     });
   }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,8 @@
     "rootDir": "src",
     "outDir": "dist",
     "declaration": true,
-    "sourceMap": true
+    "sourceMap": true,
+    "jsx": "react-jsx"
   },
-  "include": ["src/**/*.ts"]
+  "include": ["src/**/*.ts", "src/**/*.tsx"]
 }


### PR DESCRIPTION
## Summary
- Add an Ink-based `agent-orchestrator watch` TUI with live/archive orchestrator groups, clear overview vs worker timeline surfaces, sidebar worker names, scroll indicators, and mouse/keyboard controls.
- Extend observability snapshots with orchestrator worker grouping so follow-up runs render as one worker conversation.
- Preserve full Markdown final responses in worker timelines while summarizing tool/activity events, and document the new watch controls.

## Verification
- `pnpm verify`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Interactive terminal UI for the `watch` command with keyboard/mouse navigation, sidebar grouping, follow/scroll behavior, and transcript rendering (Markdown & tool-call visualization)
  * New `--recent-events` option and increased recent-event limit (now up to 500)

* **Documentation**
  * Expanded `watch` command docs with detailed TUI behavior and complete keyboard/mouse control reference

* **Tests**
  * Added comprehensive tests for observability formatting, watch view model, and UI rendering

* **Chores**
  * Added runtime/dev dependencies for terminal UI and Markdown rendering; TypeScript JSX/TSX support enabled

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ralphkrauss/agent-orchestrator/pull/62)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->